### PR TITLE
Update definitions of SolidFossilFuels

### DIFF
--- a/oeo.omn
+++ b/oeo.omn
@@ -2420,7 +2420,8 @@ Class: Grid
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-rdfs:comment "Synonym: Network"@en
+        rdfs:comment "Synonym: Network"@en
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
@@ -3380,7 +3381,6 @@ Class: Person
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
-
     
     DisjointWith: 
         Organization
@@ -4559,11 +4559,11 @@ Class: SolarThermalPowerplant
 Class: SolidFossilFuels
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a combustible black or brownish-black sedimentary rock usually occurring in rock strata in layers or veins called coal beds or coal seams. The harder forms, such as anthracite coal, can be regarded as metamorphic rock because of later exposure to elevated temperature and pressure. Coal is composed primarily of carbon, along with variable quantities of other elements, chiefly hydrogen, sulfur, oxygen, and nitrogen.[1] Coal is a fossil fuel that forms when dead plant matter is converted into peat, which in turn is converted into lignite, then sub-bituminous coal, after that bituminous coal, and lastly anthracite. This involves biological and geological processes. The geological processes take place over millions of years."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=868515262"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions."@en
     
     SubClassOf: 
         Fuel,
+        has_normal_state_of_matter value solid,
         has_origin value fossil
     
     
@@ -6292,3 +6292,4 @@ DisjointClasses:
 
 DisjointClasses: 
     LinearOptimalPowerflow,SingleNodeModel,TranshipmentModel
+


### PR DESCRIPTION
SolidFossilFuels
new def: "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions."
I also added the the normal_state_of_matter property with value solid
closes #106: Update definitions of SolidFossilFuels