### PR TITLE
add term tracker items to oeo-physical

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -321,7 +321,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/CarbonDioxide>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214"
     
     SubClassOf: 
         Energy
@@ -552,7 +554,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NitrousOxide>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
         EnergyCarrierDisposition
@@ -682,7 +686,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/ThermalEnergyStorag
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
         PortionOfMatter,
@@ -705,7 +711,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteRole is a role of an object aggregate that has been discarded after primary use."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteRole is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -714,7 +722,9 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>
 Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -867,7 +877,10 @@ Class: Appliance
 Class: ArtificialObject
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ArtificialObject is an object that was deliberately manufactured by humans to address a particular purpose."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ArtificialObject is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (ArtificialObject definition),
+ https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
@@ -1121,7 +1134,9 @@ Class: Combustion
 Class: CombustionFuel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     EquivalentTo: 
         Fuel
@@ -1308,7 +1323,9 @@ Class: ElectricityExport
 Class: ElectricityGrid
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a grid that distributes electrical energy / electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165"
     
     SubClassOf: 
         Grid,
@@ -1361,7 +1378,9 @@ Class: Energy
 Class: EnergyCarrierDisposition
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EnergyCarrierDisposition is a disposition of an object or objectAggregate that contains energy for conversion as usable energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EnergyCarrierDisposition is a disposition of an object or objectAggregate that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -1673,6 +1692,8 @@ Class: Grid
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
         rdfs:comment "Synonym: Network"@en
     
     SubClassOf: 
@@ -1779,7 +1800,9 @@ Class: HydroEnergy
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         Energy
@@ -2278,7 +2301,9 @@ Class: NuclearEnergy
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear power is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         Energy
@@ -2296,7 +2321,9 @@ Class: NuclearEnergyProduction
 Class: NuclearFuel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     EquivalentTo: 
         Fuel
@@ -2708,7 +2735,9 @@ Class: SolarEnergy
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         Energy,
@@ -2772,7 +2801,9 @@ Class: SolarThermalPowerplant
 Class: SolidFossilFuel
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164"
     
     EquivalentTo: 
         (<http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition)
@@ -2961,6 +2992,8 @@ Class: WasteFuel
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "WasteFuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
         rdfs:comment "The energy content of WasteFuel is typically released by incineration or gasification."
     
     EquivalentTo: 
@@ -3028,7 +3061,9 @@ Class: WindEnergy
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         Energy,
@@ -3076,7 +3111,9 @@ Class: WoodAndOther
 Class: origin
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source)."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -3086,7 +3123,9 @@ Class: state_of_matter
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1135,7 +1135,7 @@ Class: CombustionFuel
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2322,7 +2322,7 @@ Class: NuclearFuel
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -555,7 +555,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrie
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
@@ -3259,4 +3259,3 @@ Individual: synthetic
     
 DisjointClasses: 
     Generator,Heater,Turbine
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -687,7 +687,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/182
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 


### PR DESCRIPTION
this just adds a bunch of term tracker items to oeo-physical.
I went through the ontology and through closed pull-request to add as much as I could find.
As I already went through oeo-model and oeo-social this will close #259.