### PR TITLE
Feature/add template for ontology definition update

### DIFF
--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -1,0 +1,27 @@
+---
+name: "[C] Ontology definition update" 
+about: For restructuring existing parts
+of the ontology title: Your title should make sense if said after "The
+issue is <your issue title>" 
+labels: "[C] definition update" 
+assignees: ''
+---
+
+## Description of the issue
+
+Here describe the issue as extensively as possible
+
+## Ideas of solution
+
+If you already have ideas for the solution describe them here
+
+## Workflow checklist
+
+- [ ] I discussed the issue with someone else than me before working on a solution
+- [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository
+- [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
+
+I am aware that
+- [ ] every entry in the ontology should have an annotation
+- [ ] classes should arise from concepts rather than from words
+- [ ] class or property names should follow the [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case)

--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -18,7 +18,7 @@ If you already have ideas for the solution describe them here
 ## Workflow checklist
 
 - [ ] I discussed the issue with someone else than me before working on a solution
-- [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository
+- [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTING.md) for this repository
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that

--- a/.github/ISSUE_TEMPLATE/-d--normal-issue.md
+++ b/.github/ISSUE_TEMPLATE/-d--normal-issue.md
@@ -17,4 +17,6 @@ If you already have ideas for the solution describe them here
 
 ## Workflow checklist
 
-- [ ] I am aware of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository
+- [ ] I am aware of the
+      [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md)
+      for this repository

--- a/.github/ISSUE_TEMPLATE/-d--normal-issue.md
+++ b/.github/ISSUE_TEMPLATE/-d--normal-issue.md
@@ -18,5 +18,5 @@ If you already have ideas for the solution describe them here
 ## Workflow checklist
 
 - [ ] I am aware of the
-      [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md)
+      [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTING.md)
       for this repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Here is a template for new release sections
 - Add has_normal_state_of_matter value solid/liquid/gaseous/plasmatic to fuels (#39)
 - object properties: 'has_disposition', 'has_role', 'has_function',
   'has_quality' (#51)
-- issue templates (#92) 
+- issue templates (#92, #146) 
 - ArtificialObject (#121) 
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ Please read [OEO wiki](https://github.com/OpenEnergyPlatform/ontology/wiki/Best-
 The development of a feature for this repository is inspired from the workflow described 
 by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
 
-1. Create [an issue](https://help.github.com/en/articles/creating-an-issue) on the github repository
+1. Create
+   [an issue](https://help.github.com/en/articles/creating-an-issue) on
+   the github repository
 
     Choose the right issue for you among the choices you have on github:
 
@@ -20,7 +22,9 @@ by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
     
     B) Restructuring existing parts of the ontology
 
-    C) Other issue
+    C) Updating definition of the ontology
+
+    D) Other issue
 
     Discussion about the implementation details should occur within this issue. [Assign a project](https://help.github.com/en/github/managing-your-work-on-github/adding-issues-and-pull-requests-to-a-project-board#adding-issues-and-pull-requests-to-a-project-board-from-the-sidebar) (default "Issues") to the issue
 
@@ -63,7 +67,11 @@ by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
     
     B) If restructuring the ontology, ask at least two persons to review
     
-    C) If your PR does not modify the ontology, only one reviewer is enough
+    C) If updating a definition in the ontology, ask at least two
+    persons to review
+    
+    D) If your PR does not modify the ontology, only one reviewer is
+    enough
 
     When more than one reviewer is requested, please try to combine modelling and ontology expertise in your choice of reviewers. (see the section "Teams tag" of the [README](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) for more information about who is expert of what)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
     C) If updating a definition in the ontology, ask at least two
     persons to review
     
-    D) If your PR does not modify the ontology, only one reviewer is
+    D) If your PR does not modify the ontology, one reviewer is
     enough
 
     When more than one reviewer is requested, please try to combine modelling and ontology expertise in your choice of reviewers. (see the section "Teams tag" of the [README](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) for more information about who is expert of what)


### PR DESCRIPTION
We should also comment on definition updates in the ontology. They have an own tag [C] but no special template. Template [C] is for changes other than in oeo-files. Issue originated from [here](https://github.com/OpenEnergyPlatform/ontology/pull/139#issuecomment-559844282)