### PR TITLE
Add RenewableEnergyCarrier and assign subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Here is a template for new release sections
 - classes for objects that apply to technologies like EnergyGenerator (#128)
 - Grid class (#137)
 - object properties to describe models (#109)
+- RenewableEnergyCarrier (#206)
 
 ### Changed
 - Split the ontology file into three modules: oeo-social,oeo-model and oeo-physical (#167)

--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -1336,7 +1336,17 @@ Class: GeographicRegion
         <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
-Class: Geothermal
+Class: GeothermalGenerator
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."
+    
+    SubClassOf: 
+        Generator,
+        uses some Heat
+    
+    
+Class: GeothermalHeat
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
@@ -1347,16 +1357,6 @@ Class: Geothermal
     SubClassOf: 
         Heat,
         has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
-    
-    
-Class: GeothermalGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."
-    
-    SubClassOf: 
-        Generator,
-        uses some Heat
     
     
 Class: GeothermalPowerplant
@@ -2911,18 +2911,6 @@ Class: SolarPowerPlant
         Turbine or (has_part some PVPanel)
     
     
-Class: SolarThermal
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
-(a) solar thermal-electric plants; or
-(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
-    
-    SubClassOf: 
-        Heat
-    
-    
 Class: SolarThermalCollector
 
     Annotations: 
@@ -2932,7 +2920,19 @@ Class: SolarThermalCollector
     SubClassOf: 
         EnergyGenerator,
         has_physical_output some Power,
-        has_physical_input only SolarThermal
+        has_physical_input only SolarThermalHeat
+    
+    
+Class: SolarThermalHeat
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
+(a) solar thermal-electric plants; or
+(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+    
+    SubClassOf: 
+        Heat
     
     
 Class: SolarThermalHeatGenerator
@@ -3249,18 +3249,6 @@ Class: WavePowerPlant
         uses some Wave
     
     
-Class: Wind
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
-    
-    SubClassOf: 
-        PortionOfAir,
-        has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
-    
-    
 Class: WindElectricityGenerator
 
     Annotations: 
@@ -3298,6 +3286,18 @@ Class: WindOnshore
         has_part some WindTurbine
     
     
+Class: WindPower
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
+    
+    SubClassOf: 
+        PortionOfAir,
+        has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
+    
+    
 Class: WindTurbine
 
     Annotations: 
@@ -3309,8 +3309,8 @@ Wind turbines are manufactured in a wide range of vertical and horizontal axis. 
     SubClassOf: 
         Turbine,
         has_physical_output some Power,
-        uses some Wind,
-        has_physical_input only Wind
+        uses some WindPower,
+        has_physical_input only WindPower
     
     
 Class: Year

--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -285,6 +285,16 @@ ObjectProperty: uses
         is_used_by
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
+
+    EquivalentTo: 
+        EnergyCarrier
+         and (has_origin value renewable)
+    
+    SubClassOf: 
+        EnergyCarrier
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
@@ -1335,7 +1345,8 @@ Class: Geothermal
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
     
     SubClassOf: 
-        Heat
+        Heat,
+        has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
     
     
 Class: GeothermalGenerator
@@ -1538,7 +1549,9 @@ Class: Hydrogen
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en
     
     SubClassOf: 
-        EnergyStorage
+        EnergyStorage,
+        has_disposition some Fuel,
+        has_origin value synthetic
     
     
 Class: HydrogenPowerplant
@@ -2883,7 +2896,8 @@ Class: SolarPower
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
     
     SubClassOf: 
-        Energy
+        Energy,
+        has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
     
     
 Class: SolarPowerPlant
@@ -3243,7 +3257,8 @@ Class: Wind
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
     
     SubClassOf: 
-        PortionOfAir
+        PortionOfAir,
+        has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
     
     
 Class: WindElectricityGenerator


### PR DESCRIPTION
closes #184.
Original Plan was: 
- add "renewable" origin and "energy carrier" disposition to wind, geothermal heat and solar power
- add "synthetic" origin and "fuel" disposition to hydrogen
- add annotation to hydrogen explaining why it hasn't the origin "renewable"
- add equivalent class "RenewableEnergyCarrier": EnergyCarrier
def: A RenewableEnergyCarrier is an EnergyCarrier from renwable resources, which are naturally
replenished on a human timescale.
source: https://en.wikipedia.org/wiki/Renewable_energy
equivalent to: every class that has origin "renewable" and disposition "EnergyCarrier"

This sadly didnt work because it wasn't logical correct because eg wind isnt a RenewableEnergyCarrier, it just has the disposition RenewableEnergyCarrier. So I now did:
- add **"RenewableEnergyCarrier"** disposition to wind, geothermal heat and solar power
- add "synthetic" origin and "fuel" disposition to hydrogen
- add annotation to hydrogen explaining why it hasn't the origin "renewable"
- add equivalent class "RenewableEnergyCarrier": EnergyCarrier
  - def: A RenewableEnergyCarrier is an EnergyCarrier from renwable resources, which are naturally
replenished on a human timescale.
  - source: https://en.wikipedia.org/wiki/Renewable_energy
  - equivalent to: **every  EnergyCarrier with has_origin "renewable"**