### PR TITLE
Create AUTHORS.rst file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,80 @@
+Guidelines
+==========
+
+The purpose of this file is to let newcomers know who is who and to whom best address their
+best address questions or ask a review. The format of this file can also be questionned and
+change, do not hesitate to make suggestions!
+
+Ontology experts
+================
+With Ph.D.
+----------
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+
+With Master
+-----------
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+
+Researchers
+===========
+
+* @Bachibouzouk
+
+ * 0 year of experience with ontology
+ * Started working on this project since 2019-10-01
+ * Specific relevant area of expertise for this project: github workflow
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+
+
+Students currently working on the ontology
+==========================================
+During Master
+-------------
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+
+
+During Bachelor
+---------------
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+
+
+Past contributors to the ontology
+=================================
+
+* github handle (+ real name if relevant/wanted)
+
+ * X years of experience with ontology
+ * Started working on this project since 20XX-XX-XX
+ * Specific relevant area of expertise for this project: ...
+
+

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,7 +55,11 @@ During Master
  * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
+* @izzet91 
 
+ * 2 months of experience with ontology
+ * Started working on this project since 2019-09-01
+ * Specific relevant area of expertise for this project: Implementing MaStR in the ontology
 
 During Bachelor
 ---------------

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,7 +13,7 @@ With Ph.D.
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 
@@ -23,7 +23,7 @@ With Master
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 
@@ -33,13 +33,13 @@ Researchers
 * @Bachibouzouk
 
  * 0 year of experience with ontology
- * Started working on this project since 2019-10-01
+ * Working on this ontology since 2019-10-01
  * Specific relevant area of expertise for this project: github workflow
 
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 
@@ -52,7 +52,7 @@ During Master
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 
@@ -63,7 +63,7 @@ During Bachelor
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 
@@ -74,7 +74,7 @@ Past contributors to the ontology
 * github handle (+ real name if relevant/wanted)
 
  * X years of experience with ontology
- * Started working on this project since 20XX-XX-XX
+ * Working on this ontology since 20XX-XX-XX
  * Specific relevant area of expertise for this project: ...
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Here is a template for new release sections
 - Add has_normal_state_of_matter value solid/liquid/gaseous/plasmatic to fuels (#39)
 - object properties: 'has_disposition', 'has_role', 'has_function',
   'has_quality' (#51)
+- file AUTHORS.rst (#70)
 ### Changed
 - agent and subclasses (#51)
 - pollutant and subclasses (#51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,20 @@ Here is a template for new release sections
 - factsheet categories (#47)
 - storage technologies (#47)
 - `ObjectProperty` `has_normal_state_of_matter` (#39)
-- add individuals `solid`, `liquid`, `gaseous`, `plasmatic` (#39)
-- Add has_normal_state_of_matter value solid/liquid/gaseous/plasmatic to fuels (#39)
+- individuals `solid`, `liquid`, `gaseous`, `plasmatic` (#39)
+- has_normal_state_of_matter value solid/liquid/gaseous/plasmatic to
+  fuels (#39)
 - object properties: 'has_disposition', 'has_role', 'has_function',
   'has_quality' (#51)
 - file AUTHORS.rst (#70)
+- file for with guideline for testing ontology (#54)
 ### Changed
 - agent and subclasses (#51)
 - pollutant and subclasses (#51)
 - structure of the ontology (#47)
 - change peat to solid and not gas (#39)
-- StateOfMatter and subclasses (#45)
+- StateOfMatter and subclasses (#58)
+- Unify WindEntityData and WindEntityDataset (#59)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -5,12 +5,18 @@
 - [Git](https://git-scm.com/)
 
 ### Contribution of OEO content
-Please read [OEO wiki](https://github.com/OpenEnergyPlatform/ontology/wiki/Best-Practice-Principles) carefully.
+- Please read [OEO wiki](https://github.com/OpenEnergyPlatform/ontology/wiki/Best-Practice-Principles) carefully.
+- Please add your information to the `AUTHORS.rst` file using the
+  workflow described below. This will be your first Pull request on this
+  repository and will help you to familiarize yourself with our workflow
+  
+### Workflow
 
-### Philosophy
-
-The development of a feature for this repository is inspired from the workflow described 
-by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
+The development of a feature for this repository is inspired from the
+workflow described by
+[Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/).
+If you are unsure about an instruction please notify @Bachibouzouk (you
+can also create an issue, point 1 below, to explain what is not clear).
 
 1. Create [an issue](https://help.github.com/en/articles/creating-an-issue) on the github repository to describe the addition to the ontology. Discussion about the implementation details should occur within this issue 
 2. Create a branch from dev to work on your issue (see below, the "Branch name convention" section)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ This repository is licensed under CC0 1.0 Universell (CC0 1.0) Public Domain Ded
 ## Installation
 
 * [protégé](https://protege.stanford.edu/)
+
+## Development
+
+Please read the `CONTRIBUTE.md` file before working on this repository


### PR DESCRIPTION
Closes #68 

Such a file would be useful to know who knows what and who is currently working on the repository (and maybe also since when).

I suggest that the people already working on the ontology add their information (if they want to) by making suggestion in the section "Files changed" ([github help](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request)). Here is a screen shot of the button you have to press once you selected the line where you would like to add your information :

![example_insert_suggestion](https://user-images.githubusercontent.com/4399407/68474659-52d62480-0226-11ea-80ca-f1a0e132b8bf.png)