### PR TITLE
unify WindEntity

### DIFF
--- a/oeo.omn
+++ b/oeo.omn
@@ -882,12 +882,6 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
         Land
     
     
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HubHeight>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataWind>
-    
-    
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HydroEntityDataset>
 
     SubClassOf: 
@@ -1074,66 +1068,6 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
         <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RemoteControl>
     
     
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffAnimalProtection>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffCapacityLimitation>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffIceFalling>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffNoiseImmissionProtectionByDay>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffNoiseImmissionProtectionNights>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffOthers>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RequierementSwitchOffShadowing>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Requierements>
-
-    SubClassOf: 
-        WindEntityDataset
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RotorBladeDeIcingSystem>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataWind>
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#RotorDiameter>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataWind>
-    
-    
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#SeasideLocation>
 
     SubClassOf: 
@@ -1168,19 +1102,6 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 
     SubClassOf: 
         StorageUnitDataset
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataWind>
-
-    SubClassOf: 
-        WindEntityDataset
-    
-    
-Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Technology>
-
-    SubClassOf: 
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataStorage>,
-        <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataWind>
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TypeOfArea>
@@ -3226,7 +3147,6 @@ Class: Manufacturer
 Class: ManufacturerSpecifications
 
     SubClassOf: 
-        WindEntityData,
         WindEntityDataset
     
     
@@ -4135,7 +4055,7 @@ Class: RequierementSwitchOffShadowing
 Class: Requierements
 
     SubClassOf: 
-        WindEntityData
+        WindEntityDataset
     
     
 Class: ReservoirPowerplant
@@ -4610,8 +4530,7 @@ Class: Technical
 Class: TechnicalDataWind
 
     SubClassOf: 
-        WindEntityData,
-        part_of some WindEntity
+        WindEntityDataset
     
     
 Class: TechnologicalAssumption
@@ -5012,22 +4931,14 @@ Class: WindEntity
 
     SubClassOf: 
         ElectricityProductionUnit,
-        has_part some Generator,
-        has_part some WindEntityData
-    
-    
-Class: WindEntityData
-
-    SubClassOf: 
-        InformationArtifact
+        has_part some Generator
     
     
 Class: WindEntityDataset
 
     SubClassOf: 
         ElectricityProductionUnit,
-        has_part some Generator,
-        has_part some WindEntityData
+        has_part some Generator
     
     
 Class: WindFarm


### PR DESCRIPTION
Unify WindEntityData and WindEntityDataset as they are the same. I renamed the URIs of the subclasses in that context to the correct URI instead of semanticweb.org. (This allowed multiple classes with the same name)

I checked, this pull wont create merge conflicts with the StateOfMatter pull.

This is part of #53 as WindEntityDataset is a subclass of ElectricityGridComponent.