### PR TITLE
Change Quantity to QuantityValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Here is a template for new release sections
 - replace InformationArtifact with information content entity from imported iao-ontology module (#223)
 - unify -Energy and -Power classes (#225)
 - ModelElement and subbclasses
+- Quantity and subclasses (#239)
 
 
 ### Removed

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -8,7 +8,8 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/v0.0.1/oeo/" uri="oeo.omn"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl" uri="http://purl.obolibrary.org/obo/bfo.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1580113798864" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1580113798864" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1580977944005" name="http://open-energy-ontology.org/ontology/imports/iao-module.owl" uri="imports/iao-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1580977944005" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1580977944005" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -269,6 +269,16 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/QuantityValue>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an immaterial entity defined by a number together with a unit of measurement to quantify an entity."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -117,7 +117,7 @@ ObjectProperty: has_globalwarmingpotential
         GreenhouseGas
     
     Range: 
-        GlobalWarmingPotential
+        GlobalWarmingPotentialValue
     
     
 ObjectProperty: has_normal_state_of_matter
@@ -173,7 +173,7 @@ ObjectProperty: has_pollutant
         owl:topObjectProperty
     
     Domain: 
-        Emission
+        EmissionValue
     
     Range: 
         Pollutant
@@ -269,16 +269,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/QuantityValue>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an immaterial entity defined by a number together with a unit of measurement to quantify an entity."
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
     EquivalentTo: 
@@ -363,6 +353,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000113>
+
     
 Class: ACLine
 
@@ -524,22 +517,22 @@ Class: Bus
         NetworkNode
     
     
-Class: CarbonDioxideEmission
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission quantity is a quantity that is about carbon dioxide."@en
-    
-    SubClassOf: 
-        Emission
-    
-    
-Class: CarbonDioxideEmissionTrafficSector
+Class: CarbonDioxideEmissionTrafficSectorValue
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission traffic sector quantity is a carbon dioxide emission quantity that is restricted to carbon dioxide from the traffic sector."@en
     
     SubClassOf: 
-        CarbonDioxideEmission
+        CarbonDioxideEmissionValue
+    
+    
+Class: CarbonDioxideEmissionValue
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission quantity is a quantity that is about carbon dioxide."@en
+    
+    SubClassOf: 
+        EmissionValue
     
     
 Class: City
@@ -589,13 +582,13 @@ Class: CommonParameters
         ElectricityProductionUnit
     
     
-Class: ConsumptionQuantity
+Class: ConsumptionValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumption quantity is a quantity that describes the amount of consumption of some resource."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumption value is a QuantityValue that describes the amount of consumption of some resource."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: Continent
@@ -635,7 +628,7 @@ Class: Demand
 Source: https://wiki.openmod-initiative.org/wiki/Demand"@en
     
     SubClassOf: 
-        ConsumptionQuantity
+        ConsumptionValue
     
     
 Class: DerivedHeat
@@ -703,16 +696,16 @@ Class: ElectricityConsumption
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity consumption quantity is a consumption quantity about electricity."@en
     
     SubClassOf: 
-        ConsumptionQuantity
+        ConsumptionValue
     
     
-Class: ElectricityExport
+Class: ElectricityExportValue
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export quantity is a quantity that describes the amount of electricity that is exported from a geographic region."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: ElectricityGenerator
@@ -757,19 +750,7 @@ Class: ElectricityProductionUnit
         ElectricityGridComponent
     
     
-Class: Emission
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "1. Emissions are waste from production, distribution and consumption, which are distributed to environmental media. Emmision is often restricted to pollutants.
-        
-        2. Emissions generally means discharge of any interference in the environment. The source is called the issuer. Each emission causes an immission."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Emmision"@en
-    
-    SubClassOf: 
-        Quantity
-    
-    
-Class: EmissionFactor
+Class: EmissionFactorValue
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Emission factors assume a linear relation between the intensity of the activity and the emission resulting from this activity:
@@ -778,7 +759,19 @@ Emission (pollutant) = Activity * Emission Factor (pollutant)",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Emission_intensity&oldid=881841342"
     
     SubClassOf: 
-        Quantity
+        QuantityValue
+    
+    
+Class: EmissionValue
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "1. Emissions are waste from production, distribution and consumption, which are distributed to environmental media. Emmision is often restricted to pollutants.
+        
+        2. Emissions generally means discharge of any interference in the environment. The source is called the issuer. Each emission causes an immission."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Emmision"@en
+    
+    SubClassOf: 
+        QuantityValue
     
     
 Class: Energy
@@ -801,13 +794,13 @@ Class: EnergyCarrier
         <http://purl.obolibrary.org/obo/BFO_0000016>
     
     
-Class: EnergyCarrierQuantity
+Class: EnergyCarrierValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier quantity is a quantity about the amount of energy from a certain energy carrier."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier value is a QuantityValue about the amount of energy from a certain energy carrier."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: EnergyConsumption
@@ -816,34 +809,34 @@ Class: EnergyConsumption
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption quantity is a consumption quantity about energy."@en
     
     SubClassOf: 
-        ConsumptionQuantity
+        ConsumptionValue
     
     
-Class: EnergyFromAlternativeFuelsAndPropulsionInTraffic
+Class: EnergyFromAlternativeFuelsAndPropulsionInTrafficValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from alternative fuels and populsion in traffic quantity is a energy carrier quantity that describes the amount alternative energy carriers are used in the traffic sector."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from alternative fuels and populsion in traffic value is a energy carrier value that describes the amount alternative energy carriers are used in the traffic sector."@en
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        EnergyCarrierValue
     
     
-Class: EnergyFromBioFuelInTraffic
+Class: EnergyFromBioFuelInTrafficValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from bio fuel in traffic quantity is a energy carrier quantity that describes the amount of bio fuel as energy carrier in traffic."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from bio fuel in traffic value is a energy carrier value that describes the amount of bio fuel as energy carrier in traffic."@en
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        EnergyCarrierValue
     
     
-Class: EnergyFromElectricityInTraffic
+Class: EnergyFromElectricityInTrafficValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from electricity in traffic quantity is a energy carrier quantity that describes the amount of electricity used as energy carrier in traffic."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from electricity in traffic value is a energy carrier value that describes the amount of electricity used as energy carrier in traffic."@en
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        EnergyCarrierValue
     
     
 Class: EnergyGenerator
@@ -860,7 +853,7 @@ Class: EnergyGeneratorTechnology
     SubClassOf: 
         Technology,
         has_physical_input some (<http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrier),
-        has_physical_output some Power
+        has_physical_output some PowerValue
     
     
 Class: EnergyProduction
@@ -1034,7 +1027,7 @@ Class: GasTurbine
     
     SubClassOf: 
         Turbine,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only PortionOfNaturalGas
     
     
@@ -1110,7 +1103,7 @@ Class: GeothermalPowerplant
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
-Class: GlobalWarmingPotential
+Class: GlobalWarmingPotentialValue
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a measure of how much heat a greenhouse gas traps in the atmosphere up to a specific time horizon, relative to carbon dioxide. It compares the amount of heat trapped by a certain mass of the gas in question to the amount of heat trapped by a similar mass of carbon dioxide and is expressed as a factor of carbon dioxide (whose GWP is standardized to 1).
@@ -1119,7 +1112,7 @@ A GWP is calculated over a specific time horizon, commonly 20, 100, or 500 years
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Global_warming_potential&oldid=878160191"
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: Graph
@@ -1198,7 +1191,7 @@ Class: HeatConsumption
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat consumption quantity is a consumption quantity about heat."@en
     
     SubClassOf: 
-        ConsumptionQuantity
+        ConsumptionValue
     
     
 Class: HeatDemand
@@ -1312,7 +1305,7 @@ Class: HydrogenTurbine
     
     SubClassOf: 
         Turbine,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only Hydrogen
     
     
@@ -1332,85 +1325,85 @@ Class: IndustrialWasteFuel
         WasteFuel
     
     
-Class: InstalledHeatFromHeatPump
+Class: InstalledHeatFromHeatPumpValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from heat pump quantity is a installed power quantity restricted to heat pump power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from heat pump value is a installed power value restricted to heat pump power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledHeatFromSolar
+Class: InstalledHeatFromSolarValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from solar quantity is a installed power quantity restricted to solar heat power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from solar value is a installed power value restricted to solar heat power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromBiomass
+Class: InstalledPowerFromBiomassValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from biomass quantity is a installed power quantity restricted to biomass power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from biomass value is a installed power value restricted to biomass power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromCoalPowerPlants
+Class: InstalledPowerFromCoalPowerPlantsValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from coal power plants quantity is a installed power quantity restricted to coal power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from coal power plants value is a installed power value restricted to coal power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromGas
+Class: InstalledPowerFromGasValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from gas quantity is a installed power quantity restricted to gas power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from gas value is a installed power value restricted to gas power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromPhotovoltaics
+Class: InstalledPowerFromPhotovoltaicsValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from photovoltaics quantity is a installed power quantity restricted to photovoltaic power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from photovoltaics value is a installed power value restricted to photovoltaic power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromThermalPowerPlants
+Class: InstalledPowerFromThermalPowerPlantsValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from thermal power plants quantity is a installed power quantity restricted to thermal power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from thermal power plants value is a installed power value restricted to thermal power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerFromWind
+Class: InstalledPowerFromWindValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from wind quantity is a installed power quantity restricted to wind power plants."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from wind value is a installed power value restricted to wind power plants."@en
     
     SubClassOf: 
-        InstalledPowerQuantity
+        InstalledPowerValue
     
     
-Class: InstalledPowerQuantity
+Class: InstalledPowerValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power quantity is a quantity that describes the amount of power that some generators can generate."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power value is a QuantityValue that describes the amount of power that some generators can generate."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: InternalCombustion
@@ -1586,13 +1579,13 @@ Class: NetworkNode
         Node
     
     
-Class: NewPowerFromPhotovoltaics
+Class: NewPowerFromPhotovoltaicsValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A new power from photovoltaics quantity is a quantity that describes the amount of power from photovoltaic power plants that are going to be build in the future."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A new power from photovoltaics value is a QuantityValue that describes the amount of power from photovoltaic power plants that are going to be build in the future."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: Node
@@ -1748,7 +1741,7 @@ Class: PVPanel
     
     SubClassOf: 
         EnergyGeneratorTechnology,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only SolarPhotovoltaic
     
     
@@ -1762,13 +1755,13 @@ Class: ParticulateMatter
         AirPollutant
     
     
-Class: Percentage
+Class: PercentageValue
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A percentage is a ratio given as a fraction of 100."@en
     
     SubClassOf: 
-        Quantity
+        QuantityValue
     
     
 Class: Perfluorocarbon
@@ -2361,16 +2354,6 @@ Class: PortionOfWoodAndOther
         PortionOfSolidBiomass
     
     
-Class: Power
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the rate of doing work, the amount of energy transferred per unit time.
-Source: https://en.wikipedia.org/wiki/Power_(physics)"@en
-    
-    SubClassOf: 
-        Quantity
-    
-    
 Class: PowerGeneratingUnit
 
     SubClassOf: 
@@ -2394,6 +2377,16 @@ Class: PowerToGas
     
     SubClassOf: 
         EnergyStorage
+    
+    
+Class: PowerValue
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PowerValue is QuantityValue with a power unit as unit of measurement."@en
+    
+    SubClassOf: 
+        QuantityValue,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000113>
     
     
 Class: PumpedStorage
@@ -2427,14 +2420,14 @@ Class: PumpstoragePowerplantWithNaturalInflux
         ReservoirPowerplant
     
     
-Class: Quantity
+Class: QuantityValue
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Idea: A quantity is a property that is quantifiable by measurement."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an immaterial entity defined by a number together with a unit of measurement to quantify an entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Other Idea: A number together with a unit of measurement to quantify an entity."@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
+        <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
 Class: Rail
@@ -2622,7 +2615,7 @@ Class: SolarThermalCollector
     
     SubClassOf: 
         EnergyGenerator,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only SolarThermalHeat
     
     
@@ -2676,7 +2669,7 @@ Class: SteamTurbine
     
     SubClassOf: 
         Turbine,
-        has_physical_output some Power
+        has_physical_output some PowerValue
     
     
 Class: StorageHydropowerplant
@@ -2758,7 +2751,7 @@ Class: TidalStreamGenerator
     
     SubClassOf: 
         EnergyGenerator,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only TideWaveOcean
     
     
@@ -2907,7 +2900,7 @@ Class: WaterTurbine
     
     SubClassOf: 
         Turbine,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         has_physical_input only HydroEnergy
     
     
@@ -2988,7 +2981,7 @@ Wind turbines are manufactured in a wide range of vertical and horizontal axis. 
     
     SubClassOf: 
         Turbine,
-        has_physical_output some Power,
+        has_physical_output some PowerValue,
         uses some WindEnergy,
         has_physical_input only WindEnergy
     


### PR DESCRIPTION
closes #205.

Initially I just wanted to add the class QuantityValue as written in #205.
Def: 	A quantity value is an immaterial entity defined by a number together with a unit of measurement to quantify an entity.

While implementing  the problem came up what to do with the subclasses of the already implemented Quantity class. We decided in the issue to just have units and QuantityValues and in my opinion they fit better with QuantityValue so I made them subclasses of QuantityValue and gave them the suffix -Value (which meant I had to change the definitions a bit too).

I also changed Power to PowerValue which has part some power unit to better visualise the relationship, def: "A PowerValue is QuantityValue with a power unit as unit of measurement."

This means that this pull request got bigger than planned so review and discussion are not just about if the changes fit to the issue but if they make sense.