### PR TITLE
change Documentation

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -537,7 +537,7 @@ Class: CodeDocumentation
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CodeDocumentation is a Documentation explaining and annotating software code."^^xsd:string
     
     SubClassOf: 
-        Documentation
+        SoftwareDocumentation
     
     
 Class: CodeSource
@@ -678,12 +678,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272"
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
-Class: Documentation
-
-    SubClassOf: 
-        SoftwareMaintenance
-    
-    
 Class: Ecological
 
     SubClassOf: 
@@ -799,7 +793,7 @@ Class: InstallationGuide
         <http://purl.obolibrary.org/obo/IAO_0000115> "An InstallationGuide is a Documentation intended to help Users install a Software."^^xsd:string
     
     SubClassOf: 
-        Documentation
+        SoftwareDocumentation
     
     
 Class: Interface
@@ -1154,6 +1148,15 @@ Class: SoftwareDescriptor
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: SoftwareDocumentation
+
+    Annotations: 
+        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
 Class: SoftwareElement
 
     Annotations: 
@@ -1269,7 +1272,7 @@ Class: UserDocumentation
         <http://purl.obolibrary.org/obo/IAO_0000115> "A UserDocumentation is a Documentation intended to assist Users in using the software."^^xsd:string
     
     SubClassOf: 
-        Documentation
+        SoftwareDocumentation
     
     
 Class: Validation


### PR DESCRIPTION
closes #251
- rename to SoftwareDocumentation
- new def and subclass of document
def: A Documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.