### PR TITLE
Feature/geographic region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Here is a template for new release sections
 - pollutant and subclasses (#51)
 - structure of the ontology (#47)
 - change peat to solid and not gas (#39)
-- GeographicRegion and subclasses (#61)
+- GeographicRegion and subclasses (#62 )
 - StateOfMatter and subclasses (#45)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - pollutant and subclasses (#51)
 - structure of the ontology (#47)
 - change peat to solid and not gas (#39)
+- GeographicRegion and subclasses (#61)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/oeo.omn
+++ b/oeo.omn
@@ -1294,6 +1294,14 @@ Class: AdditionalToAddress
         GeographicInformationArtifact
     
     
+Class: Address
+
+    SubClassOf: 
+        Contact,
+        has_part some 
+            (GeographicInformationArtifact or <http://purl.obolibrary.org/obo/BFO_0000006>)
+    
+    
 Class: Agent
 
     Annotations: 

--- a/oeo.omn
+++ b/oeo.omn
@@ -696,6 +696,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000024>
 Class: <http://purl.obolibrary.org/obo/BFO_0000027>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000028>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000029>
 
     
@@ -753,19 +756,19 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ClusterBalticSea>
 
     SubClassOf: 
-        Sea
+        SeaRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ClusterNorthSea>
 
     SubClassOf: 
-        Sea
+        SeaRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#CoastDistance>
 
     SubClassOf: 
-        Sea
+        <http://purl.obolibrary.org/obo/BFO_0000009>
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#CommissioningData>
@@ -783,7 +786,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Community>
 
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ConnectionToMaximumOrHighVoltage>
@@ -795,7 +798,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#County>
 
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#DataFinalDecommissioning>
@@ -831,7 +834,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#District>
 
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#EmergencyGenerator>
@@ -879,7 +882,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HouseNumber>
 
     SubClassOf: 
-        Land
+        GeographicRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HubHeight>
@@ -981,7 +984,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ParcelNumber>
 
     SubClassOf: 
-        Land
+        GeographicRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PartOfMarginalPowerPlant>
@@ -1011,7 +1014,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PostalCode>
 
     SubClassOf: 
-        Land
+        GeographicRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PowerPlantnumber>
@@ -1137,7 +1140,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#SeasideLocation>
 
     SubClassOf: 
-        Sea
+        SeaRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#SecondaryOrientation>
@@ -1161,7 +1164,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Street>
 
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataStorage>
@@ -1240,7 +1243,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#WaterDepth>
 
     SubClassOf: 
-        Sea
+        <http://purl.obolibrary.org/obo/BFO_0000009>
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Weic>
@@ -1288,7 +1291,7 @@ Class: Acronym
 Class: AdditionalToAddress
 
     SubClassOf: 
-        Land
+        GeographicRegion
     
     
 Class: Agent
@@ -1617,7 +1620,7 @@ Class: City
         <http://purl.obolibrary.org/obo/IAO_0000115> "A city is a large human settlement."@en
     
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: Client
@@ -1811,7 +1814,7 @@ Class: Continent
         <http://purl.obolibrary.org/obo/IAO_0000115> "A continent is a large landmass on the earth."@en
     
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: CorporateIdentity
@@ -1832,7 +1835,7 @@ Class: Country
         <http://purl.obolibrary.org/obo/IAO_0000115> "A country is a geographic region that is an distinct political entity."@en
     
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: CrudeOil
@@ -2328,7 +2331,7 @@ Class: FederalState
         <http://purl.obolibrary.org/obo/IAO_0000115> "A federal state is a geographic region that is a political entity within a country. It is partially self governing."@en
     
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: FieldPhotovoltaicGenerator
@@ -3049,10 +3052,10 @@ Kerosene is widely used to power jet engines of aircraft (jet fuel) and some roc
         has_normal_state_of_matter value liquid
     
     
-Class: Land
+Class: LandRegion
 
     SubClassOf: 
-        GeographicRegion
+        <http://purl.obolibrary.org/obo/BFO_0000028>
     
     
 Class: LengthUnit
@@ -3185,7 +3188,7 @@ Class: LoadArea
 Source: https://wiki.openmod-initiative.org/wiki/Load_area"@en
     
     SubClassOf: 
-        Land
+        LandRegion
     
     
 Class: Logo
@@ -4236,10 +4239,10 @@ Class: ScenarioFactsheet
         Factsheet
     
     
-Class: Sea
+Class: SeaRegion
 
     SubClassOf: 
-        GeographicRegion
+        <http://purl.obolibrary.org/obo/BFO_0000028>
     
     
 Class: Sector
@@ -5046,7 +5049,7 @@ Class: WindOffshore
 
     SubClassOf: 
         WindTurbine,
-        has_input some Sea
+        has_input some SeaRegion
     
     
 Class: WindOnshore

--- a/oeo.omn
+++ b/oeo.omn
@@ -2575,7 +2575,7 @@ Class: GeographicRegion
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic region is a delimited part of the earth."@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
+        <http://purl.obolibrary.org/obo/BFO_0000028>
     
     
 Class: GeopgraphicCoordinate
@@ -3061,7 +3061,7 @@ Kerosene is widely used to power jet engines of aircraft (jet fuel) and some roc
 Class: LandRegion
 
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000028>
+        GeographicRegion
     
     
 Class: LengthUnit
@@ -4248,7 +4248,7 @@ Class: ScenarioFactsheet
 Class: SeaRegion
 
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000028>
+        GeographicRegion
     
     
 Class: Sector

--- a/oeo.omn
+++ b/oeo.omn
@@ -1230,13 +1230,6 @@ Class: AdditionalToAddress
         GeographicInformationArtifact
     
     
-Class: Address
-
-    SubClassOf: 
-        ContactInformation,
-        has_part some (GeographicInformationArtifact or <http://purl.obolibrary.org/obo/BFO_0000006>)
-    
-    
 Class: Agent
 
     Annotations: 

--- a/oeo.omn
+++ b/oeo.omn
@@ -1233,9 +1233,8 @@ Class: AdditionalToAddress
 Class: Address
 
     SubClassOf: 
-        ContactInfomation,
-        has_part some 
-            (GeographicInformationArtifact or <http://purl.obolibrary.org/obo/BFO_0000006>)
+        ContactInformation,
+        has_part some (GeographicInformationArtifact or <http://purl.obolibrary.org/obo/BFO_0000006>)
     
     
 Class: Agent

--- a/oeo.omn
+++ b/oeo.omn
@@ -1297,7 +1297,7 @@ Class: AdditionalToAddress
 Class: Address
 
     SubClassOf: 
-        Contact,
+        ContactInfomation,
         has_part some 
             (GeographicInformationArtifact or <http://purl.obolibrary.org/obo/BFO_0000006>)
     
@@ -1798,7 +1798,7 @@ Class: ConsumptionQuantity
         Quantity
     
     
-Class: Contact
+Class: ContactInfomation
 
     SubClassOf: 
         InformationArtifact
@@ -2172,7 +2172,7 @@ Class: ElectricitySector
 Class: Email
 
     SubClassOf: 
-        Contact
+        ContactInfomation
     
     
 Class: Emission
@@ -2330,7 +2330,7 @@ Class: Factsheet
 Class: Fax
 
     SubClassOf: 
-        Contact
+        ContactInfomation
     
     
 Class: FederalState
@@ -3789,7 +3789,7 @@ Class: Person
 Class: Phone
 
     SubClassOf: 
-        Contact
+        ContactInfomation
     
     
 Class: PhotovoltaicElectricityGenerator

--- a/oeo.omn
+++ b/oeo.omn
@@ -882,7 +882,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HouseNumber>
 
     SubClassOf: 
-        GeographicRegion
+        GeographicInformationArtifact
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#HubHeight>
@@ -984,7 +984,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ParcelNumber>
 
     SubClassOf: 
-        GeographicRegion
+        GeographicInformationArtifact
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PartOfMarginalPowerPlant>
@@ -1014,7 +1014,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PostalCode>
 
     SubClassOf: 
-        GeographicRegion
+        GeographicInformationArtifact
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#PowerPlantnumber>
@@ -1291,7 +1291,7 @@ Class: Acronym
 Class: AdditionalToAddress
 
     SubClassOf: 
-        GeographicRegion
+        GeographicInformationArtifact
     
     
 Class: Agent
@@ -2561,6 +2561,12 @@ Source: https://en.wikipedia.org/wiki/Electric_generator"@en
     
     DisjointWith: 
         Line
+    
+    
+Class: GeographicInformationArtifact
+
+    SubClassOf: 
+        InformationArtifact
     
     
 Class: GeographicRegion

--- a/oeo.omn
+++ b/oeo.omn
@@ -801,7 +801,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Community>
 
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#ConnectionToMaximumOrHighVoltage>
@@ -813,7 +813,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#County>
 
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#DataFinalDecommissioning>
@@ -849,7 +849,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#District>
 
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#EmergencyGenerator>
@@ -1113,7 +1113,7 @@ Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#Street>
 
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: <http://www.semanticweb.org/izzet_kilicarslan/ontologies/2019/9/untitled-ontology-10#TechnicalDataStorage>
@@ -1581,7 +1581,7 @@ Class: City
         <http://purl.obolibrary.org/obo/IAO_0000115> "A city is a large human settlement."@en
     
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: Client
@@ -1794,7 +1794,7 @@ Class: Country
         <http://purl.obolibrary.org/obo/IAO_0000115> "A country is a geographic region that is an distinct political entity."@en
     
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: CrudeOil
@@ -2280,7 +2280,7 @@ Class: FederalState
         <http://purl.obolibrary.org/obo/IAO_0000115> "A federal state is a geographic region that is a political entity within a country. It is partially self governing."@en
     
     SubClassOf: 
-        LandRegion
+        PoliticalRegion
     
     
 Class: FieldPhotovoltaicGenerator
@@ -3805,6 +3805,12 @@ Class: PoliticalParty
     
     SubClassOf: 
         Organization
+    
+    
+Class: PoliticalRegion
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000028>
     
     
 Class: Pollutant


### PR DESCRIPTION
This is my first try in restructuring GeographicRegion (#61). I hope for some discussion about my changes. Especially:
- classifying entities like HouseNumber as 'bfo: generically dependent continuant'. I decided to do that because HouseNumbers can change Houses and are not material entities
- classifying CoastDistance and WaterDepth as 'bfo: two-dimensional spatial region'. This would interpret those instances as the infinity thin planes consisting of every point that has a specific WaterDepth or CoastDistance.