### PR TITLE
restructure Generator and ArtificialObject classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Here is a template for new release sections
 - unify -Energy and -Power classes (#225)
 - ModelElement and subbclasses
 - update issue templates 'workflow checklist' (#258)
-- Generator (#179)
+- Generator (#273)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Here is a template for new release sections
 - unify -Energy and -Power classes (#225)
 - ModelElement and subbclasses
 - update issue templates 'workflow checklist' (#258)
+- Generator (#179)
 
 
 ### Removed

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -8,7 +8,9 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/v0.0.1/oeo/" uri="oeo.omn"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl" uri="http://purl.obolibrary.org/obo/bfo.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1580113798864" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1580113798864" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1583401917017" name="http://open-energy-ontology.org/ontology/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1583401917017" name="http://open-energy-ontology.org/ontology/imports/iao-module.owl" uri="imports/iao-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1583401917017" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1583401917017" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2376,7 +2376,7 @@ It consists of hydrocarbons of various molecular weights and other organic compo
 Class: OilPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilePowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilPowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         FossilPowerplant,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -263,12 +263,18 @@ ObjectProperty: uses
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel as fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BioGasPowerUnit is a BiofuelPowerUnit using biogas as fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
     
@@ -281,6 +287,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerUnit is a BiofuelPowerUnit using biomass as fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
     
@@ -296,6 +305,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a FossilPowerUnit using Coal as Fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
@@ -353,6 +365,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerUnit is a PowerGeneratingUnit using FossilCombustionFuel as Fuel."
+    
     SubClassOf: 
         PowerGeneratingUnit
     
@@ -368,18 +383,27 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a FossilPowerUnit using gas as Fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerUnit is a RegenerativePowerUnit using geothermal heat."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HardCoalPowerUnit is a CoalPowerUnit using HardCoal as Fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
     
@@ -387,6 +411,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydroPowerUnit is a PowerGeneratingUnit using hydrogen as fuel.",
         rdfs:comment "will be discussed later"
     
     SubClassOf: 
@@ -395,12 +420,18 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydrogenPowerUnit is a PowerGeneratingUnit using hydrogen as fuel."
+    
     SubClassOf: 
         PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A LignitePowerUnit is a CoalPowerUnit using Lignite as Fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
     
@@ -416,12 +447,18 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel as fuel."
+    
     SubClassOf: 
         PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
@@ -460,6 +497,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerUnit is a PowerGeneratingUnit using regenerative fuels as fuel."
+    
     SubClassOf: 
         PowerGeneratingUnit
     
@@ -476,18 +516,27 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarr
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a RegenerativePowerUnit using solar power."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerUnit is a SolarPowerUnit using solar thermal energy."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerUnit is a BiomassPowerUnit using solid biomass as fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
     
@@ -509,6 +558,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a FossilPowerUnit using waste as fuel."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
@@ -1794,8 +1846,8 @@ Class: PFC
 Class: PVPanel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "hotovoltaic solar panels absorb sunlight as a source of energy to generate electricity. A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=906976047"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVPanel (photovoltaic panel) is a SolarPowerUnit absorbing sunlight as a source of energy to generate electricity."@en,
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1508,10 +1508,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
          and (<http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition)
     
     SubClassOf: 
-        PortionOfMatter,
-        uses some 
-            (Fuel
-             and (has_state_of_matter value gaseous))
+        PortionOfMatter
     
     
 Class: Fusion
@@ -1588,7 +1585,8 @@ Class: Generator
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>,
+        has_physical_output some ElectricalEnergy
     
     DisjointWith: 
         Line
@@ -1763,7 +1761,8 @@ Class: Heater
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>,
+        has_physical_output some Heat
     
     
 Class: HeatingOil

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2330,7 +2330,7 @@ Class: OceanPowerplant
 Class: OffShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind electricity generator is a WindFarm that is build off shore above or in the ocean."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a WindFarm that is build in a body of water, usually the ocean."@en
     
     SubClassOf: 
         WindFarm
@@ -2374,7 +2374,7 @@ Class: OilPowerplant
 Class: OnShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind electricity generator is a WindFarm that is build on land."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a WindFarm that is build on land."@en
     
     SubClassOf: 
         WindFarm
@@ -2631,7 +2631,7 @@ Class: Retail
 Class: RooftopPhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic electricity powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en
     
     SubClassOf: 
         PhotovoltaicPowerplant

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -267,6 +267,17 @@ ObjectProperty: uses
         is_used_by
     
     
+Class: <http://openenergy-platform.org/ontology/FuelRole>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
 
     Annotations: 
@@ -301,16 +312,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
-
-Class: <http://openenergy-platform.org/ontology/FuelRole>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CarbonDioxide>
@@ -322,7 +323,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/CarbonDioxide>
     SubClassOf: 
         PortionOfMatter,
         <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition
-
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
@@ -361,17 +361,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenera
         Generator
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformer is an artificial object that transforms or changes a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "rename later to EnergyConvertingDevice"
-    
-    SubClassOf: 
-        ArtificialObject
-
 Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
 
     Annotations: 
@@ -384,6 +373,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
         <http://purl.obolibrary.org/obo/BFO_0000034>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformer is an artificial object that transforms or changes a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:comment "rename later to EnergyConvertingDevice"
+    
+    SubClassOf: 
+        ArtificialObject
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FluorinatedGreenhouseGas>
 
     Annotations: 
@@ -394,7 +395,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FluorinatedGreenhou
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
-
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
@@ -462,6 +462,21 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GreenhouseGas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+    
+    EquivalentTo: 
+        PortionOfMatter
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition)
+    
+    SubClassOf: 
+        PortionOfMatter
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
 
     Annotations: 
@@ -497,49 +512,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
-    
-
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
-
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GreenhouseGas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
-    
-    EquivalentTo: 
-        PortionOfMatter
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition)
-    
-    SubClassOf: 
-        PortionOfMatter
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a Generator that converts light into electrical energy."
-    
-    SubClassOf: 
-        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Methane>
@@ -586,6 +558,33 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrie
         EnergyCarrierDisposition
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel as fuel."
+    
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a Generator that converts light into electrical energy."
+    
+    SubClassOf: 
+        Generator
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 
     Annotations: 
@@ -605,8 +604,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUn
     SubClassOf: 
         PowerGeneratingUnit
     
-
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
+
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A RenewableFuel is a portion of matter that has a renewable origin and an energy carrier disposition that is used as a fuel."
     
@@ -616,39 +616,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SulphurHexafluoride>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/ThermalEnergyStorage>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ThermalEnergyStorage is an EnergyStorage that stores thermal energy for later use."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal."
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>,
-        has_normal_state_of_matter value solid,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
@@ -687,12 +654,37 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerpl
         BiomassPowerplant
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SulphurHexafluoride>
+
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteRole is a role of an object aggregate that has been discarded after primary use."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        PortionOfMatter,
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/ThermalEnergyStorage>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A ThermalEnergyStorage is an EnergyStorage that stores thermal energy for later use."
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal."
+    
+    SubClassOf: 
+        PortionOfMatter,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>,
+        has_normal_state_of_matter value solid,
+        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
@@ -702,6 +694,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteRole is a role of an object aggregate that has been discarded after primary use."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
@@ -918,7 +919,7 @@ Class: BatteryStorage
     DisjointWith: 
         MethanationGasStorage
     
-      
+    
 Class: Biodiesel
 
     Annotations: 
@@ -932,7 +933,7 @@ Class: Biodiesel
         has_normal_state_of_matter value liquid,
         has_origin value biogenic
     
-
+    
 Class: Biofuel
 
     Annotations: 
@@ -951,6 +952,16 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
         has_origin value biogenic,
         has_origin value renewable
     
+    
+Class: BiofuelPowerplant
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a RegenerativePowerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
+    
+    SubClassOf: 
+        RegenerativePowerplant
+    
+    
 Class: Biogas
 
     Annotations: 
@@ -963,14 +974,7 @@ Class: Biogas
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
         has_origin value biogenic
     
-Class: BiofuelPowerplant
     
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a RegenerativePowerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
-    
-    SubClassOf: 
-        RegenerativePowerplant
-     
 Class: Biogasoline
 
     Annotations: 
@@ -985,7 +989,6 @@ Class: Biogasoline
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
         has_normal_state_of_matter value liquid,
         has_origin value biogenic
-    
     
     
 Class: BiomassPowerplant
@@ -1050,7 +1053,7 @@ Class: City
     SubClassOf: 
         Land
     
-
+    
 Class: Coal
 
     Annotations: 
@@ -1063,6 +1066,7 @@ Class: Coal
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
         has_normal_state_of_matter value solid,
         has_origin value fossil
+    
     
 Class: CoalPowerplant
 
@@ -1474,19 +1478,6 @@ Class: FlowBattery
         Battery
     
     
-Class: FluorinatedGreenhouseGas
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fluorinated greenhouse gases (F-gases) are man-made gases that can stay in the atmosphere for centuries. As they contribute to a global greenhouse effect they are greenhouse gases.
-
-There are four types: hydrofluorocarbons (HFCs), perfluorocarbons (PFCs), sulfur hexafluoride (SF6) and nitrogen trifluoride (NF3)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Adapted from https://en.wikipedia.org/w/index.php?title=Fluorinated_gases&oldid=902170998"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
-    
-    
 Class: FossilPowerplant
 
     Annotations: 
@@ -1587,6 +1578,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+    
+    DisjointWith: 
+        Line
     
     
 Class: GeographicCoordinate
@@ -2205,7 +2199,8 @@ It does not include gases created by anaerobic digestion of biomass (e.g. munici
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
         has_normal_state_of_matter value gaseous,
         has_origin value fossil
-        
+    
+    
 Class: NegativeEmission
 
     Annotations: 
@@ -2307,7 +2302,7 @@ Class: NuclearFuel
     SubClassOf: 
         Fuel
     
- 
+    
 Class: NuclearPowerplant
 
     Annotations: 
@@ -2352,6 +2347,21 @@ Class: Office
         CommericalDemand
     
     
+Class: OilAndPetroleumProducts
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
+
+It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en
+    
+    SubClassOf: 
+        PortionOfMatter,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
+        has_origin value fossil
+    
+    
 Class: OilPowerplant
 
     Annotations: 
@@ -2375,21 +2385,6 @@ Class: OnShoreWindFarm
         OffShoreWindFarm
     
     
-Class: OilAndPetroleumProducts
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
-
-It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_origin value fossil
-    
-    
 Class: PVPanel
 
     Annotations: 
@@ -2401,18 +2396,6 @@ Class: PVPanel
         has_physical_output some Power,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/PVCell>,
         has_physical_input only SolarPhotovoltaic
-    
-    
-    
-Class: PhotovoltaicPowerplant
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
-    
-    SubClassOf: 
-        SolarPowerPlant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
-        
     
     
 Class: ParticulateMatter
@@ -2461,7 +2444,7 @@ Class: Perfluorocarbon
         PortionOfMatter,
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
     
-      
+    
 Class: PhotovoltaicGenerator
 
     SubClassOf: 
@@ -2472,6 +2455,7 @@ Class: PhotovoltaicGenerator
 Class: PhotovoltaicPowerplant
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic generator uses PVPanels and solar energy to generate electricity."@en
     
     SubClassOf: 
@@ -3028,7 +3012,7 @@ Class: Water
     SubClassOf: 
         PortionOfMatter,
         <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition
-
+    
     
 Class: WaterTurbine
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -281,7 +281,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel as fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
@@ -423,7 +423,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerUnit is a PowerGeneratingUnit using FossilCombustionFuel as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerUnit is a PowerGeneratingUnit using FossilCombustionFuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -561,7 +561,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrie
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel as fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -601,7 +601,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerUnit is a PowerGeneratingUnit using regenerative fuels as fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerUnit is a PowerGeneratingUnit using regenerative fuels."
     
     SubClassOf: 
         PowerGeneratingUnit,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2445,13 +2445,6 @@ Class: Perfluorocarbon
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
     
     
-Class: PhotovoltaicGenerator
-
-    SubClassOf: 
-        Generator,
-        uses some SolarEnergy
-    
-    
 Class: PhotovoltaicPowerplant
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2732,7 +2732,7 @@ Class: SolarEnergy
 Class: SolarPark
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar park (also: solar farm, field photovoltaic electricity powerplant)  is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar park (also: solar farm, field photovoltaic electricity powerplant) is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
     
     SubClassOf: 
         PhotovoltaicPowerplant

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -642,10 +642,11 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerUnit is a SolarPowerUnit using solar thermal energy."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerUnit is a SolarPowerUnit that has SolarThermalCollectors as parts."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some SolarThermalCollector
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -494,7 +494,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydroPowerUnit is a PowerGeneratingUnit using hydrogen as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydroPowerUnit is a PowerGeneratingUnit using the potential and/or kinetic energy of water.",
         rdfs:comment "will be discussed later"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -312,6 +312,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
         <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectricHeatPump>
+
+    Annotations: 
+        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy."
+    
+    SubClassOf: 
+        HeatPump
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
 
     Annotations: 
@@ -1349,7 +1358,7 @@ Class: HeatDemand
 Class: HeatPump
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HeatPump is a heater that transforms energy from air, ground or water into useful heat."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using a drive energy."@en
     
     SubClassOf: 
         Heater
@@ -2872,7 +2881,7 @@ Class: TransportDemand
 Class: Turbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "a turbine is a energy transformer that converts energy from a moving fluid flow into useful work."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy transformer that converts energy from a moving fluid flow into rotational energy."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -261,7 +261,8 @@ ObjectProperty: uses
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some BiomassElectricityGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
@@ -276,7 +277,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some CoalElectricityGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
@@ -330,7 +332,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some FossileGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
@@ -342,7 +345,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some GeothermalGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
@@ -351,16 +355,35 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroGenerator>
+
+    Annotations: 
+        rdfs:comment "will be discussed later"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
 
+    Annotations: 
+        rdfs:comment "will be discussed later"
+    
     SubClassOf: 
         PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenGenerator>
+
+    SubClassOf: 
+        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydrogenGenerator>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
@@ -381,13 +404,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some NuclearPowerGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OilElectricityGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
@@ -396,7 +421,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a RenewableGenerator that converts light into electrical energy."
     
     SubClassOf: 
-        RegenerativeGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
@@ -423,7 +448,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some RegenerativeGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
@@ -436,16 +462,24 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarr
         EnergyCarrier
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
+
+    SubClassOf: 
+        RegenerativeGenerator
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some SolarThermalHeatGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
@@ -457,10 +491,17 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteElectricityGenerator>
+
+    SubClassOf: 
+        FossileGenerator
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WasteElectricityGenerator>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
@@ -479,8 +520,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
+        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some WindElectricityGenerator
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -1133,15 +1174,6 @@ Class: GasTurbine
         Turbine,
         has_physical_output some Power,
         has_physical_input only PortionOfNaturalGas
-    
-    
-Class: GasTurbineGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine generator is a electricity generator that uses hot or high pressure gas to produce electricity."@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     
 Class: Generator
@@ -2698,7 +2730,7 @@ Class: SolarThermalCollector
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en
     
     SubClassOf: 
-        Generator,
+        ArtificialObject,
         has_physical_output some Power,
         has_physical_input only SolarThermalHeat
     
@@ -2721,7 +2753,7 @@ Class: SolarThermalHeatGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal heat generator is a heat generator that uses solar power to produce heat."@en
     
     SubClassOf: 
-        HeatGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
     
     
 Class: SolarThermalPowerplant
@@ -2973,7 +3005,7 @@ Class: WaterElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electricity generator is a renewable energy generator that uses power from water to generate electricity."@en
     
     SubClassOf: 
-        RegenerativeGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/HydroGenerator>
     
     
 Class: WaterTurbine

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2986,7 +2986,7 @@ Class: WasteFuel
 Class: WastePowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilePowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilPowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         FossilPowerplant,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1752,7 +1752,7 @@ Class: HeatDemand
 Class: HeatPump
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using a drive energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en
     
     SubClassOf: 
         Heater

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -307,15 +307,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
         BiofuelPowerplant
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerUnit is a BiofuelPowerUnit using biomass as fuel."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CarbonDioxide>
 
     Annotations: 
@@ -655,7 +646,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUn
         <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerUnit is a BiomassPowerUnit using solid biomass as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>,
+        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>,
         uses some PortionOfSolidBiomass
     
     
@@ -665,7 +656,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerpl
         <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerplant is a BiomassPowerplant having an aggregate of SolidBiomassPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
-        BiomassPowerplant
+        BiofuelPowerplant
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SulphurHexafluoride>
@@ -1004,17 +995,6 @@ Class: Biogasoline
         <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
         has_normal_state_of_matter value liquid,
         has_origin value biogenic
-    
-    
-Class: BiomassPowerplant
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerplant is a BiofuelPowerplant having an aggregate of BiomassPowerUnits as its PowerGeneratingUnits."@en
-    
-    SubClassOf: 
-        BiofuelPowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
 Class: BlastFurnaceGas
@@ -1515,7 +1495,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
          and (<http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition)
     
     SubClassOf: 
-        PortionOfMatter
+        PortionOfMatter,
+        uses some 
+            (Fuel
+             and (has_state_of_matter value gaseous))
     
     
 Class: Fusion

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -312,6 +312,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenera
 Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformer is an artificial object that transforms or changes a certain type of energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
         rdfs:comment "rename later to EnergyConverter"
@@ -521,7 +522,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
 
     Annotations: 
-        rdfs:comment "A WindEnergyConverter is the PowerGeneratingUnit that uses wind energy."
+        rdfs:comment "A WindEnergyConverter is a RegenerativePowerUnit that uses wind energy."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
@@ -1138,8 +1139,7 @@ Class: GasTurbine
 Class: Generator
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is a grid component that converts motive power (mechanical energy) into electrical power for use in an external circuit.
-Source: https://en.wikipedia.org/wiki/Electric_generator"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy transformer that converts other forms of energy into electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
@@ -1291,19 +1291,22 @@ Class: HeatDemand
         Demand
     
     
-Class: HeatGenerator
-
-    SubClassOf: 
-        Generator
-    
-    
-Class: HeatPumpHeatGenerator
+Class: HeatPump
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump heat generator is a heat generator that uses a heat pump to generate heat."@en
     
     SubClassOf: 
-        HeatGenerator
+        Heater
+    
+    
+Class: Heater
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy transformer that converts other forms of energy into useful heat."
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
     
     
 Class: HydroEnergy
@@ -2414,6 +2417,7 @@ Source: https://en.wikipedia.org/wiki/Power_(physics)"@en
 Class: PowerGeneratingUnit
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
@@ -2640,7 +2644,7 @@ Class: SolarThermalCollector
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en
     
     SubClassOf: 
-        ArtificialObject,
+        Heater,
         has_physical_output some Power,
         has_physical_input only SolarThermalHeat
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -361,7 +361,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroGenerator>
         rdfs:comment "will be discussed later"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
+        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -814,12 +814,6 @@ Class: ElectricityExport
         Quantity
     
     
-Class: ElectricityGenerator
-
-    SubClassOf: 
-        Generator
-    
-    
 Class: ElectricityGrid
 
     Annotations: 
@@ -1023,7 +1017,7 @@ There are four types: hydrofluorocarbons (HFCs), perfluorocarbons (PFCs), sulfur
 Class: FossilGenerator
 
     SubClassOf: 
-        ElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     DisjointWith: 
         RenewableGenerator
@@ -1074,7 +1068,7 @@ Class: GasTurbineGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine generator is a electricity generator that uses hot or high pressure gas to produce electricity."@en
     
     SubClassOf: 
-        ElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     
 Class: Generator
@@ -2463,7 +2457,7 @@ Class: RegenerativePowerplant
 Class: RenewableGenerator
 
     SubClassOf: 
-        ElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     DisjointWith: 
         FossilGenerator
@@ -2747,7 +2741,7 @@ Class: TidalStreamGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tidal stream generator uses tidal movement, wave motion or water current for electricity generation."@en
     
     SubClassOf: 
-        Generator,
+        WaterElectricityGenerator,
         has_physical_output some Power,
         has_physical_input only TideWaveOcean
     
@@ -2948,13 +2942,6 @@ Class: WindFarm
     SubClassOf: 
         RegenerativePowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
-    
-    
-Class: WindOffshore
-
-    SubClassOf: 
-        WindTurbine,
-        <http://purl.obolibrary.org/obo/RO_0002233> some Sea
     
     
 Class: WindTurbine

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -498,8 +498,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
     
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
 
@@ -1485,8 +1483,8 @@ There are four types: hydrofluorocarbons (HFCs), perfluorocarbons (PFCs), sulfur
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adapted from https://en.wikipedia.org/w/index.php?title=Fluorinated_gases&oldid=902170998"@en
     
     SubClassOf: 
-        GreenhouseGas,
-        <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseGas
+        <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
     
     
 Class: FossilPowerplant
@@ -1588,11 +1586,7 @@ Class: Generator
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>,
-        uses some EnergyCarrier
-    
-    DisjointWith: 
-        Line
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
     
     
 Class: GeographicCoordinate
@@ -1863,7 +1857,7 @@ Class: HydrogenTurbine
     SubClassOf: 
         GasTurbine,
         has_physical_output some Power,
-        has_physical_input only PortionOfHydrogen
+        has_physical_input only Hydrogen
     
     
 Class: HydrogenVehicle
@@ -2418,34 +2412,7 @@ Class: PhotovoltaicPowerplant
     SubClassOf: 
         SolarPowerPlant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
-    
         
-Class: OilElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil electricity generator technology uses oil to generate electricity."@en
-    
-    SubClassOf: 
-        FossilGenerator
-    
-    
-Class: OilPowerplant
-
-    SubClassOf: 
-        FossilePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
-    
-    
-Class: OnShoreWindElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An on shore wind electricity generator is a wind electricity generator that is build on land."@en
-    
-    SubClassOf: 
-        WindElectricityGenerator
-    
-    DisjointWith: 
-        OffShoreWindElectricityGenerator
     
     
 Class: ParticulateMatter
@@ -3286,21 +3253,3 @@ Individual: synthetic
         has_origin some origin
     
     
-DisjointClasses: 
-    BioElectricityGenerator,PhotovoltaicElectricityGenerator,WaterElectricityGenerator,WindElectricityGenerator
-
-DisjointClasses: 
-    BiomassPowerplant,CoalPowerplant,GasPowerplant,GeothermalGenerator,HydroPowerplant,NuclearPowerplant,OceanPowerplant,OilPowerplant,PhotovoltaicGenerator,WastePowerplant,WindTurbine
-
-DisjointClasses: 
-    CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator
-
-DisjointClasses: 
-    ElectricityGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology
-
-DisjointClasses: 
-    ElectricityGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology,HeatGeneratorTechnology
-
-DisjointClasses: 
-    EnergyGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -281,6 +281,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiogasPowerplant is a BiofuelPowerplant having an aggregate of BiogasPowerUnits as its PowerGeneratingUnits."
+    
     SubClassOf: 
         BiofuelPowerplant
     
@@ -475,7 +478,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a RenewableGenerator that converts light into electrical energy."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a Generator that converts light into electrical energy."
     
     SubClassOf: 
         Generator
@@ -552,6 +555,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUn
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerplant>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerplant is a BiomassPowerplant having an aggregate of SolidBiomassPowerUnits as its PowerGeneratingUnits."
+    
     SubClassOf: 
         BiomassPowerplant
     
@@ -759,6 +765,9 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
     
 Class: BiofuelPowerplant
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a RegenerativePowerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
+    
     SubClassOf: 
         RegenerativePowerplant
     
@@ -766,7 +775,7 @@ Class: BiofuelPowerplant
 Class: BiomassPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerplant is a RegenerativePowerplant having an aggregate of BiomassPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerplant is a BiofuelPowerplant having an aggregate of BiomassPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         BiofuelPowerplant,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1476,7 +1476,7 @@ Class: FlowBattery
 Class: FossilPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilePowerplant is a Powerplant having an aggregate of one kind of  FossilePowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilePowerplant is a Powerplant having an aggregate of FossilePowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -2446,8 +2446,7 @@ Class: Perfluorocarbon
 Class: PhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic generator uses PVPanels and solar energy to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         SolarPowerPlant,
@@ -2589,7 +2588,7 @@ Class: Rail
 Class: RegenerativePowerplant
 
     Annotations: 
-        rdfs:comment "A RegenerativePowerplant is a Powerplant having an aggregate of one kind of RegenerativePowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerplant is a Powerplant having an aggregate of RegenerativePowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -336,10 +336,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a generator that converts light into electrical energy."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a RenewableGenerator that converts light into electrical energy."
     
     SubClassOf: 
-        Generator
+        RenewableGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
@@ -948,12 +948,6 @@ Class: EnergyFromElectricityInTraffic
         EnergyCarrierQuantity
     
     
-Class: EnergyGenerator
-
-    SubClassOf: 
-        Generator
-    
-    
 Class: EnergyGeneratorTechnology
 
     Annotations: 
@@ -1015,13 +1009,13 @@ Class: FederalState
 Class: FieldPhotovoltaicGenerator
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic electricity generator is a photovoltaic electricity generator that is installed out in the open on the ground."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic electricity powerplant is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
     
     SubClassOf: 
-        PhotovoltaicElectricityGenerator
+        PhotovoltaicPowerplant
     
     DisjointWith: 
-        RooftopPhotovoltaicGenerator
+        RooftopPhotovoltaicPowerplant
     
     
 Class: Fission
@@ -1760,16 +1754,16 @@ Class: OceanPowerplant
         HydroPowerplant
     
     
-Class: OffShoreWindElectricityGenerator
+Class: OffShoreWindFarm
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An off shore wind electricity generator is a wind electricity generator that is build off shore above or in the ocean."@en
     
     SubClassOf: 
-        WindElectricityGenerator
+        WindFarm
     
     DisjointWith: 
-        OnShoreWindElectricityGenerator
+        OnShoreWindFarm
     
     
 Class: Office
@@ -1794,16 +1788,16 @@ Class: OilPowerplant
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
-Class: OnShoreWindElectricityGenerator
+Class: OnShoreWindFarm
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An on shore wind electricity generator is a wind electricity generator that is build on land."@en
     
     SubClassOf: 
-        WindElectricityGenerator
+        WindFarm
     
     DisjointWith: 
-        OffShoreWindElectricityGenerator
+        OffShoreWindFarm
     
     
 Class: PFC
@@ -1865,19 +1859,10 @@ Class: Perfluorocarbon
         FluorinatedGreenhouseGas
     
     
-Class: PhotovoltaicElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic electricity generator is a renewable energy generator that uses power from the sun to generate electricity."@en
-    
-    SubClassOf: 
-        Generator
-    
-    
 Class: PhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic generator uses PVPanels and solar energy to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a Powerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         SolarPowerPlant,
@@ -2595,13 +2580,13 @@ Class: Retail
         CommericalDemand
     
     
-Class: RooftopPhotovoltaicGenerator
+Class: RooftopPhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic electricity generator is a photovoltaic electricity generator that is installed on top of the roof of a building."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic electricity powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en
     
     SubClassOf: 
-        PhotovoltaicElectricityGenerator
+        PhotovoltaicPowerplant
     
     DisjointWith: 
         FieldPhotovoltaicGenerator
@@ -2694,7 +2679,7 @@ Class: SolarPowerPlant
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_power&oldid=904827092"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        RegenerativePowerplant,
         Turbine or (<http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel)
     
     
@@ -2705,7 +2690,7 @@ Class: SolarThermalCollector
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en
     
     SubClassOf: 
-        EnergyGenerator,
+        Generator,
         has_physical_output some Power,
         has_physical_input only SolarThermalHeat
     
@@ -2841,7 +2826,7 @@ Class: TidalStreamGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tidal stream generator uses tidal movement, wave motion or water current for electricity generation."@en
     
     SubClassOf: 
-        EnergyGenerator,
+        Generator,
         has_physical_output some Power,
         has_physical_input only TideWaveOcean
     
@@ -3049,16 +3034,6 @@ Class: WindOffshore
     SubClassOf: 
         WindTurbine,
         <http://purl.obolibrary.org/obo/RO_0002233> some Sea
-    
-    
-Class: WindOnshore
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Onshore wind power is the complement to Offshore wind power. It is harvested on land."@en
-    
-    SubClassOf: 
-        ArtificialObject,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some WindTurbine
     
     
 Class: WindTurbine
@@ -3356,13 +3331,7 @@ Individual: synthetic
     
     
 DisjointClasses: 
-    BioElectricityGenerator,PhotovoltaicElectricityGenerator,WaterElectricityGenerator,WindElectricityGenerator
-
-DisjointClasses: 
     CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator
-
-DisjointClasses: 
-    ElectricityGenerator,EnergyGenerator,EnergyStorage,EnergyTransfer,HeatGenerator
 
 DisjointClasses: 
     ElectricityGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1538,7 +1538,7 @@ Class: GasDieselOil
 Class: GasPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilePowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilPowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         FossilPowerplant,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1588,9 +1588,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>,
         has_physical_output some ElectricalEnergy
     
-    DisjointWith: 
-        Line
-    
     
 Class: GeographicCoordinate
 
@@ -2049,9 +2046,6 @@ Class: Line
     
     SubClassOf: 
         Link
-    
-    DisjointWith: 
-        Generator
     
     
 Class: Link
@@ -3226,3 +3220,6 @@ Individual: synthetic
         has_origin some origin
     
     
+DisjointClasses: 
+    Generator,Heater,Turbine
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2390,7 +2390,7 @@ Class: OilPowerplant
 Class: OnShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An on shore wind electricity generator is a WindFarm that is build on land."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind electricity generator is a WindFarm that is build on land."@en
     
     SubClassOf: 
         WindFarm

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -152,9 +152,6 @@ ObjectProperty: has_physical_input
         Irreflexive,
         Asymmetric
     
-    Domain: 
-        EnergyGeneratorTechnology
-    
     Range: 
         <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrier
     
@@ -820,17 +817,7 @@ Class: ElectricityExport
 Class: ElectricityGenerator
 
     SubClassOf: 
-        Generator,
-        applies_technology some ElectricityGeneratorTechnology
-    
-    
-Class: ElectricityGeneratorTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generator technology is an technology used to transform energy from some source into electricity."@en
-    
-    SubClassOf: 
-        EnergyGeneratorTechnology
+        Generator
     
     
 Class: ElectricityGrid
@@ -948,17 +935,6 @@ Class: EnergyFromElectricityInTraffic
         EnergyCarrierQuantity
     
     
-Class: EnergyGeneratorTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy generator technology is an technology used to transform energy into a form such that it is useable."@en
-    
-    SubClassOf: 
-        Technology,
-        has_physical_input some (<http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrier),
-        has_physical_output some Power
-    
-    
 Class: EnergyProduction
 
     SubClassOf: 
@@ -968,33 +944,13 @@ Class: EnergyProduction
 Class: EnergyStorage
 
     SubClassOf: 
-        ArtificialObject,
-        applies_technology some EnergyStorageTechnology
-    
-    
-Class: EnergyStorageTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage technology is a technology used for storing energy."@en
-    
-    SubClassOf: 
-        Technology
+        ArtificialObject
     
     
 Class: EnergyTransfer
 
     SubClassOf: 
-        ArtificialObject,
-        applies_technology some EnergyTransferTechnology
-    
-    
-Class: EnergyTransferTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer technology is a technology used to transport energy or a carrier of energy."@en
-    
-    SubClassOf: 
-        Technology
+        ArtificialObject
     
     
 Class: FederalState
@@ -1073,18 +1029,6 @@ Class: FossilGenerator
         RenewableGenerator
     
     
-Class: FossilGeneratorTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil electricity generator technology is an electricity generator techonolgy that uses fossil fuels such as oil, coal and natural gas to generate electricity."@en
-    
-    SubClassOf: 
-        ElectricityGeneratorTechnology
-    
-    DisjointWith: 
-        RenewableGeneratorTechnology
-    
-    
 Class: FossilePowerplant
 
     SubClassOf: 
@@ -1141,8 +1085,7 @@ Source: https://en.wikipedia.org/wiki/Electric_generator"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>,
-        uses some EnergyCarrier,
-        uses some EnergyGeneratorTechnology
+        uses some EnergyCarrier
     
     DisjointWith: 
         Line
@@ -1300,15 +1243,6 @@ Class: HeatGenerator
 
     SubClassOf: 
         Generator
-    
-    
-Class: HeatGeneratorTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generator technology is an technology used to transform energy from some source into heat."@en
-    
-    SubClassOf: 
-        EnergyGeneratorTechnology
     
     
 Class: HeatPumpHeatGenerator
@@ -2535,18 +2469,6 @@ Class: RenewableGenerator
         FossilGenerator
     
     
-Class: RenewableGeneratorTechnology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable electricity generator technology is an electricity generator techonolgy that uses resources that are practically unlimited or regenerate quickly to generate electricity."@en
-    
-    SubClassOf: 
-        ElectricityGeneratorTechnology
-    
-    DisjointWith: 
-        FossilGeneratorTechnology
-    
-    
 Class: RenewableMunicipalWasteFuel
 
     Annotations: 
@@ -2761,7 +2683,6 @@ Class: StorageUnit
     
     SubClassOf: 
         ElectricityGridComponent,
-        uses some EnergyStorageTechnology,
         <http://purl.obolibrary.org/obo/BFO_0000050> some ElectricityGrid
     
     
@@ -3332,15 +3253,6 @@ Individual: synthetic
     
 DisjointClasses: 
     CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator
-
-DisjointClasses: 
-    ElectricityGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology
-
-DisjointClasses: 
-    ElectricityGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology,HeatGeneratorTechnology
-
-DisjointClasses: 
-    EnergyGeneratorTechnology,EnergyStorageTechnology,EnergyTransferTechnology
 
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2752,7 +2752,6 @@ Class: SolarThermalCollector
     
     SubClassOf: 
         Heater,
-        has_physical_output some Power,
         has_physical_input only SolarThermalHeat
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -284,7 +284,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        uses some Biofuel
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
@@ -293,7 +294,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A BioGasPowerUnit is a BiofuelPowerUnit using biogas as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>,
+        uses some Biogas
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
@@ -340,7 +342,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a FossilPowerUnit using Coal as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        uses some Coal
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectricHeatPump>
@@ -432,7 +435,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerUnit is a PowerGeneratingUnit using FossilCombustionFuel as Fuel."
     
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        uses some <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
@@ -483,7 +487,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A HardCoalPowerUnit is a CoalPowerUnit using HardCoal as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
+        uses some HardCoal
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
@@ -502,13 +507,17 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A HydrogenPowerUnit is a PowerGeneratingUnit using hydrogen as fuel."
     
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        uses some Hydrogen
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A LignitePowerUnit is a CoalPowerUnit using Lignite as Fuel."
+    
+    EquivalentTo: 
+        uses some Lignite
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
@@ -564,7 +573,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel as fuel."
     
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        uses some NuclearFuel
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
@@ -573,7 +583,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        uses some OilAndPetroleumProducts
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
@@ -602,7 +613,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUn
         <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerUnit is a PowerGeneratingUnit using regenerative fuels as fuel."
     
     SubClassOf: 
-        PowerGeneratingUnit
+        PowerGeneratingUnit,
+        uses some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
@@ -642,7 +654,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUn
         <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerUnit is a BiomassPowerUnit using solid biomass as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>,
+        uses some PortionOfSolidBiomass
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerplant>
@@ -693,7 +706,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a FossilPowerUnit using waste as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        uses some WasteFuel
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13,8 +13,8 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo-physical/>
 <http://openenergy-platform.org/ontology/v0.0.1/oeo-physical/>
-Import: <http://open-energy-ontology.org/ontology/imports/ro-module.owl>
 Import: <http://open-energy-ontology.org/ontology/imports/iao-annotation-module.owl>
+Import: <http://open-energy-ontology.org/ontology/imports/ro-module.owl>
 Import: <http://purl.obolibrary.org/obo/uo/releases/2019-04-01/uo.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
@@ -270,6 +270,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+
+    Annotations: 
+        rdfs:comment "rename later to EnergyConverter"
+    
+    SubClassOf: 
+        ArtificialObject
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
 
     Annotations: 
@@ -319,6 +328,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
         <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>,
         has_normal_state_of_matter value solid,
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
+
+    SubClassOf: 
+        ArtificialObject
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
@@ -1044,7 +1059,7 @@ Class: FossilGeneratorTechnology
 Class: FossilePowerplant
 
     SubClassOf: 
-        PowerGeneratingUnit
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
     
     
 Class: Fusion
@@ -1096,7 +1111,7 @@ Class: Generator
 Source: https://en.wikipedia.org/wiki/Electric_generator"@en
     
     SubClassOf: 
-        ArtificialObject,
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>,
         uses some EnergyCarrier,
         uses some EnergyGeneratorTechnology
     
@@ -1289,7 +1304,7 @@ Class: HydroEnergy
 Class: HydroPowerplant
 
     SubClassOf: 
-        ArtificialObject
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
     
     
 Class: HydroelectricPowerplant
@@ -1298,7 +1313,7 @@ Class: HydroelectricPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydroelectric powerplant uses water to generate electricity."@en
     
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some WaterTurbine
     
     
@@ -1446,7 +1461,7 @@ Class: InstalledPowerQuantity
 Class: InternalCombustion
 
     SubClassOf: 
-        EnergyGeneratorTechnology
+        ArtificialObject
     
     
 Class: InternalCombustionVehicle
@@ -1707,7 +1722,7 @@ Class: Ocean
 Class: OceanPowerplant
 
     SubClassOf: 
-        ArtificialObject
+        HydroPowerplant
     
     
 Class: OffShoreWindElectricityGenerator
@@ -1777,7 +1792,7 @@ Class: PVPanel
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=906976047"@en
     
     SubClassOf: 
-        EnergyGeneratorTechnology,
+        Generator,
         has_physical_output some Power,
         has_physical_input only SolarPhotovoltaic
     
@@ -1820,7 +1835,7 @@ Class: PhotovoltaicElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic electricity generator is a renewable energy generator that uses power from the sun to generate electricity."@en
     
     SubClassOf: 
-        RenewableGeneratorTechnology
+        Generator
     
     
 Class: PhotovoltaicGenerator
@@ -2416,7 +2431,7 @@ Source: https://en.wikipedia.org/wiki/Power_(physics)"@en
 Class: PowerGeneratingUnit
 
     SubClassOf: 
-        NetworkNode,
+        ArtificialObject,
         uses some EnergyGeneratorTechnology,
         uses some EnergyStorageTechnology,
         uses some EnergyTransferTechnology
@@ -2488,14 +2503,14 @@ Class: Rail
 Class: ReactivePowerplant
 
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
 Class: RegenerativePowerplant
 
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some WindTurbine
     
     
@@ -2652,7 +2667,7 @@ Class: SolarPowerPlant
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_power&oldid=904827092"@en
     
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         Turbine or (<http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel)
     
     
@@ -2858,7 +2873,7 @@ Class: Turbine
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Turbine&oldid=905470312"
     
     SubClassOf: 
-        EnergyGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
     
     
 Class: UndergroundHydrogenStorage
@@ -3319,9 +3334,6 @@ DisjointClasses:
 
 DisjointClasses: 
     BiomassPowerplant,CoalPowerplant,GasPowerplant,GeothermalGenerator,HydroPowerplant,NuclearPowerplant,OceanPowerplant,OilPowerplant,PhotovoltaicGenerator,WastePowerplant,WindTurbine
-
-DisjointClasses: 
-    Bus,Generator,PowerGeneratingUnit,ShuntImpedance,StorageUnit,Subgrid,Transformer
 
 DisjointClasses: 
     CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -34,6 +34,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000116>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
@@ -309,6 +312,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenera
 Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
         rdfs:comment "rename later to EnergyConverter"
     
     SubClassOf: 
@@ -441,7 +446,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of EnergyConverters that is connected to an electric grid."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of EnergyConverters that is connected to an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
         ArtificialObject
@@ -1132,7 +1139,9 @@ Class: Generator
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is a grid component that converts motive power (mechanical energy) into electrical power for use in an external circuit.
-Source: https://en.wikipedia.org/wiki/Electric_generator"@en
+Source: https://en.wikipedia.org/wiki/Electric_generator"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>,
@@ -2404,6 +2413,10 @@ Source: https://en.wikipedia.org/wiki/Power_(physics)"@en
     
 Class: PowerGeneratingUnit
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
+    
     SubClassOf: 
         ArtificialObject,
         <http://purl.obolibrary.org/obo/BFO_0000051> some Generator

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1489,7 +1489,7 @@ Class: FlowBattery
 Class: FossilPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilePowerplant is a Powerplant having an aggregate of FossilePowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerplant is a Powerplant having an aggregate of FossilPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -315,7 +315,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GasEnergyConverter>
+Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 
     SubClassOf: 
         PowerGeneratingUnit
@@ -390,6 +390,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
 
+    Annotations: 
+        rdfs:comment "A WindEnergyConverter is the PowerGeneratingUnit that uses wind energy."
+    
     SubClassOf: 
         PowerGeneratingUnit,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>,
@@ -941,12 +944,6 @@ Class: EnergyStorage
         ArtificialObject
     
     
-Class: EnergyTransfer
-
-    SubClassOf: 
-        ArtificialObject
-    
-    
 Class: FederalState
 
     Annotations: 
@@ -1047,7 +1044,7 @@ Class: GasPowerplant
     
     SubClassOf: 
         FossilePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasEnergyConverter>
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
     
     
 Class: GasTurbine
@@ -1260,6 +1257,9 @@ Class: HydroEnergy
     
 Class: HydroPowerplant
 
+    Annotations: 
+        rdfs:comment "will be discussed later"
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
     
@@ -1270,7 +1270,7 @@ Class: HydroelectricPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydroelectric powerplant uses water to generate electricity."@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        HydroPowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some WaterTurbine
     
     
@@ -1303,7 +1303,7 @@ Class: HydrogenPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant uses hydrogen to generate electricity."@en
     
     SubClassOf: 
-        ReactivePowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some HydrogenTurbine
     
     
@@ -1663,7 +1663,7 @@ Class: NuclearPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power_plant&oldid=867102016"
     
     SubClassOf: 
-        ReactivePowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -2438,13 +2438,6 @@ Class: Rail
 
     SubClassOf: 
         TransportDemand
-    
-    
-Class: ReactivePowerplant
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
 Class: RegenerativePowerplant

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -315,7 +315,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformer is an artificial object that transforms or changes a certain type of energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "rename later to EnergyConverter"
+        rdfs:comment "rename later to EnergyConvertingDevice"
     
     SubClassOf: 
         ArtificialObject
@@ -2640,7 +2640,7 @@ Class: SolarPowerPlant
 Class: SolarThermalCollector
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector collects heat by absorbing sunlight. The term \"solar collector\" commonly refers to a device for solar hot water heating, but may refer to large power generating installations such as solar parabolic troughs and solar towers or non water heating devices such as solar air heaters."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en
     
     SubClassOf: 
@@ -2815,8 +2815,7 @@ Class: TransportDemand
 Class: Turbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine [...] is a rotary mechanical device that extracts energy from a fluid flow and converts it into useful work. The work produced by a turbine can be used for generating electrical power when combined with a generator."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Turbine&oldid=905470312"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "a turbine is a energy transformer that converts energy from a moving fluid flow into useful work."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -359,6 +359,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FuelCell is a Generator that converts chemical energy into electricity using redox reactions."
+    
     SubClassOf: 
         Generator
     
@@ -1294,7 +1297,7 @@ Class: HeatDemand
 Class: HeatPump
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump heat generator is a heat generator that uses a heat pump to generate heat."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HeatPump is a heater that transforms energy from air, ground or water into useful heat."@en
     
     SubClassOf: 
         Heater
@@ -1303,7 +1306,9 @@ Class: HeatPump
 Class: Heater
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy transformer that converts other forms of energy into useful heat."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy transformer that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -270,6 +270,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
         Energy
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ElectroMotiveGenerator is a Generator that converts kinetic energy into electric energy."
+    
+    SubClassOf: 
+        Generator
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
 
     Annotations: 
@@ -309,6 +318,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/GasEnergyConverter>
+
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 
     Annotations: 
@@ -316,6 +331,15 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
     
     SubClassOf: 
         EnergyCarrier
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a generator that converts light into electrical energy."
+    
+    SubClassOf: 
+        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
@@ -332,6 +356,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of EnergyConverters that is connected to an electric grid."
+    
     SubClassOf: 
         ArtificialObject
     
@@ -362,6 +389,14 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
+
+    SubClassOf: 
+        PowerGeneratingUnit,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -1080,7 +1115,7 @@ Class: GasPowerplant
     
     SubClassOf: 
         FossilePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some GasTurbine
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasEnergyConverter>
     
     
 Class: GasTurbine
@@ -1467,7 +1502,7 @@ Class: InternalCombustion
 Class: InternalCombustionVehicle
 
     SubClassOf: 
-        Generator
+        ArtificialObject
     
     
 Class: Land
@@ -1792,8 +1827,9 @@ Class: PVPanel
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=906976047"@en
     
     SubClassOf: 
-        Generator,
+        PowerGeneratingUnit,
         has_physical_output some Power,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/PVCell>,
         has_physical_input only SolarPhotovoltaic
     
     
@@ -1836,13 +1872,6 @@ Class: PhotovoltaicElectricityGenerator
     
     SubClassOf: 
         Generator
-    
-    
-Class: PhotovoltaicGenerator
-
-    SubClassOf: 
-        Generator,
-        uses some SolarEnergy
     
     
 Class: PhotovoltaicPowerplant
@@ -2432,9 +2461,7 @@ Class: PowerGeneratingUnit
 
     SubClassOf: 
         ArtificialObject,
-        uses some EnergyGeneratorTechnology,
-        uses some EnergyStorageTechnology,
-        uses some EnergyTransferTechnology
+        <http://purl.obolibrary.org/obo/BFO_0000051> some Generator
     
     
 Class: PowerPlantData
@@ -3010,12 +3037,11 @@ Class: WindEnergy
 Class: WindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm uses wind turbines and and wind to generate renewable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Wind_turbine&oldid=867838943"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is an aggregate of WindEnergyConverter that are connected to electricity."@en
     
     SubClassOf: 
         RegenerativePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some WindTurbine
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
     
     
 Class: WindOffshore
@@ -3031,7 +3057,7 @@ Class: WindOnshore
         <http://purl.obolibrary.org/obo/IAO_0000115> "Onshore wind power is the complement to Offshore wind power. It is harvested on land."@en
     
     SubClassOf: 
-        RegenerativePowerplant,
+        ArtificialObject,
         <http://purl.obolibrary.org/obo/BFO_0000051> some WindTurbine
     
     
@@ -3331,9 +3357,6 @@ Individual: synthetic
     
 DisjointClasses: 
     BioElectricityGenerator,PhotovoltaicElectricityGenerator,WaterElectricityGenerator,WindElectricityGenerator
-
-DisjointClasses: 
-    BiomassPowerplant,CoalPowerplant,GasPowerplant,GeothermalGenerator,HydroPowerplant,NuclearPowerplant,OceanPowerplant,OilPowerplant,PhotovoltaicGenerator,WastePowerplant,WindTurbine
 
 DisjointClasses: 
     CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -396,7 +396,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a RenewableGenerator that converts light into electrical energy."
     
     SubClassOf: 
-        RenewableGenerator
+        RegenerativeGenerator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
@@ -639,7 +639,7 @@ Class: BioElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bio electricity generator is a renewable energy generator that uses biomass or biogas to generate electricity."@en
     
     SubClassOf: 
-        RenewableGenerator
+        RegenerativeGenerator
     
     
 Class: Biofuel
@@ -683,7 +683,7 @@ Class: BiomassElectricityGenerator
 Class: BiomassPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass powerplant uses biomass to generate electricity or heat."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerplant is a RegenerativePowerplant having an aggregate of BiomassPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         RegenerativePowerplant,
@@ -734,14 +734,13 @@ Class: CoalElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal electricity generator technology uses coal to generate electricity."@en
     
     SubClassOf: 
-        FossilGenerator
+        FossileGenerator
     
     
 Class: CoalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal-fired power station or coal power plant is a thermal power station which burns coal to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal-fired_power_station&oldid=905322370"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a FossilePowerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         FossilePowerplant,
@@ -1085,17 +1084,20 @@ There are four types: hydrofluorocarbons (HFCs), perfluorocarbons (PFCs), sulfur
         <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseGas
     
     
-Class: FossilGenerator
+Class: FossileGenerator
 
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     DisjointWith: 
-        RenewableGenerator
+        RegenerativeGenerator
     
     
 Class: FossilePowerplant
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilePowerplant is a Powerplant having an aggregate of one kind of  FossilePowerUnits as its PowerGeneratingUnits."
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
@@ -1114,8 +1116,7 @@ Class: Fusion
 Class: GasPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas-fired power plant or gas-fired power station or natural gas power plant is a thermal power station which burns natural gas to generate electricity. Natural gas power stations generate a quarter of world electricity and a significant part of global greenhouse gas emissions and thus global warming."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Gas-fired_power_plant&oldid=905149105"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilePowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         FossilePowerplant,
@@ -1178,7 +1179,7 @@ Class: GeothermalGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."
     
     SubClassOf: 
-        RenewableGenerator,
+        RegenerativeGenerator,
         uses some Heat
     
     
@@ -1198,7 +1199,7 @@ Class: GeothermalHeat
 Class: GeothermalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerplant is a RegenerativePowerplant having an aggregate of GeothermalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         RegenerativePowerplant,
@@ -1260,7 +1261,7 @@ Class: HFC
 Class: HardCoalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant burns coal to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HardCoalPowerplant is a CoalPowerplant having an aggregate of HardCoalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         CoalPowerplant,
@@ -1378,7 +1379,7 @@ Class: Hydrofluorocarbon
 Class: HydrogenPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant uses hydrogen to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydrogenPowerplant is a Powerplant having an aggregate of HydrogenPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -1525,7 +1526,7 @@ Class: Li-ionBattery
 Class: LignitePowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant burns lignite to generate electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A LignitePowerplant is a CoalPowerplant having an aggregate of LignitePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         CoalPowerplant,
@@ -1656,7 +1657,7 @@ Class: NaturalGasGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas electricity generator technology uses natural gas to generate electricity."@en
     
     SubClassOf: 
-        FossilGenerator
+        FossileGenerator
     
     
 Class: NetworkNode
@@ -1739,8 +1740,7 @@ Class: NuclearPowerGenerator
 Class: NuclearPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant or nuclear power station is a thermal power station in which the heat source is a nuclear reactor. As it is typical of thermal power stations, heat is used to generate steam that drives a steam turbine connected to a generator that produces electricity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power_plant&oldid=867102016"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerplant is a Powerplant having an aggregate of NuclearPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -1766,7 +1766,7 @@ Class: OceanPowerplant
 Class: OffShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An off shore wind electricity generator is a wind electricity generator that is build off shore above or in the ocean."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An off shore wind electricity generator is a WindFarm that is build off shore above or in the ocean."@en
     
     SubClassOf: 
         WindFarm
@@ -1787,11 +1787,14 @@ Class: OilElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A oil electricity generator technology uses oil to generate electricity."@en
     
     SubClassOf: 
-        FossilGenerator
+        FossileGenerator
     
     
 Class: OilPowerplant
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilePowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
+    
     SubClassOf: 
         FossilePowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>,
@@ -1801,7 +1804,7 @@ Class: OilPowerplant
 Class: OnShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An on shore wind electricity generator is a wind electricity generator that is build on land."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An on shore wind electricity generator is a WindFarm that is build on land."@en
     
     SubClassOf: 
         WindFarm
@@ -1872,7 +1875,7 @@ Class: Perfluorocarbon
 Class: PhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a Powerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         SolarPowerPlant,
@@ -2522,20 +2525,23 @@ Class: Rail
         TransportDemand
     
     
-Class: RegenerativePowerplant
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
-    
-    
-Class: RenewableGenerator
+Class: RegenerativeGenerator
 
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
     
     DisjointWith: 
-        FossilGenerator
+        FossileGenerator
+    
+    
+Class: RegenerativePowerplant
+
+    Annotations: 
+        rdfs:comment "A RegenerativePowerplant is a Powerplant having an aggregate of one kind of RegenerativePowerUnits as its PowerGeneratingUnits."
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: RenewableMunicipalWasteFuel
@@ -2678,8 +2684,7 @@ Class: SolarPhotovoltaic
 Class: SolarPowerPlant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar power is the conversion of energy from sunlight into electricity, either directly using photovoltaics (PV), indirectly using concentrated solar power, or a combination. Concentrated solar power systems use lenses or mirrors and tracking systems to focus a large area of sunlight into a small beam. Photovoltaic cells convert light into an electric current using the photovoltaic effect."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_power&oldid=904827092"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerplant is a Powerplant having an aggregate of SolarPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         RegenerativePowerplant,
@@ -2722,7 +2727,7 @@ Class: SolarThermalHeatGenerator
 Class: SolarThermalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "uses solar thermal energy to generate electrical energy"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerplant is a Powerplant consisting of SolarThermalPowerUnits."@en
     
     SubClassOf: 
         SolarPowerPlant,
@@ -2954,8 +2959,7 @@ Class: WasteFuel
 Class: WastePowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste-to-energy plant is a waste management facility that combusts wastes to produce electricity. This type of power plant is sometimes called a trash-to-energy, municipal waste incineration, energy recovery, or resource recovery plant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Waste-to-energy_plant&oldid=904634168"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilePowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         FossilePowerplant,
@@ -2969,7 +2973,7 @@ Class: WaterElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electricity generator is a renewable energy generator that uses power from water to generate electricity."@en
     
     SubClassOf: 
-        RenewableGenerator
+        RegenerativeGenerator
     
     
 Class: WaterTurbine
@@ -3007,7 +3011,7 @@ Class: WindElectricityGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind electricity generator technology uses wind power to generate electricity."@en
     
     SubClassOf: 
-        RenewableGenerator
+        RegenerativeGenerator
     
     
 Class: WindEnergy
@@ -3026,7 +3030,7 @@ Class: WindEnergy
 Class: WindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is an aggregate of WindEnergyConverter that are connected to electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WindFarm is a RegenerativePowerplant having an aggregate of WindEnergyConverters as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         RegenerativePowerplant,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -258,6 +258,12 @@ ObjectProperty: uses
         is_used_by
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 
     Annotations: 
@@ -265,6 +271,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
     
     SubClassOf: 
         Energy
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
@@ -315,10 +327,46 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
+Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
 
     SubClassOf: 
         PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
+
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
+
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
@@ -328,6 +376,18 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
     
     SubClassOf: 
         EnergyCarrier
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
+
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
@@ -360,6 +420,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
         ArtificialObject
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
 
     EquivalentTo: 
@@ -370,6 +436,18 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarr
         EnergyCarrier
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
 
     Annotations: 
@@ -377,6 +455,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
@@ -394,7 +478,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter
         rdfs:comment "A WindEnergyConverter is the PowerGeneratingUnit that uses wind energy."
     
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
@@ -603,6 +687,7 @@ Class: BiomassPowerplant
     
     SubClassOf: 
         RegenerativePowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -660,6 +745,7 @@ Class: CoalPowerplant
     
     SubClassOf: 
         FossilePowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -1011,7 +1097,8 @@ Class: FossilGenerator
 Class: FossilePowerplant
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
     
     
 Class: Fusion
@@ -1091,7 +1178,7 @@ Class: GeothermalGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."
     
     SubClassOf: 
-        Generator,
+        RenewableGenerator,
         uses some Heat
     
     
@@ -1115,6 +1202,7 @@ Class: GeothermalPowerplant
     
     SubClassOf: 
         RegenerativePowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -1175,7 +1263,8 @@ Class: HardCoalPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant burns coal to generate electricity."@en
     
     SubClassOf: 
-        CoalPowerplant
+        CoalPowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
     
     
 Class: Hardware
@@ -1249,7 +1338,8 @@ Class: HydroPowerplant
         rdfs:comment "will be discussed later"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
     
     
 Class: HydroelectricPowerplant
@@ -1292,6 +1382,7 @@ Class: HydrogenPowerplant
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some HydrogenTurbine
     
     
@@ -1437,7 +1528,8 @@ Class: LignitePowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant burns lignite to generate electricity."@en
     
     SubClassOf: 
-        CoalPowerplant
+        CoalPowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
     
     
 Class: Line
@@ -1641,7 +1733,7 @@ Class: NuclearPowerGenerator
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear generator technology is a fossil electricity generator that uses nuclear reactions to generate electricity."@en
     
     SubClassOf: 
-        FossilGenerator
+        Generator
     
     
 Class: NuclearPowerplant
@@ -1652,6 +1744,7 @@ Class: NuclearPowerplant
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -1701,6 +1794,7 @@ Class: OilPowerplant
 
     SubClassOf: 
         FossilePowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -1737,7 +1831,7 @@ Class: PVPanel
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=906976047"@en
     
     SubClassOf: 
-        PowerGeneratingUnit,
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
         has_physical_output some Power,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/PVCell>,
         has_physical_input only SolarPhotovoltaic
@@ -2432,7 +2526,7 @@ Class: RegenerativePowerplant
 
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some WindTurbine
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: RenewableGenerator
@@ -2589,7 +2683,7 @@ Class: SolarPowerPlant
     
     SubClassOf: 
         RegenerativePowerplant,
-        Turbine or (<http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel)
+        <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
     
     
 Class: SolarThermalCollector
@@ -2632,6 +2726,7 @@ Class: SolarThermalPowerplant
     
     SubClassOf: 
         SolarPowerPlant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -2864,6 +2959,7 @@ Class: WastePowerplant
     
     SubClassOf: 
         FossilePowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -364,6 +364,18 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenera
         Generator
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:comment "formerly called EnergyTransformer"
+    
+    SubClassOf: 
+        ArtificialObject
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
 
     Annotations: 
@@ -374,18 +386,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
     SubClassOf: 
         EnergyCarrierDisposition,
         <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformer is an artificial object that transforms or changes a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "rename later to EnergyConvertingDevice"
-    
-    SubClassOf: 
-        ArtificialObject
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FluorinatedGreenhouseGas>
@@ -1586,12 +1586,12 @@ The production of other coal gases (i.e. coke oven gas, blast furnace gas and ox
 Class: Generator
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy transformer that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
     
     DisjointWith: 
         Line
@@ -1761,12 +1761,12 @@ Class: HeatPump
 Class: Heater
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy transformer that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy converting device that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
     
     
 Class: HeatingOil
@@ -2933,10 +2933,10 @@ Class: TransportDemand
 Class: Turbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy transformer that converts energy from a moving fluid flow into rotational energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyTransformer>
+        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
     
     
 Class: UndergroundHydrogenStorage

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2346,7 +2346,7 @@ Class: OceanPowerplant
 Class: OffShoreWindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An off shore wind electricity generator is a WindFarm that is build off shore above or in the ocean."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind electricity generator is a WindFarm that is build off shore above or in the ocean."@en
     
     SubClassOf: 
         WindFarm

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -720,10 +720,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
+Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
 
     Annotations: 
-        rdfs:comment "A WindEnergyConverter is a RegenerativePowerUnit that uses wind energy."
+        definition "A WindEnergyConvertiongUnit is a RegenerativePowerUnit that uses wind energy."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
@@ -1438,6 +1438,19 @@ Class: FederalState
     
     SubClassOf: 
         Land
+    
+    
+Class: FieldPhotovoltaicPowerplant
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FieldPhotovoltaicPowerplant (also: solar farm, solar park) is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park"
+    
+    SubClassOf: 
+        PhotovoltaicPowerplant
+    
+    DisjointWith: 
+        RooftopPhotovoltaicPowerplant
     
     
 Class: Fission
@@ -2637,7 +2650,7 @@ Class: RooftopPhotovoltaicPowerplant
         PhotovoltaicPowerplant
     
     DisjointWith: 
-        SolarPark
+        FieldPhotovoltaicPowerplant
     
     
 Class: RunOfRiverPowerplant
@@ -2710,18 +2723,6 @@ Class: SolarEnergy
     SubClassOf: 
         Energy,
         <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
-    
-    
-Class: SolarPark
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar park (also: solar farm, field photovoltaic electricity powerplant) is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
-    
-    SubClassOf: 
-        PhotovoltaicPowerplant
-    
-    DisjointWith: 
-        RooftopPhotovoltaicPowerplant
     
     
 Class: SolarPhotovoltaic
@@ -3053,7 +3054,7 @@ Class: WindFarm
     
     SubClassOf: 
         RegenerativePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter>
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
     
     
 Class: WindTurbine

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -953,18 +953,6 @@ Class: FederalState
         Land
     
     
-Class: FieldPhotovoltaicGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic electricity powerplant is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
-    
-    SubClassOf: 
-        PhotovoltaicPowerplant
-    
-    DisjointWith: 
-        RooftopPhotovoltaicPowerplant
-    
-    
 Class: Fission
 
     Annotations: 
@@ -2498,7 +2486,7 @@ Class: RooftopPhotovoltaicPowerplant
         PhotovoltaicPowerplant
     
     DisjointWith: 
-        FieldPhotovoltaicGenerator
+        SolarPark
     
     
 Class: RunOfRiverElectricityGenerator
@@ -2569,6 +2557,18 @@ Class: SolarEnergy
     SubClassOf: 
         Energy,
         <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
+    
+    
+Class: SolarPark
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar park (also: solar farm, field photovoltaic electricity powerplant)  is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en
+    
+    SubClassOf: 
+        PhotovoltaicPowerplant
+    
+    DisjointWith: 
+        RooftopPhotovoltaicPowerplant
     
     
 Class: SolarPhotovoltaic

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -258,11 +258,28 @@ ObjectProperty: uses
         is_used_by
     
     
+Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
+
+    SubClassOf: 
+        BiofuelPowerplant
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some BiomassElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
@@ -277,8 +294,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some CoalElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
@@ -329,39 +345,34 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some FossileGenerator
+        PowerGeneratingUnit
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
+
+    SubClassOf: 
+        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some GeothermalGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
 
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroGenerator>
-
-    Annotations: 
-        rdfs:comment "will be discussed later"
-    
-    SubClassOf: 
-        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
@@ -373,17 +384,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
         PowerGeneratingUnit
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenGenerator>
-
-    SubClassOf: 
-        Generator
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydrogenGenerator>
+        PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
@@ -404,15 +408,13 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearFuel>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some NuclearPowerGenerator
+        PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OilElectricityGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
@@ -421,7 +423,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a RenewableGenerator that converts light into electrical energy."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
+        Generator
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/PortionOfUranium>
@@ -448,8 +450,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
 
     SubClassOf: 
-        PowerGeneratingUnit,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some RegenerativeGenerator
+        PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarrier>
@@ -462,24 +463,28 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableEnergyCarr
         EnergyCarrier
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
-
-    SubClassOf: 
-        RegenerativeGenerator
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
+        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SolarThermalHeatGenerator
+        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerplant>
+
+    SubClassOf: 
+        BiomassPowerplant
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
@@ -491,17 +496,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Waste>
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteElectricityGenerator>
-
-    SubClassOf: 
-        FossileGenerator
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WasteElectricityGenerator>
+        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
@@ -520,8 +518,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConverter
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some WindElectricityGenerator
+        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -674,15 +671,6 @@ Class: BatteryStorage
         MethanationGasStorage
     
     
-Class: BioElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A bio electricity generator is a renewable energy generator that uses biomass or biogas to generate electricity."@en
-    
-    SubClassOf: 
-        RegenerativeGenerator
-    
-    
 Class: Biofuel
 
     Annotations: 
@@ -697,28 +685,10 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
         has_origin value renewable
     
     
-Class: BiogasElectricityGenerator
+Class: BiofuelPowerplant
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas electricity generator is a bio energy generator that uses biogas to generate electricity."@en
-    
     SubClassOf: 
-        BioElectricityGenerator
-    
-    DisjointWith: 
-        BiomassElectricityGenerator
-    
-    
-Class: BiomassElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass electricity generator is a bio energy generator that uses biomass to generate electricity."@en
-    
-    SubClassOf: 
-        BioElectricityGenerator
-    
-    DisjointWith: 
-        BiogasElectricityGenerator
+        RegenerativePowerplant
     
     
 Class: BiomassPowerplant
@@ -727,8 +697,8 @@ Class: BiomassPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A BiomassPowerplant is a RegenerativePowerplant having an aggregate of BiomassPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        RegenerativePowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/BiomassPowerUnit>,
+        BiofuelPowerplant,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
     
@@ -769,22 +739,13 @@ Class: City
         Land
     
     
-Class: CoalElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal electricity generator technology uses coal to generate electricity."@en
-    
-    SubClassOf: 
-        FossileGenerator
-    
-    
 Class: CoalPowerplant
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a FossilePowerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilePowerplant,
+        FossilPowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -1125,23 +1086,14 @@ There are four types: hydrofluorocarbons (HFCs), perfluorocarbons (PFCs), sulfur
         <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseGas
     
     
-Class: FossileGenerator
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
-    
-    DisjointWith: 
-        RegenerativeGenerator
-    
-    
-Class: FossilePowerplant
+Class: FossilPowerplant
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilePowerplant is a Powerplant having an aggregate of one kind of  FossilePowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/FossilePowerUnit>
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
     
     
 Class: Fusion
@@ -1160,7 +1112,7 @@ Class: GasPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilePowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilePowerplant,
+        FossilPowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
     
     
@@ -1203,16 +1155,6 @@ Class: GeographicRegion
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: GeothermalGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal generator uses geothermal energy to generate electricity."
-    
-    SubClassOf: 
-        RegenerativeGenerator,
-        uses some Heat
     
     
 Class: GeothermalHeat
@@ -1425,7 +1367,7 @@ Class: HydrogenTurbine
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a turbine fueled with liquid hydrogen."@en
     
     SubClassOf: 
-        Turbine,
+        GasTurbine,
         has_physical_output some Power,
         has_physical_input only PortionOfHydrogen
     
@@ -1683,15 +1625,6 @@ Class: MunicipalWasteFuel
         WasteFuel
     
     
-Class: NaturalGasGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas electricity generator technology uses natural gas to generate electricity."@en
-    
-    SubClassOf: 
-        FossileGenerator
-    
-    
 Class: NetworkNode
 
     Annotations: 
@@ -1760,15 +1693,6 @@ Class: NuclearEnergyProduction
         EnergyProduction
     
     
-Class: NuclearPowerGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear generator technology is a fossil electricity generator that uses nuclear reactions to generate electricity."@en
-    
-    SubClassOf: 
-        Generator
-    
-    
 Class: NuclearPowerplant
 
     Annotations: 
@@ -1813,22 +1737,13 @@ Class: Office
         CommericalDemand
     
     
-Class: OilElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil electricity generator technology uses oil to generate electricity."@en
-    
-    SubClassOf: 
-        FossileGenerator
-    
-    
 Class: OilPowerplant
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilePowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
-        FossilePowerplant,
+        FossilPowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -2557,15 +2472,6 @@ Class: Rail
         TransportDemand
     
     
-Class: RegenerativeGenerator
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
-    
-    DisjointWith: 
-        FossileGenerator
-    
-    
 Class: RegenerativePowerplant
 
     Annotations: 
@@ -2619,15 +2525,6 @@ Class: RooftopPhotovoltaicPowerplant
     
     DisjointWith: 
         SolarPark
-    
-    
-Class: RunOfRiverElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river electricity generator is a water energy generator that stores little or no water and produces electricity."@en
-    
-    SubClassOf: 
-        WaterElectricityGenerator
     
     
 Class: RunOfRiverPowerplant
@@ -2747,15 +2644,6 @@ Class: SolarThermalHeat
         Heat
     
     
-Class: SolarThermalHeatGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal heat generator is a heat generator that uses solar power to produce heat."@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarGenerator>
-    
-    
 Class: SolarThermalPowerplant
 
     Annotations: 
@@ -2858,17 +2746,6 @@ Class: TidalPowerPlant
     
     DisjointWith: 
         RunOfRiverPowerplant
-    
-    
-Class: TidalStreamGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tidal stream generator uses tidal movement, wave motion or water current for electricity generation."@en
-    
-    SubClassOf: 
-        WaterElectricityGenerator,
-        has_physical_output some Power,
-        has_physical_input only TideWaveOcean
     
     
 Class: TidalStreamPowerplant
@@ -2994,18 +2871,9 @@ Class: WastePowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilePowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilePowerplant,
+        FossilPowerplant,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
-    
-    
-Class: WaterElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electricity generator is a renewable energy generator that uses power from water to generate electricity."@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/HydroGenerator>
     
     
 Class: WaterTurbine
@@ -3035,15 +2903,6 @@ Class: WavePowerPlant
     SubClassOf: 
         OceanPowerplant,
         uses some Wave
-    
-    
-Class: WindElectricityGenerator
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind electricity generator technology uses wind power to generate electricity."@en
-    
-    SubClassOf: 
-        RegenerativeGenerator
     
     
 Class: WindEnergy
@@ -3363,9 +3222,6 @@ Individual: synthetic
         has_origin some origin
     
     
-DisjointClasses: 
-    CoalElectricityGenerator,NaturalGasGenerator,NuclearPowerGenerator,OilElectricityGenerator
-
 DisjointClasses: 
     Generator,ShuntImpedance,StorageUnit,Subgrid,Transformer
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -455,10 +455,7 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
-    
-Class: Model
 
-    
 
-    
+
     


### PR DESCRIPTION
closes #173 and hopefully almost every other issue in the generator project:
closes #275, closes #264, closes #162, closes #136, closes #161, closes #159  

Restructures the widely distributed generator and powerplant classes as discussed in the 4. OntoHack

- Technology has no subclasses anymore as they weren't needed
- its now differentiated between EnergyConvertingDevice, PowerGeneratingUnit and Powerplant
     - An **energy converting device** is an artificial object that transforms or changes a certain type of energy.
            - A **generator** is an energy converting device that converts other forms of energy into electrical energy.
            - A **Heater** is an energy converting device that converts other forms of energy into useful heat.
            - A **turbine** is an energy converting device that converts energy from a moving fluid flow into rotational energy.
     - A **power generating unit** is an artificial object that contains a generator, among other parts.
     - A **Powerplant** is an aggregate of EnergyConverters that is connected to an electric grid.