### PR TITLE
reclassify Model as generically dependent continuant

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -712,7 +712,7 @@ Class: FixedOperationCost
 
     SubClassOf: 
         Cost
-      
+    
     
 Class: FrameworkFactsheet
 
@@ -834,10 +834,10 @@ Class: Minimization
 Class: Model
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a tool for computing the behavior of a system using an idealized representation."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing the behavior of a system using an idealized representation."@en
     
     SubClassOf: 
-        ModelingSoftware,
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SoftwareElement
     
     
@@ -1151,6 +1151,7 @@ Class: Study
 
     SubClassOf: 
         Reference
+    
     
 Class: SynthethicDataset
 
@@ -1584,4 +1585,4 @@ Individual: gdx
     Types: 
         DataFormat
     
-
+    

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -637,6 +637,10 @@ Class: DataPreprocessing
     
 Class: DataProcessing
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289"
+    
     SubClassOf: 
         SoftwareElement
     
@@ -834,7 +838,9 @@ Class: Minimization
 Class: Model
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing the behavior of a system using an idealized representation."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing the behavior of a system using an idealized representation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
@@ -1108,6 +1114,8 @@ Class: SoftwareDescriptor
 Class: SoftwareDocumentation
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
         rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program."
     
     SubClassOf: 
@@ -1126,7 +1134,9 @@ Class: SoftwareElement
 Class: SoftwareFramework
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareFramework is a Software that is generic and can be adapted to a specific application."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareFramework is a Software that is generic and can be adapted to a specific application.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>


### PR DESCRIPTION
closes #208.
The new definition is: "A model is a generically dependent continuant that is used for computing the behavior of a system using an idealized representation."