### PR TITLE
Add Uranium, geogenic, NuclearFuel

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -302,7 +302,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000119> "\"Nuclear fuel is an energy carrier used in nuclear power stations to produce heat to power turbines. Heat is created when nuclear fuel undergoes nuclear fission.\""
+        <http://purl.obolibrary.org/obo/IAO_0000119> "\"Nuclear fuel is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.\""
     
     SubClassOf: 
         EnergyCarrier
@@ -1330,7 +1330,8 @@ Class: Hydrogen
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en
     
     SubClassOf: 
-        EnergyStorage,
+        PortionOfMatter,
+        has_disposition CombustionFuel
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
         has_origin value synthetic
     
@@ -3338,4 +3339,3 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -316,7 +316,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
     SubClassOf: 
         PortionOfMatter,
         has_normal_state_of_matter value solid,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>,
         'has disposition' some NuclearFuel
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1323,19 +1323,6 @@ Class: Hydrofluorocarbon
         FluorinatedGreenhouseGas
     
     
-Class: Hydrogen
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a chemical element with chemical symbol H and atomic number 1. It is used in water electrolysis during the power-to-gas process as a storage medium for excess electricty."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en
-    
-    SubClassOf: 
-        PortionOfMatter,
-        has_disposition CombustionFuel
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
-        has_origin value synthetic
-    
-    
 Class: HydrogenPowerplant
 
     Annotations: 
@@ -1354,7 +1341,7 @@ Class: HydrogenTurbine
     SubClassOf: 
         Turbine,
         has_physical_output some Power,
-        has_physical_input only Hydrogen
+        has_physical_input only PortionOfHydrogen
     
     
 Class: HydrogenVehicle
@@ -2128,6 +2115,18 @@ Class: PortionOfHeatingOil
         PortionOfGasDieselOil
     
     
+Class: PortionOfHydrogen
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a chemical element with chemical symbol H and atomic number 1. It is used in water electrolysis during the power-to-gas process as a storage medium for excess electricty."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en
+    
+    SubClassOf: 
+        PortionOfMatter,
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
+        has_origin value synthetic
+    
+    
 Class: PortionOfIndustrialWasteFuel
 
     SubClassOf: 
@@ -2867,7 +2866,7 @@ Class: UndergroundHydrogenStorage
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780"
     
     SubClassOf: 
-        Hydrogen
+        EnergyStorage
     
     
 Class: UndirectedEdge
@@ -3339,3 +3338,4 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -269,6 +269,36 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilCombustionFuel is a CombustionFuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic."
+    
+    EquivalentTo: 
+        CombustionFuel
+         and (has_origin value fossil)
+    
+    SubClassOf: 
+        CombustionFuel,
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatter>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPortionOfMatter is a PortionOfMatter with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic."
+    
+    EquivalentTo: 
+        PortionOfMatter
+         and (has_origin value fossil)
+    
+    SubClassOf: 
+        PortionOfMatter,
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -269,6 +269,26 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000119> "\"Nuclear fuel is an energy carrier used in nuclear power stations to produce heat to power turbines. Heat is created when nuclear fuel undergoes nuclear fission.\""
+    
+    SubClassOf: 
+        EnergyCarrier
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal."
+    
+    SubClassOf: 
+        PortionOfMatter,
+        has_normal_state_of_matter value solid,
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
     EquivalentTo: 
@@ -465,7 +485,7 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109"
     
     SubClassOf: 
-        Fuel,
+        CombustionFuel,
         has_origin value biogenic,
         has_origin value renewable
     
@@ -565,6 +585,16 @@ Class: Combustion
 
     SubClassOf: 
         TransportDemand
+    
+    
+Class: CombustionFuel
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "CombustionFuel is an EnergyCarrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances."
+    
+    SubClassOf: 
+        EnergyCarrier,
+        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrier
     
     
 Class: CommericalDemand
@@ -985,16 +1015,6 @@ Class: FossilePowerplant
         PowerGeneratingUnit
     
     
-Class: Fuel
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel is an EnergyCarrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances."
-    
-    SubClassOf: 
-        EnergyCarrier,
-        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrier
-    
-    
 Class: Fusion
 
     Annotations: 
@@ -1281,7 +1301,7 @@ Class: Hydrogen
     
     SubClassOf: 
         EnergyStorage,
-        <http://purl.obolibrary.org/obo/RO_0000091> some Fuel,
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
         has_origin value synthetic
     
     
@@ -2012,7 +2032,7 @@ Class: PortionOfDieselFuel
 Class: PortionOfFuel
 
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some Fuel
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel
     
     SubClassOf: 
         PortionOfMatter
@@ -2204,7 +2224,7 @@ It does not include gases created by anaerobic digestion of biomass (e.g. munici
     
     SubClassOf: 
         PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000091> some Fuel,
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
         has_normal_state_of_matter value gaseous,
         has_origin value fossil
     
@@ -2245,7 +2265,7 @@ It consists of hydrocarbons of various molecular weights and other organic compo
     
     SubClassOf: 
         PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000091> some Fuel,
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustionFuel,
         has_origin value fossil
     
     
@@ -2653,7 +2673,7 @@ Class: SolidFossilFuels
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions."@en
     
     SubClassOf: 
-        Fuel,
+        CombustionFuel,
         has_normal_state_of_matter value solid,
         has_origin value fossil
     
@@ -2862,11 +2882,11 @@ Class: WasteFuel
         rdfs:comment "The energy content of WasteFuel is typically released by incineration or gasification."
     
     EquivalentTo: 
-        Fuel
+        CombustionFuel
          and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo-physical/Waste>)
     
     SubClassOf: 
-        Fuel
+        CombustionFuel
     
     
 Class: WastePowerplant
@@ -3006,6 +3026,15 @@ Class: state_of_matter
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Individual: <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is geogenic if it is the result of geological processes."
+    
+    Types: 
+        origin
     
     
 Individual: CH4
@@ -3187,7 +3216,7 @@ Individual: biogenic
 Individual: fossil
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created by natural processes lasting thousands or millions of years.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created on Earth by geological processes lasting thousands or millions of years.
 
 In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain."
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -315,9 +315,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
     
     SubClassOf: 
         PortionOfMatter,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>,
         has_normal_state_of_matter value solid,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>,
-        'has disposition' some NuclearFuel
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
@@ -3338,3 +3339,4 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -317,7 +317,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
         PortionOfMatter,
         has_normal_state_of_matter value solid,
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
-    
+        'has disposition' some NuclearFuel
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
@@ -3338,4 +3338,3 @@ DisjointClasses:
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3246,7 +3246,7 @@ Individual: biogenic
 Individual: fossil
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created on Earth by geological processes lasting thousands or millions of years.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created from organic material by geolocial processes lasting thousands or millions of years.
 
 In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain."
     


### PR DESCRIPTION
closes #182.
- Add Uranium: Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal.
   - PortionOfMatter,
   - has_normal_state_of_matter value solid,
   - has_origin value geogenic
- change Fuel to CombustionFuel
- change fossil origin: "x is fossil if it was created on Earth by geological processes lasting thousands or millions of years."
- add NuclearFuel: "Nuclear fuel is an energy carrier used in nuclear power stations to produce heat to power turbines. Heat is created when nuclear fuel undergoes nuclear fission."
- add geogenic origin:  "x is geogenic if it is the result of geological processes."

This is a draft because I haven't got the time to find a solution for the geogenic-fossil-relationship