### PR TITLE
Add information about github teams in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Here is a template for new release sections
 - StateOfMatter and subclasses (#45)
 - improved workflow in `CONTRIBUTE.md` (#98)
 - linked wiki and `CONTRIBUTE.md` in `README`(#113)
+- add github team handle in `README` (#119)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ This repository is licensed under CC0 1.0 Universell (CC0 1.0) Public Domain Ded
 Please read the [wiki](https://github.com/OpenEnergyPlatform/ontology/wiki) for information about the ontology and its standards.
  
 The workflow is described in the [CONTRIBUTE.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) file. Please check it out **before** you start working on this project. Points that are not clear in the file can be discussed in a [github issue](https://github.com/OpenEnergyPlatform/ontology/issues/new/choose).
+
+## Teams tag
+
+If you have a specific question about ontology, modelling or economy (in context of the ontology), you can [tag](https://github.com/OmahaGirlsWhoCode/OmahaGirlsWhoCode/wiki/How-to-tag-someone-in-a-pull-request) one of these team to notify its members that you need their feedback/help.
+
+- @economy-experts
+
+- @ontology-experts
+
+- @modelling-experts

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The workflow is described in the [CONTRIBUTE.md](https://github.com/OpenEnergyPl
 
 If you have a specific question about ontology, modelling or economy (in context of the ontology), you can [tag](https://github.com/OmahaGirlsWhoCode/OmahaGirlsWhoCode/wiki/How-to-tag-someone-in-a-pull-request) one of these team to notify its members that you need their feedback/help.
 
-- @economy-experts
+- [@economy-experts](https://github.com/orgs/OpenEnergyPlatform/teams/economy-experts)
 
-- @ontology-experts
+- [@ontology-experts](https://github.com/orgs/OpenEnergyPlatform/teams/modelling-experts)
 
-- @modelling-experts
+- [@modelling-experts](https://github.com/orgs/OpenEnergyPlatform/teams/ontology-experts)


### PR DESCRIPTION
Closes #118 

## Description of the issue

The user groups created tp solve the issue #99 are listed [here](https://github.com/orgs/OpenEnergyPlatform/teams). The issue is twofold:

- [ ] The link is not directly accessible in the repository (either in AUTHORS.rts, README.md or CONTRIBUTE.md)

- [ ] Not everyone has access to the link

## Solution

Provide the teams handles in the readme, so that people can tag them in issues or PR (one cannot ask a team to review a PR)