### PR TITLE
restructure DataProcessing

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -620,7 +620,7 @@ Class: DataFormat
 Class: DataPostprocessing
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPostProcessing is DataProcessing happening after the main processing happened to prepare the data for output."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPostProcessing is DataProcessing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string
     
     SubClassOf: 
         DataProcessing
@@ -629,7 +629,7 @@ Class: DataPostprocessing
 Class: DataPreprocessing
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPreProcessing is DataProcessing happening to the raw data to prepare it for the main processing."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPreProcessing is DataProcessing that transforms the input into a form that is useable for a model calculation."^^xsd:string
     
     SubClassOf: 
         DataProcessing
@@ -637,8 +637,12 @@ Class: DataPreprocessing
     
 Class: DataProcessing
 
+    Annotations: 
+        rdfs:comment "data processing is a transformation in which a data item gets transformed."
+    
     SubClassOf: 
-        SoftwareElement
+        Transformation,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
 Class: DataProcessingSoftware
@@ -712,7 +716,7 @@ Class: FixedOperationCost
 
     SubClassOf: 
         Cost
-      
+    
     
 Class: FrameworkFactsheet
 
@@ -959,24 +963,6 @@ Class: PoliticalAssumption
         Assumption
     
     
-Class: Postprocessing
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Postprocessing is a transformation that transforms the output of a model calculation into a form that is suitable for presentation."@en
-    
-    SubClassOf: 
-        Transformation
-    
-    
-Class: Preprocessing
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Preprocessing is a transformation that transforms the input into a form that is useable for a model calculation."@en
-    
-    SubClassOf: 
-        Transformation
-    
-    
 Class: PrimaryOutputs
 
     Annotations: 
@@ -1151,6 +1137,7 @@ Class: Study
 
     SubClassOf: 
         Reference
+    
     
 Class: SynthethicDataset
 
@@ -1584,4 +1571,4 @@ Individual: gdx
     Types: 
         DataFormat
     
-
+    


### PR DESCRIPTION
closes #252
- reclassify DataProcessing as transformation
- 'has participant' some 'data item'
- def: "data processing is a transformation in which a data item gets transformed." (I changed the definition a bit to get it more human readable
- delete Postprocessing and Preprocessing because we have Datapostprocessing and Datapreprocessing