### PR TITLE
delete biogasgenerator (was duplicate)

### DIFF
--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -828,17 +828,6 @@ Class: BioElectricityGenerator
         RenewableGenerator
     
     
-Class: BioGasGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas generator uses biogas to generate electricity."@en
-    
-    SubClassOf: 
-        EnergyGenerator,
-        has_physical_output some Power,
-        has_physical_input only PortionOfBiogas
-    
-    
 Class: Biofuel
 
     Annotations: 


### PR DESCRIPTION
closes #160 by deleting BioGasGenerator: subclass of EnergyGenerator
because we have BiogasElectricityGenerator: subclass of BioElectricityGenerator
