### PR TITLE
Add ChemicalEnergy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Here is a template for new release sections
 - Grid class (#137)
 - object properties to describe models (#109)
 - RenewableEnergyCarrier (#206)
+- ChemicalEnergy (#214)
 
 ### Changed
 - Restructured the repository to add a 'src' folder with an 'ontology' sub-folder with sub-folders for editable modules and import modules (#200)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -287,7 +287,16 @@ ObjectProperty: uses
     InverseOf: 
         is_used_by
     
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction."
+    
+    SubClassOf: 
+        Energy
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
     EquivalentTo: 
@@ -296,7 +305,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarr
     
     SubClassOf: 
         EnergyCarrier
-
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
 
     Annotations: 
@@ -304,7 +314,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
-
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 


### PR DESCRIPTION
closes #174 

Adds ChemicalEnergy as subclass of Energy with def:
"Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction."