### PR TITLE
change Framework

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -745,12 +745,6 @@ Class: Forum
         Support
     
     
-Class: Framework
-
-    SubClassOf: 
-        SoftwareElement
-    
-    
 Class: FrameworkFactsheet
 
     Annotations: 
@@ -1163,6 +1157,15 @@ Class: SoftwareElement
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
+Class: SoftwareFramework
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareFramework is a Software that is generic and can be adapted to a specific application."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
 Class: SoftwareMaintenance
 
     SubClassOf: 
@@ -1308,13 +1311,13 @@ Class: Workshop
 Individual: <http://openenergy-platform.org/ontology/oeo/C++>
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/MS_Excel/VBA>
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/Spatial(GIS)>
@@ -1410,7 +1413,7 @@ Individual: False
 Individual: Fortran
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: FuzzyLogic
@@ -1422,7 +1425,7 @@ Individual: FuzzyLogic
 Individual: GAMS
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: GLPK
@@ -1434,7 +1437,7 @@ Individual: GLPK
 Individual: GNU
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Gurobi
@@ -1458,7 +1461,7 @@ Individual: Inactive
 Individual: Java
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: LinearProgramming
@@ -1476,7 +1479,7 @@ Individual: MOSEK
 Individual: MS_Excel
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Macro-Economic
@@ -1488,13 +1491,13 @@ Individual: Macro-Economic
 Individual: MathProg
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Matlab
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: MixedIntegerLinearProgramming
@@ -1506,7 +1509,7 @@ Individual: MixedIntegerLinearProgramming
 Individual: Modellca
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: MonteCarlo
@@ -1539,7 +1542,7 @@ Individual: Other
 Individual: PHP
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Passive
@@ -1551,19 +1554,19 @@ Individual: Passive
 Individual: Python
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: R
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Ruby
 
     Types: 
-        Framework
+        SoftwareFramework
     
     
 Individual: Simulation


### PR DESCRIPTION
closes #262
- rename to SoftwareFramework
- new def, subclass of Software
def: A SoftwareFramework is a Software that is generic and can be adapted to a specific application.