### PR TITLE
restructure Powerplant, PowerGeneratingUnit

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -330,7 +330,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a PowerGeneratingUnit using Coal as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a PowerGeneratingUnit using coal as fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -678,7 +678,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a PowerUnit using waste as fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a PowerGeneratingUnit using waste as fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -284,7 +284,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        PowerGeneratingUnit,
         uses some Biofuel
     
     
@@ -333,7 +333,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a FossilPowerUnit using Coal as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        PowerGeneratingUnit,
         uses some Coal
     
     
@@ -420,16 +420,6 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatt
         has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerUnit is a PowerGeneratingUnit using FossilCombustionFuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
 
     Annotations: 
@@ -445,7 +435,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a FossilPowerUnit using gas as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
+        PowerGeneratingUnit,
+        uses some 
+            (Fuel
+             and (has_normal_state_of_matter value gaseous))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
@@ -454,7 +447,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerUnit is a RegenerativePowerUnit using geothermal heat."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
@@ -574,7 +567,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        PowerGeneratingUnit,
         uses some OilAndPetroleumProducts
     
     
@@ -590,22 +583,12 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of EnergyConverters that is connected to an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of PowerGeneratingUnits that feeds electric energy into an electric grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
     
     SubClassOf: 
         ArtificialObject
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerUnit is a PowerGeneratingUnit using regenerative fuels."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
@@ -627,7 +610,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a RegenerativePowerUnit using solar power."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
+        PowerGeneratingUnit
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
@@ -698,7 +681,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a FossilPowerUnit using waste as fuel."
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>,
+        PowerGeneratingUnit,
         uses some WasteFuel
     
     
@@ -727,7 +710,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertin
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>,
+        PowerGeneratingUnit,
         <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
@@ -966,7 +949,8 @@ Class: BiofuelPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a RegenerativePowerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
-        RegenerativePowerplant
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
     
     
 Class: Biogas
@@ -1068,7 +1052,7 @@ Class: CoalPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a FossilePowerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilPowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -1484,16 +1468,6 @@ Class: FlowBattery
         Battery
     
     
-Class: FossilPowerplant
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPowerplant is a Powerplant having an aggregate of FossilPowerUnits as its PowerGeneratingUnits."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/FossilPowerUnit>
-    
-    
 Class: Fuel
 
     Annotations: 
@@ -1507,6 +1481,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
     
     SubClassOf: 
         PortionOfMatter
+    
+    
+Class: FueledPowerUnit
+
+    EquivalentTo: 
+        uses some Fuel
+    
+    SubClassOf: 
+        PowerGeneratingUnit
+    
+    
+Class: FueledPowerplant
+
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some FueledPowerUnit
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
     
     
 Class: Fusion
@@ -1536,7 +1528,7 @@ Class: GasPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilPowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilPowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
     
     
@@ -1624,7 +1616,7 @@ Class: GeothermalPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerplant is a RegenerativePowerplant having an aggregate of GeothermalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        RegenerativePowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -2371,7 +2363,7 @@ Class: OilPowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilPowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
-        FossilPowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -2588,16 +2580,6 @@ Class: Rail
         TransportDemand
     
     
-Class: RegenerativePowerplant
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A RegenerativePowerplant is a Powerplant having an aggregate of RegenerativePowerUnits as its PowerGeneratingUnits."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/RegenerativePowerUnit>
-    
-    
 Class: RenewableMunicipalWasteFuel
 
     Annotations: 
@@ -2731,7 +2713,7 @@ Class: SolarPowerPlant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerplant is a Powerplant having an aggregate of SolarPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        RegenerativePowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
     
     
@@ -2977,7 +2959,7 @@ Class: WastePowerplant
         <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilPowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        FossilPowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
     
@@ -3042,7 +3024,7 @@ Class: WindFarm
         <http://purl.obolibrary.org/obo/IAO_0000115> "A WindFarm is a RegenerativePowerplant having an aggregate of WindEnergyConverters as its PowerGeneratingUnits."@en
     
     SubClassOf: 
-        RegenerativePowerplant,
+        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -432,7 +432,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a PowerGeneratingUnit using gas as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a PowerGeneratingUnit using gas as fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -607,7 +607,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a PowerUnit using solar power."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a PowerGeneratingUnit using solar power."
     
     SubClassOf: 
         PowerGeneratingUnit
@@ -3212,4 +3212,3 @@ Individual: synthetic
     
 DisjointClasses: 
     Generator,Heater,Turbine
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -706,7 +706,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
 
     Annotations: 
-        definition "A WindEnergyConvertingUnit is a PowerUnit that uses wind energy.",
+        definition "A WindEnergyConvertingUnit is a PowerGeneratingUnit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -564,7 +564,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a PowerGeneratingUnit using oil as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a PowerGeneratingUnit using oil as fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -281,7 +281,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
 Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a RegenerativePowerUnit using biofuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a PowerGeneratingUnit using biofuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -330,7 +330,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a FossilPowerUnit using Coal as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a PowerGeneratingUnit using Coal as Fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -432,7 +432,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a FossilPowerUnit using gas as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a PowerGeneratingUnit using gas as Fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -444,7 +444,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerUnit is a RegenerativePowerUnit using geothermal heat."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerGeneratingUnit is a PowerUnit using geothermal heat."
     
     SubClassOf: 
         PowerGeneratingUnit
@@ -564,7 +564,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a FossilPowerUnit using oil as Fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a PowerGeneratingUnit using oil as Fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -607,7 +607,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a RegenerativePowerUnit using solar power."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a PowerUnit using solar power."
     
     SubClassOf: 
         PowerGeneratingUnit
@@ -678,7 +678,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a FossilPowerUnit using waste as fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a PowerUnit using waste as fuel."
     
     SubClassOf: 
         PowerGeneratingUnit,
@@ -706,7 +706,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
 
     Annotations: 
-        definition "A WindEnergyConvertingUnit is a RegenerativePowerUnit that uses wind energy.",
+        definition "A WindEnergyConvertingUnit is a PowerUnit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"
     
     SubClassOf: 
@@ -946,7 +946,7 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
 Class: BiofuelPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a RegenerativePowerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a Powerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -1049,7 +1049,7 @@ Class: Coal
 Class: CoalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a FossilePowerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a Powerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -1485,6 +1485,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
     
 Class: FueledPowerUnit
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerUnit is a PowerGeneratingUnit that uses fuel."
+    
     EquivalentTo: 
         uses some Fuel
     
@@ -1494,6 +1497,9 @@ Class: FueledPowerUnit
     
 Class: FueledPowerplant
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerplant is a Powerplant that has FueledPowerUnits as parts."
+    
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000051> some FueledPowerUnit
     
@@ -1525,7 +1531,7 @@ Class: GasDieselOil
 Class: GasPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a FossilPowerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a Powerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -1613,7 +1619,7 @@ Class: GeothermalHeat
 Class: GeothermalPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerplant is a RegenerativePowerplant having an aggregate of GeothermalPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerplant is a Powerplant having an aggregate of GeothermalPowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -2360,7 +2366,7 @@ It consists of hydrocarbons of various molecular weights and other organic compo
 Class: OilPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a FossilPowerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a Powerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -2442,7 +2448,7 @@ Class: Perfluorocarbon
 Class: PhotovoltaicPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a RegenerativePowerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a Powerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         SolarPowerPlant,
@@ -2956,7 +2962,7 @@ Class: WasteFuel
 Class: WastePowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a FossilPowerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a Powerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
@@ -3021,7 +3027,7 @@ Class: WindEnergy
 Class: WindFarm
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WindFarm is a RegenerativePowerplant having an aggregate of WindEnergyConverters as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A WindFarm is a Powerplant having an aggregate of WindEnergyConverters as its PowerGeneratingUnits."@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1486,7 +1486,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
 Class: FueledPowerUnit
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerUnit is a PowerGeneratingUnit that uses fuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerUnit is a PowerGeneratingUnit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
     
     EquivalentTo: 
         uses some Fuel
@@ -1498,7 +1500,9 @@ Class: FueledPowerUnit
 Class: FueledPowerplant
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerplant is a Powerplant that has FueledPowerUnits as parts."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerplant is a Powerplant that has FueledPowerUnits as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000051> some FueledPowerUnit


### PR DESCRIPTION
closes #292 
- delete Fossil- and Regenerative- Powerunits and - Powerplants
- create equivalent classes:
  - FueledPowerplant: A FueledPowerplant is a Powerplant that has FueledPowerUnits as parts.
  - FueledPowerUnit: A FueledPowerUnit is a PowerGeneratingUnit that uses fuel.