### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -1,0 +1,21 @@
+---
+name: "[A] New ontology term"
+about: For including new terms into the ontology
+title: Your title should make sense if said after "The issue is <your issue title>"
+labels: "[A] new term"
+assignees: ''
+
+---
+
+## Description of the issue
+
+Here describe the issue as extensively as possible
+
+## Ideas of solution
+
+If you already have ideas for the solution describe them here
+
+## Workflow checklist
+
+- [ ] I discussed the issue with someone else than me before working on a solution
+- [ ] I am aware of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository

--- a/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
+++ b/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
@@ -1,0 +1,21 @@
+---
+name: "[B] Restructure ontology"
+about: For restructuring existing parts of the ontology
+title: Your title should make sense if said after "The issue is <your issue title>"
+labels: "[B] restructure"
+assignees: ''
+
+---
+
+## Description of the issue
+
+Here describe the issue as extensively as possible
+
+## Ideas of solution
+
+If you already have ideas for the solution describe them here
+
+## Workflow checklist
+
+- [ ] I discussed the issue with someone else than me before working on a solution
+- [ ] I am aware of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository

--- a/.github/ISSUE_TEMPLATE/-c--normal-issue.md
+++ b/.github/ISSUE_TEMPLATE/-c--normal-issue.md
@@ -1,0 +1,20 @@
+---
+name: "Normal issue"
+about: ''
+title: Your title should make sense if said after "The issue is <your issue title>"
+labels: ''
+assignees: ''
+
+---
+
+## Description of the issue
+
+Here describe the issue as extensively as possible
+
+## Ideas of solution
+
+If you already have ideas for the solution describe them here
+
+## Workflow checklist
+
+- [ ] I am aware of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Here is a template for new release sections
 - Add has_normal_state_of_matter value solid/liquid/gaseous/plasmatic to fuels (#39)
 - object properties: 'has_disposition', 'has_role', 'has_function',
   'has_quality' (#51)
+- issue templates (#92) 
+  
 ### Changed
 - agent and subclasses (#51)
 - pollutant and subclasses (#51)


### PR DESCRIPTION
Closes #85

## Description of the issue #85 
There is the possibility to define issue template in github. This could help format issues for case A and case B proposed by @stap-m [here](https://github.com/OpenEnergyPlatform/ontology/issues/64#issuecomment-551045643)

In these templates we could setup section so that the [request](https://github.com/OpenEnergyPlatform/ontology/pull/70#issuecomment-552394213) of @han-f can be fulfilled.

[Here](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates) are the instructions for implementing that.



[Here](https://github.com/rl-institut/NESP2_website/issues/new/choose) is an example of what it looks like when someone clicks on the "New Issue" button.

We should decide if we store the templates under `docs/`, `.github/` or in the root of the repository (it **must** be one of the three)
