### PR TITLE
Update Waste and WasteFuel

### DIFF
--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -285,6 +285,15 @@ ObjectProperty: uses
         is_used_by
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste is a disposition of an object aggregate when it has been discarded after primary use."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
@@ -1247,7 +1256,7 @@ Class: FossilePowerplant
 Class: Fuel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel is an EnergyCarrier that releases energy in form of heat or work, by chemical reaction with other substances."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel is an EnergyCarrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances."
     
     SubClassOf: 
         EnergyCarrier,
@@ -3179,8 +3188,12 @@ Class: Warehouse
 Class: WasteFuel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste (or wastes) are unwanted or unusable materials. Waste is any substance which is discarded after primary use, or is worthless, defective and of no use."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Waste&oldid=903993587"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteFuel is a fuel in which the material entity is waste."@en,
+        rdfs:comment "The energy content of WasteFuel is typically released by incineration or gasification."
+    
+    EquivalentTo: 
+        Fuel
+         and (has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/Waste>)
     
     SubClassOf: 
         Fuel

--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -288,7 +288,7 @@ ObjectProperty: uses
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste is a disposition of an object aggregate when it has been discarded after primary use."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste is a role of an object aggregate that has been discarded after primary use."
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -3937,4 +3937,3 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
-

--- a/oeo-physical.omn
+++ b/oeo-physical.omn
@@ -55,6 +55,9 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo-physical/has_role>
+
+    
 ObjectProperty: applies_technology
 
     Annotations: 
@@ -291,7 +294,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
         <http://purl.obolibrary.org/obo/IAO_0000115> "Waste is a role of an object aggregate that has been discarded after primary use."
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -3193,7 +3196,7 @@ Class: WasteFuel
     
     EquivalentTo: 
         Fuel
-         and (has_disposition some <http://openenergy-platform.org/ontology/oeo-physical/Waste>)
+         and (<http://openenergy-platform.org/ontology/oeo-physical/has_role> some <http://openenergy-platform.org/ontology/oeo-physical/Waste>)
     
     SubClassOf: 
         Fuel
@@ -3937,3 +3940,4 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
+


### PR DESCRIPTION
closes #132. 
Original idea from the issue:
- Waste => An object aggregate that has been discarded after primary use.
- Fuel => An EnergyCarrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.
- WasteFuel => A fuel in which the material entity is waste.
   - defined via an equivalence class expression: WasteFuel is equivalent to Fuel and has_disposition some Waste
   - Comment: The energy content of waste fuel is typically released by incineration or gasification.

For the equivalent definition from WasteFuel the class Waste has to be a disposition which also makes more sense than object aggregate because an object is most times primary sth different then waste and just has the disposition.

So I changed:
- Waste to disposition
- Waste definition to: "Waste is a disposition of an object aggregate when it has been discarded after primary use."
