### PR TITLE
restructure ModelElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Here is a template for new release sections
 - import ro-ontology module replacing some of our relations (#216)
 - replace InformationArtifact with information content entity from imported iao-ontology module (#223)
 - unify -Energy and -Power classes (#225)
+- ModelElement and subbclasses
 
 
 ### Removed

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -500,7 +500,7 @@ Class: BooleanVariable
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
+        Variable
     
     
 Class: CitationReference
@@ -568,7 +568,7 @@ Class: CorporateIdentity
 Class: Cost
 
     SubClassOf: 
-        ModelVariable
+        Variable
     
     
 Class: DOI
@@ -765,7 +765,7 @@ Class: MarketModel
 Class: MathematicalConcept
 
     SubClassOf: 
-        ModelElement
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: Maximization
@@ -809,24 +809,7 @@ Class: ModelCalculation
 Class: ModelComponent
 
     SubClassOf: 
-        ModelElement
-    
-    
-Class: ModelConstraint
-
-    SubClassOf: 
-        ModelComponent
-    
-    
-Class: ModelElement
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model element is an elementary model component."@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some Model
-
+        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: ModelExamples
@@ -851,15 +834,6 @@ Class: ModelFunction
         Model
     
     
-Class: ModelVariable
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model variable is a variable inside a model."@en
-    
-    SubClassOf: 
-        ModelElement
-    
-    
 Class: ModelingSoftware
 
     SubClassOf: 
@@ -875,7 +849,7 @@ Class: Modus
 Class: ObjectiveFunction
 
     SubClassOf: 
-        ModelElement
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OpenSource
@@ -966,7 +940,7 @@ Class: ProgramParameter
         <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en
     
     SubClassOf: 
-        ModelElement
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: Project
@@ -1109,19 +1083,19 @@ Class: TestDataset
 Class: TimeHorizon
 
     SubClassOf: 
-        ModelVariable
+        Variable
     
     
 Class: TimeSeries
 
     SubClassOf: 
-        ModelVariable
+        Variable
     
     
 Class: TimeStep
 
     SubClassOf: 
-        ModelVariable
+        Variable
     
     
 Class: Transformation
@@ -1160,7 +1134,16 @@ Class: UserDocumentation
 Class: Validation
 
     SubClassOf: 
-        ModelElement
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: Variable
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Variable is an InformationArtifact that represents a changable value, vector, matrix or function within a mathematical expression."@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: VariableOperationCost

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -30,6 +30,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000116>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
@@ -808,6 +811,14 @@ Class: ModelCalculation
     
 Class: ModelComponent
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A ModelComponent is a generically dependent continuant that is part of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Model element",
+        rdfs:label "Model component"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000050> some Model
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -73,6 +73,9 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
@@ -452,4 +455,18 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
+    
+Class: Model
+
+    
+Class: ModelComponent
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A ModelComponent is a generically dependent continuant that is part of a model.",
+        rdfs:label "Model component",
+        rdfs:label "Model element"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000050> some Model
+    
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -459,14 +459,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 Class: Model
 
     
-Class: ModelComponent
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ModelComponent is a generically dependent continuant that is part of a model.",
-        rdfs:label "Model component",
-        rdfs:label "Model element"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000050> some Model
     
     


### PR DESCRIPTION
closes #196 
- Make ModelComponent an equivalent class defined as "All classes with a 'part_of some Model' relationship". Definition: "A ModelComponent is a generically dependent continuant that is part of a model."
- Make ModelElement a label/synonym of ModelComponent 
- Delete ModelConstraint because the class Constraint is enough
- Rename ModelVariable to Variable and move it to information content entity. Definition: "A Variable is an InformationArtifact that represents a changable value, vector, matrix or function within a mathematical expression."
- Move all remaining subclasses of ModelElement to information content entity

(information content entity replaced our InformationArtifact when importing IAO. The class Unit couldnt be deleted because it got deleted in some other pull request).