### PR TITLE
Adding Patrick Kuckertz to the OEO contributor list @284

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -8,9 +8,9 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/v0.0.1/oeo/" uri="oeo.omn"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl" uri="http://purl.obolibrary.org/obo/bfo.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1585655720585" name="http://open-energy-ontology.org/ontology/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1585655720585" name="http://open-energy-ontology.org/ontology/imports/iao-module.owl" uri="imports/iao-module.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1585655720585" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1585655720585" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1585818243989" name="http://open-energy-ontology.org/ontology/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1585818243989" name="http://open-energy-ontology.org/ontology/imports/iao-module.owl" uri="imports/iao-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1585818243989" name="http://open-energy-ontology.org/ontology/imports/ro-module.owl" uri="imports/ro-module.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1585818243989" name="http://purl.obolibrary.org/obo/uo.owl" uri="imports/uo-module.owl"/>
     </group>
 </catalog>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -30,6 +30,7 @@ Annotations:
     dc:contributor "Lukas Emele",
     dc:contributor "Martin Glauer",
     dc:contributor "Mirjam Stappel",
+    dc:contributor "Patrick Kuckertz (@p-kuckertz)",
     dc:contributor "Pierre-Francois Duc",
     dc:contributor "Sebastian Cordes",
     dc:contributor "Vera Sehn (@Vera-IER)",


### PR DESCRIPTION
Adding my name to the OEO's contributors list like discussed in OntoHack#5 (issue @284)

During the commit, I received a Git warning:

"warning: LF will be replaced by CRLF in src/ontology/oeo.omn.
The file will have its original line endings in your working directory."

This is about Windows and Linux having different ways of marking line endings within the source code.
I'm working on Windows and do not want to overwrite (mess up) line endings in shared documents.
I think it should be fine, since Git automatically handles this issue if "core.autocrlf=true" in the Git config - which it is for me.

Still, please be sure, that my files have the proper format...

Thank you.