### PR TITLE
change turbine definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Here is a template for new release sections
 - update issue templates 'workflow checklist' (#258)
 - Generator (#273)
 - EnergyStorage (#276)
+- Turbine (#299)
 
 
 ### Removed

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -723,7 +723,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
 
     Annotations: 
-        definition "A WindEnergyConvertiongUnit is a RegenerativePowerUnit that uses wind energy."
+        definition "A WindEnergyConvertingUnit is a RegenerativePowerUnit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1544,6 +1544,8 @@ Class: GasTurbine
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Combustiuon turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
         rdfs:label "Gas turbine"
     
     SubClassOf: 
@@ -1851,7 +1853,9 @@ Class: HydrogenPowerplant
 Class: HydrogenTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300"
     
     SubClassOf: 
         GasTurbine,
@@ -2991,7 +2995,9 @@ Class: Water
 Class: WaterTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300"
     
     SubClassOf: 
         Turbine,
@@ -3044,6 +3050,8 @@ Class: WindTurbine
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
         rdfs:label "wind rotor"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1542,8 +1542,9 @@ Class: GasPowerplant
 Class: GasTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine, also called a combustion turbine, is a type of continuous combustion, internal combustion engine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Gas_turbine&oldid=901583703"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustiuon turbine",
+        rdfs:label "Gas turbine"
     
     SubClassOf: 
         Turbine,
@@ -1850,7 +1851,7 @@ Class: HydrogenPowerplant
 Class: HydrogenTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a turbine fueled with liquid hydrogen."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en
     
     SubClassOf: 
         GasTurbine,
@@ -2782,8 +2783,7 @@ Class: SolidFossilFuel
 Class: SteamTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a device that extracts thermal energy from pressurized steam and uses it to do mechanical work on a rotating output shaft.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Steam_turbine&oldid=906022336"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy."
     
     SubClassOf: 
         Turbine,
@@ -2991,8 +2991,7 @@ Class: Water
 Class: WaterTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a rotary machine that converts kinetic energy and potential energy of water into mechanical work."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Water_turbine&oldid=902161000"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en
     
     SubClassOf: 
         Turbine,
@@ -3043,10 +3042,9 @@ Class: WindFarm
 Class: WindTurbine
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind turbine is a device that converts the wind's kinetic energy into electrical energy.
-
-Wind turbines are manufactured in a wide range of vertical and horizontal axis. The smallest turbines are used for applications such as battery charging for auxiliary power for boats or caravans or to power traffic warning signs. Slightly larger turbines can be used for making contributions to a domestic power supply while selling unused power back to the utility supplier via the electrical grid. Arrays of large turbines, known as wind farms, are becoming an increasingly important source of intermittent renewable energy and are used by many countries as part of a strategy to reduce their reliance on fossil fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Wind_turbine&oldid=867838943"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        rdfs:label "wind rotor"
     
     SubClassOf: 
         Turbine,


### PR DESCRIPTION
close #299 
- change definitions of turbine classes
- rename wind turbine to wind rotor

definitions:
- GasTurbine: A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine.
- HydrogenTurbine: A hydrogen turbine is a gas turbine fueled with hydrogen.
SteamTurbine: A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.
- WaterTurbine: A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy.
- WindRotor: A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy.