### PR TITLE
Change to alphanumeric identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Here is a template for new release sections
 - Generator (#273)
 - EnergyStorage (#276)
 - Turbine (#299)
-
+- Change to use numeric identifiers for classes and individuals (#133)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/):
     git checkout -b feature/myfeature
     ```
     It is best to merge one's changes *as fast as possible* (i.e. do not wait for 6 months) to avoid merging conflicts
-3. Open [Protégé](https://protege.stanford.edu/) and work on the ontology
+3. Open [Protégé](https://protege.stanford.edu/) and work on the ontology. If you haven't already, make sure you change your protégé settings to use [numeric identifiers](https://github.com/OpenEnergyPlatform/ontology/wiki/Numerical-Identifiers).
 
     One can also edit the `oeo.omn` file in a text editor
 4. Before committing your changes, open the `oeo.omn` file with Protégé and save the file from Protégé. You should also check if you included inconsistencies by following [this ontology test procedure](https://github.com/OpenEnergyPlatform/ontology/wiki/ontology-test-guide)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -818,7 +818,7 @@ Class: OEO_00000202
 Class: OEO_00000228
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help Users install a Software."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
         rdfs:label "installation guide"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -692,7 +692,7 @@ Class: OEO_00000125
 Class: OEO_00000133
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International organization for Standardization (ISO).
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
 source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
         rdfs:label "DOI"
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -20,7 +20,7 @@ Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)",
-    rdfs:comment "The Open energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
+    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1368,7 +1368,7 @@ Class: OEO_00000428
 Class: OEO_00000432
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist Users in using the software."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
         rdfs:label "user documentation"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -473,7 +473,7 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 Class: OEO_00000048
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is a abbreviation of the title by using the first letters of each part of the title."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
         rdfs:label "acronym"
     
     SubClassOf: 
@@ -682,7 +682,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
 Class: OEO_00000125
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "data processingSoftware is Software used in the context of data processing."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
         rdfs:label "data processing software"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -19,7 +19,7 @@ Import: <http://open-energy-ontology.org/ontology/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open energy Ontology (Modelling module)",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)",
     rdfs:comment "The Open energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -805,7 +805,7 @@ Class: OEO_00000201
 Class: OEO_00000202
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is an interface allowing users to communicate with a Software application through a graphical window."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is an interface allowing users to communicate with a software application through a graphical window."^^xsd:string,
         rdfs:label "GUI"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -885,7 +885,7 @@ Class: OEO_00000265
 Class: OEO_00000268
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "minimization is a modelFunction that minimizes some variable of a model."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "maximization is a model function that maximizes some variable of a model."^^xsd:string,
         rdfs:label "maximization"
     
     SubClassOf: 
@@ -904,6 +904,7 @@ Class: OEO_00000270
 Class: OEO_00000272
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "minimization is a model function that minimizes some variable of a model.",
         rdfs:label "minimization"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -19,8 +19,8 @@ Import: <http://open-energy-ontology.org/ontology/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
+    <http://purl.org/dc/terms/title> "Open energy Ontology (Modelling module)",
+    rdfs:comment "The Open energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -171,7 +171,7 @@ ObjectProperty: has_numercical_input
         Asymmetric
     
     Domain: 
-        Transformation
+        OEO_00000419
     
     
 ObjectProperty: has_numerical_output
@@ -187,7 +187,7 @@ ObjectProperty: has_numerical_output
         Asymmetric
     
     Domain: 
-        Transformation
+        OEO_00000419
     
     
 ObjectProperty: has_objective
@@ -196,10 +196,10 @@ ObjectProperty: has_objective
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimization and its objective function or objective variable."@en
     
     Domain: 
-        Optimization
+        OEO_00000313
     
     Range: 
-        SoftwareElement
+        OEO_00000381
     
     
 ObjectProperty: has_objectivefunction
@@ -281,10 +281,10 @@ ObjectProperty: has_tool
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     Domain: 
-        ModelCalculation
+        OEO_00000275
     
     Range: 
-        Model
+        OEO_00000274
     
     
 ObjectProperty: has_typical_computation_hardware
@@ -470,1114 +470,1423 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000300>
 Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 
     
-Class: API
+Class: OEO_00000048
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming Interface) is an Interface allowing two Software applications to communicate with each other."^^xsd:string
-    
-    SubClassOf: 
-        Interface
-    
-    DisjointWith: 
-        GUI
-    
-    
-Class: Acronym
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is a abbreviation of the title by using the first letters of each part of the title."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is a abbreviation of the title by using the first letters of each part of the title."@en,
+        rdfs:label "acronym"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000028>
     
     
-Class: AnalyticalApproach
+Class: OEO_00000057
 
+    Annotations: 
+        rdfs:label "analytical approach"
+    
     SubClassOf: 
-        ContentDescriptor
+        OEO_00000108
     
     
-Class: Assumption
+Class: OEO_00000059
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is an interface allowing two Software applications to communicate with each other."^^xsd:string,
+        rdfs:label "API"
+    
+    SubClassOf: 
+        OEO_00000239
+    
+    DisjointWith: 
+        OEO_00000202
+    
+    
+Class: OEO_00000063
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "The predicted demographic development for a country in the future."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is a statement about a property of a system or process that is considered to be true."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is a statement about a property of a system or process that is considered to be true."@en,
+        rdfs:label "assumption"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: BooleanVariable
+Class: OEO_00000078
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
+        rdfs:label "boolean variable"
     
     SubClassOf: 
-        Variable
+        OEO_00000435
     
     
-Class: CitationReference
+Class: OEO_00000085
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CitationReference is a Reference stating where a citation was taken from."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
+        rdfs:label "citation reference"
     
     SubClassOf: 
-        Reference
+        OEO_00000353
     
     
-Class: CodeDocumentation
+Class: OEO_00000090
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CodeDocumentation is a Documentation explaining and annotating software code."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
+        rdfs:label "code documentation"
     
     SubClassOf: 
-        SoftwareDocumentation
+        OEO_00000380
     
     
-Class: CodeSource
+Class: OEO_00000091
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CodeSource is a DataDescriptor describing the origin of some code."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
+        rdfs:label "code source"
     
     SubClassOf: 
-        DataDescriptor
+        OEO_00000119
     
     
-Class: CollaborativeProgramming
-
-    SubClassOf: 
-        OpenSource
-    
-    
-Class: ComputationTime
+Class: OEO_00000095
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "ComputationTime is a SoftwareDescriptor describing how long a Software or an Algorithm needs to compute."^^xsd:string
+        rdfs:label "collaborative programming"
     
     SubClassOf: 
-        SoftwareDescriptor
+        OEO_00000312
     
     
-Class: Constraint
+Class: OEO_00000103
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "computation time is a software descriptor describing how long a Software or an Algorithm needs to compute."^^xsd:string,
+        rdfs:label "computation time"
+    
+    SubClassOf: 
+        OEO_00000378
+    
+    
+Class: OEO_00000104
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
+        rdfs:label "constraint"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: ContentDescriptor
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: CorporateIdentity
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: Cost
-
-    SubClassOf: 
-        Variable
-    
-    
-Class: DOI
+Class: OEO_00000108
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
-source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000028>
-    
-    
-Class: DataDescriptor
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DataDescriptor is an information content entity that contains additional information about some data."^^xsd:string
+        rdfs:label "content descriptor"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: DataFormat
+Class: OEO_00000111
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DataFormat is a DataDescriptor that describes in which format the data is encoded."^^xsd:string
+        rdfs:label "corporate identity"
     
     SubClassOf: 
-        DataDescriptor
-    
-    DisjointWith: 
-        OpenSource
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: DataPostprocessing
+Class: OEO_00000112
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPostProcessing is DataProcessing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string
+        rdfs:label "cost"
     
     SubClassOf: 
-        DataProcessing
+        OEO_00000435
     
     
-Class: DataPreprocessing
+Class: OEO_00000118
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "DataPreProcessing is DataProcessing that transforms the input into a form that is useable for a model calculation."^^xsd:string
-    
-    SubClassOf: 
-        DataProcessing
-    
-    
-Class: DataProcessing
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
-        rdfs:comment "data processing is a transformation in which a data item gets transformed."
-
-    
-    SubClassOf: 
-        Transformation,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
-    
-    
-Class: DataProcessingSoftware
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "DataProcessingSoftware is Software used in the context of DataProcessing."^^xsd:string
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: Database
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Database is an information content entity that stores data items and data sets.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
+        rdfs:label "database"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
-Class: Ecological
-
-    SubClassOf: 
-        Type
-    
-    
-Class: Economical
-
-    SubClassOf: 
-        Type
-    
-    
-Class: EmpiricalDataset
+Class: OEO_00000119
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
+        rdfs:label "data descriptor"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000120
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
+        rdfs:label "data format"
+    
+    SubClassOf: 
+        OEO_00000119
     
     DisjointWith: 
-        SynthethicDataset
+        OEO_00000312
     
     
-Class: ExternalOptimizer
+Class: OEO_00000122
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ExternalOptimizer is a Software external to a Model that computes an Optimization."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
+        rdfs:label "data postprocessing"
+    
+    SubClassOf: 
+        OEO_00000124
+    
+    
+Class: OEO_00000123
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
+        rdfs:label "data preprocessing"
+    
+    SubClassOf: 
+        OEO_00000124
+    
+    
+Class: OEO_00000124
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
+        rdfs:comment "data processing is a transformation in which a data item gets transformed.",
+        rdfs:label "data processing"
+    
+    SubClassOf: 
+        OEO_00000419,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: OEO_00000125
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "data processingSoftware is Software used in the context of data processing."^^xsd:string,
+        rdfs:label "data processing software"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: Factsheet
+Class: OEO_00000133
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International organization for Standardization (ISO).
+source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
+        rdfs:label "DOI"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000028>
+    
+    
+Class: OEO_00000135
+
+    Annotations: 
+        rdfs:label "ecological"
+    
+    SubClassOf: 
+        OEO_00000427
+    
+    
+Class: OEO_00000137
+
+    Annotations: 
+        rdfs:label "economical"
+    
+    SubClassOf: 
+        OEO_00000427
+    
+    
+Class: OEO_00000149
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
+        rdfs:label "empirical dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        OEO_00000403
+    
+    
+Class: OEO_00000161
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimizer is a software external to a model that computes an optimization."^^xsd:string,
+        rdfs:label "external optimizer"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000162
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
-        rdfs:comment "this entity is general and not specific to the OEP factsheets."
+        rdfs:comment "this entity is general and not specific to the OEP factsheets.",
+        rdfs:label "factsheet"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: FixedOperationCost
-
-    SubClassOf: 
-        Cost
-    
-    
-Class: FrameworkFactsheet
+Class: OEO_00000167
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FrameworkFactsheet is a Factsheet that contains information about a software framework."^^xsd:string
+        rdfs:label "fixed operation cost"
     
     SubClassOf: 
-        Factsheet
+        OEO_00000112
     
     
-Class: FuelPrice
-
-    SubClassOf: 
-        Cost
-    
-    
-Class: Funding
-
-    SubClassOf: 
-        SoftwareMaintenance
-    
-    
-Class: GUI
+Class: OEO_00000172
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical User Interface)  is an Interface allowing Users to communicate with a Software application through a graphical window."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
+        rdfs:label "framework factsheet"
     
     SubClassOf: 
-        Interface
+        OEO_00000162
+    
+    
+Class: OEO_00000176
+
+    Annotations: 
+        rdfs:label "fuel price"
+    
+    SubClassOf: 
+        OEO_00000112
+    
+    
+Class: OEO_00000177
+
+    Annotations: 
+        rdfs:label "funding"
+    
+    SubClassOf: 
+        OEO_00000383
+    
+    
+Class: OEO_00000201
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid model is a model is about the electricity grid."^^xsd:string,
+        rdfs:label "grid model"
+    
+    SubClassOf: 
+        OEO_00000381
+    
+    
+Class: OEO_00000202
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is an interface allowing users to communicate with a Software application through a graphical window."^^xsd:string,
+        rdfs:label "GUI"
+    
+    SubClassOf: 
+        OEO_00000239
     
     DisjointWith: 
-        API
+        OEO_00000059
     
     
-Class: GridModel
+Class: OEO_00000228
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GridModel is a Model is about the ElectricityGrid."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help Users install a Software."^^xsd:string,
+        rdfs:label "installation guide"
     
     SubClassOf: 
-        SoftwareElement
+        OEO_00000380
     
     
-Class: InstallationGuide
+Class: OEO_00000239
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An InstallationGuide is a Documentation intended to help Users install a Software."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An interface is a software element that enables an agent to interact with a software."^^xsd:string,
+        rdfs:label "interface"
     
     SubClassOf: 
-        SoftwareDocumentation
+        OEO_00000381
     
     
-Class: Interface
+Class: OEO_00000241
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An Interface is a SoftwareElement that enables an Agent to interact with a software."^^xsd:string
+        rdfs:label "investment cost"
     
     SubClassOf: 
-        SoftwareElement
+        OEO_00000112
     
     
-Class: InvestmentCost
-
-    SubClassOf: 
-        Cost
-    
-    
-Class: License
+Class: OEO_00000249
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A License is a SoftwareDescriptor that determines the official permissions for using the software."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A license is a software descriptor that determines the official permissions for using the software."^^xsd:string,
+        rdfs:label "license"
     
     SubClassOf: 
-        SoftwareDescriptor
+        OEO_00000378
     
     
-Class: Logo
-
-    SubClassOf: 
-        CorporateIdentity
-    
-    
-Class: MarketModel
+Class: OEO_00000261
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A MarketModel is a Model is about the EnergyMarket."^^xsd:string
+        rdfs:label "logo"
     
     SubClassOf: 
-        Model
+        OEO_00000111
     
     
-Class: MathematicalConcept
+Class: OEO_00000264
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market model is a model is about the EnergyMarket."^^xsd:string,
+        rdfs:label "market model"
+    
+    SubClassOf: 
+        OEO_00000274
+    
+    
+Class: OEO_00000265
+
+    Annotations: 
+        rdfs:label "mathematical concept"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: Maximization
+Class: OEO_00000268
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Minimization is a ModelFunction that minimizes some Variable of a Model."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "minimization is a modelFunction that minimizes some variable of a model."^^xsd:string,
+        rdfs:label "maximization"
     
     SubClassOf: 
-        ModelFunction
+        OEO_00000278
     
     
-Class: MethodicalFocus
+Class: OEO_00000270
 
+    Annotations: 
+        rdfs:label "methodical focus"
+    
     SubClassOf: 
-        ContentDescriptor
+        OEO_00000108
     
     
-Class: Minimization
+Class: OEO_00000272
 
+    Annotations: 
+        rdfs:label "minimization"
+    
     SubClassOf: 
-        ModelFunction
+        OEO_00000278
     
     
-Class: Model
+Class: OEO_00000274
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing the behavior of a system using an idealized representation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287",
+        rdfs:label "model"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SoftwareElement
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000381
     
     
-Class: ModelCalculation
+Class: OEO_00000275
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a transformation using at least one model."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a transformation using at least one model."@en,
+        rdfs:label "model calculation"
     
     SubClassOf: 
-        Transformation,
-        has_tool some Model
+        OEO_00000419,
+        has_tool some OEO_00000274
     
     
-Class: ModelComponent
+Class: OEO_00000276
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ModelComponent is a generically dependent continuant that is part of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Model element",
-        rdfs:label "Model component"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
+        rdfs:label "model component"
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000050> some Model
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000274
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: ModelFactsheet
+Class: OEO_00000277
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ModelFactsheet is a Factsheet that contains information about a model."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a factsheet that contains information about a model."^^xsd:string,
+        rdfs:label "model factsheet"
     
     SubClassOf: 
-        Factsheet
+        OEO_00000162
     
     
-Class: ModelFunction
+Class: OEO_00000278
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "The function that calculates the costs of the energy system in a simulation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model function is a model component that is a function."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model function is a model component that is a function."@en,
+        rdfs:label "model function"
     
     SubClassOf: 
-        Model
+        OEO_00000274
     
     
-Class: ModelingSoftware
+Class: OEO_00000279
 
+    Annotations: 
+        rdfs:label "modeling software"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: Modus
+Class: OEO_00000281
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
+        rdfs:label "modus"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: ObjectiveFunction
+Class: OEO_00000304
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ObjectiveFunction is an information content entity stating the function that should be maximised or minimised to solve the problem."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve the problem."^^xsd:string,
+        rdfs:label "objective function"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: OpenSource
+Class: OEO_00000312
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "OpenSource is a SoftwareDescriptor labeling software whose source code is available online for free and can be modified or redistributed."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labeling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
+        rdfs:label "open source"
     
     SubClassOf: 
-        SoftwareDescriptor
+        OEO_00000378
     
     DisjointWith: 
-        DataFormat
+        OEO_00000120
     
     
-Class: Optimization
+Class: OEO_00000313
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
+        rdfs:label "optimization"
     
     SubClassOf: 
-        ModelCalculation
+        OEO_00000275
     
     DisjointWith: 
-        Simulation
+        OEO_00000370
     
     
-Class: OptimizationModel
+Class: OEO_00000314
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization model is a model that optimizes a target function."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization model is a model that optimizes a target function."@en,
+        rdfs:label "optimization model"
     
     SubClassOf: 
-        Model
+        OEO_00000274
     
     
-Class: Plotting
+Class: OEO_00000327
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is DataProcessing where data is visualised in form of a diagram."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
+        rdfs:label "plotting"
     
     SubClassOf: 
-        DataProcessing
+        OEO_00000124
     
     
-Class: PoliticalAssumption
+Class: OEO_00000328
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
+        rdfs:label "political assumption"
     
     SubClassOf: 
-        Assumption
+        OEO_00000063
     
     
-Class: PrimaryOutputs
+Class: OEO_00000336
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PrimaryOutputs is a ContentDescriptor stating the main outputs of the content."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "primary outputs is a content descriptor stating the main outputs of the content."^^xsd:string,
+        rdfs:label "primary outputs"
     
     SubClassOf: 
-        ContentDescriptor
+        OEO_00000108
     
     
-Class: PrimaryPurpose
+Class: OEO_00000337
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PrimaryPurpose is a ContentDescriptor stating the main purpose of a content."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary purpose is a content descriptor stating the main purpose of a content."^^xsd:string,
+        rdfs:label "primary purpose"
     
     SubClassOf: 
-        ContentDescriptor
+        OEO_00000108
     
     
-Class: Private
+Class: OEO_00000338
 
+    Annotations: 
+        rdfs:label "private"
+    
     SubClassOf: 
-        Funding
+        OEO_00000177
     
     
-Class: ProgramParameter
+Class: OEO_00000339
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
+        rdfs:label "program parameter"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: Project
-
-    SubClassOf: 
-        Reference
-    
-    
-Class: Public
-
-    SubClassOf: 
-        Funding
-    
-    
-Class: Reference
+Class: OEO_00000340
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string
+        rdfs:label "project"
+    
+    SubClassOf: 
+        OEO_00000353
+    
+    
+Class: OEO_00000342
+
+    Annotations: 
+        rdfs:label "public"
+    
+    SubClassOf: 
+        OEO_00000177
+    
+    
+Class: OEO_00000353
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
+        rdfs:label "reference"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: Robustness
+Class: OEO_00000360
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Robustness is Validation stating how secure sth is against changes."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "robustness is validation stating how secure sth is against changes."^^xsd:string,
+        rdfs:label "robustness"
     
     SubClassOf: 
-        Validation
+        OEO_00000434
     
     
-Class: Scenario
+Class: OEO_00000364
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "(WIP) A scenario is a collection of assumptions about the energy system.
-There is not yet a consens about the definition."@en
+There is not yet a consens about the definition."@en,
+        rdfs:label "scenario"
     
     SubClassOf: 
-        SoftwareElement
+        OEO_00000381
     
     
-Class: ScenarioFactsheet
+Class: OEO_00000365
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ScenarioFactsheet is a Factsheet that contains information about a Scenario."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
+        rdfs:label "scenario factsheet"
     
     SubClassOf: 
-        Factsheet
+        OEO_00000162
     
     
-Class: Simulation
+Class: OEO_00000370
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behavior from the real world."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behavior from the real world."@en,
+        rdfs:label "simulation"
     
     SubClassOf: 
-        ModelCalculation
+        OEO_00000275
     
     DisjointWith: 
-        Optimization
+        OEO_00000313
     
     
-Class: SimulationModel
+Class: OEO_00000371
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simultaion model is a model that simulates the behaviour of a system without a target function."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simultaion model is a model that simulates the behaviour of a system without a target function."@en,
+        rdfs:label "simulation model"
     
     SubClassOf: 
-        Model
+        OEO_00000274
     
     
-Class: SingleNodeModel
+Class: OEO_00000372
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SingleNodeModel is a GridModel where a region is represented as a single node."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a grid model where a region is represented as a single node."^^xsd:string,
+        rdfs:label "single node model"
     
     SubClassOf: 
-        GridModel
+        OEO_00000201
     
     
-Class: Social
-
-    SubClassOf: 
-        Type
-    
-    
-Class: SoftwareDescriptor
+Class: OEO_00000375
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareDescriptor is an information content entity that contains additional information about the software."^^xsd:string
+        rdfs:label "social"
+    
+    SubClassOf: 
+        OEO_00000427
+    
+    
+Class: OEO_00000378
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
+        rdfs:label "software descriptor"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: SoftwareDocumentation
+Class: OEO_00000380
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
-        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program."
+        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
+        rdfs:label "software documentation"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: SoftwareElement
+Class: OEO_00000381
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a part of a model."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a part of a model."@en,
+        rdfs:label "software element"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: SoftwareFramework
+Class: OEO_00000382
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareFramework is a Software that is generic and can be adapted to a specific application.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
+        rdfs:label "software framework"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: SoftwareMaintenance
+Class: OEO_00000383
 
+    Annotations: 
+        rdfs:label "software maintenance"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: Solver
+Class: OEO_00000392
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Solver is a SoftwareElement that solves a mathematical problem."^^xsd:string
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software element that solves a mathematical problem."^^xsd:string,
+        rdfs:label "solver"
     
     SubClassOf: 
-        SoftwareElement
+        OEO_00000381
     
     
-Class: Study
+Class: OEO_00000400
 
+    Annotations: 
+        rdfs:label "study"
+    
     SubClassOf: 
-        Reference
+        OEO_00000353
     
     
-Class: SynthethicDataset
+Class: OEO_00000403
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealized model year."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
+        rdfs:label "synthethic dataset"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
     
     DisjointWith: 
-        EmpiricalDataset
+        OEO_00000149
     
     
-Class: Technical
-
-    SubClassOf: 
-        Type
-    
-    
-Class: TestDataset
+Class: OEO_00000406
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A TestDataset is a data set used for testing."^^xsd:string
+        rdfs:label "technical"
+    
+    SubClassOf: 
+        OEO_00000427
+    
+    
+Class: OEO_00000408
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
+        rdfs:label "test dataset"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
-Class: TimeHorizon
-
-    SubClassOf: 
-        Variable
-    
-    
-Class: TimeSeries
-
-    SubClassOf: 
-        Variable
-    
-    
-Class: TimeStep
-
-    SubClassOf: 
-        Variable
-    
-    
-Class: Transformation
+Class: OEO_00000413
 
     Annotations: 
-        definition "A transformation is a process that transforms one or more inputs into at least one output."@en
+        rdfs:label "time horizon"
+    
+    SubClassOf: 
+        OEO_00000435
+    
+    
+Class: OEO_00000414
+
+    Annotations: 
+        rdfs:label "time series"
+    
+    SubClassOf: 
+        OEO_00000435
+    
+    
+Class: OEO_00000415
+
+    Annotations: 
+        rdfs:label "time step"
+    
+    SubClassOf: 
+        OEO_00000435
+    
+    
+Class: OEO_00000419
+
+    Annotations: 
+        definition "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        rdfs:label "transformation"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: TransshipmentModel
-
-    SubClassOf: 
-        GridModel
-    
-    
-Class: Type
-
-    SubClassOf: 
-        DataDescriptor
-    
-    
-Class: Uncertainty
-
-    SubClassOf: 
-        Validation
-    
-    
-Class: UserDocumentation
+Class: OEO_00000423
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A UserDocumentation is a Documentation intended to assist Users in using the software."^^xsd:string
+        rdfs:label "transshipment model"
     
     SubClassOf: 
-        SoftwareDocumentation
+        OEO_00000201
     
     
-Class: Validation
+Class: OEO_00000427
 
+    Annotations: 
+        rdfs:label "type"
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    
+Class: OEO_00000428
+
+    Annotations: 
+        rdfs:label "uncertainty"
+    
+    SubClassOf: 
+        OEO_00000434
+    
+    
+Class: OEO_00000432
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist Users in using the software."^^xsd:string,
+        rdfs:label "user documentation"
+    
+    SubClassOf: 
+        OEO_00000380
+    
+    
+Class: OEO_00000434
+
+    Annotations: 
+        rdfs:label "validation"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: Variable
+Class: OEO_00000435
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
+        rdfs:label "variable"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: VariableOperationCost
-
-    SubClassOf: 
-        Cost
-    
-    
-Class: Website
-
-    SubClassOf: 
-        CorporateIdentity
-    
-    
-Individual: <http://openenergy-platform.org/ontology/oeo/C++>
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: <http://openenergy-platform.org/ontology/oeo/MS_Excel/VBA>
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: <http://openenergy-platform.org/ontology/oeo/Spatial(GIS)>
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: Accounting
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: Active
-
-    Types: 
-        Modus
-    
-    
-Individual: AgentBasedProgramming
-
-    Types: 
-        MathematicalConcept
-    
-    
-Individual: BackCasting
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: BottomUp
-
-    Types: 
-        AnalyticalApproach
-    
-    
-Individual: CPLEX
-
-    Types: 
-        Solver
-    
-    
-Individual: CSV
-
-    Types: 
-        DataFormat
-    
-    
-Individual: Coin-Or_CBC
-
-    Types: 
-        Solver
-    
-    
-Individual: DataFrame
-
-    Types: 
-        DataFormat
-    
-    
-Individual: Dict
-
-    Types: 
-        DataFormat
-    
-    
-Individual: DynamicProgramming
-
-    Types: 
-        MathematicalConcept
-    
-    
-Individual: Econometric
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: EconomicEquilibrium
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: False
-
-    Types: 
-        BooleanVariable
-    
-    
-Individual: Fortran
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: FuzzyLogic
-
-    Types: 
-        MathematicalConcept
-    
-    
-Individual: GAMS
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: GLPK
-
-    Types: 
-        Solver
-    
-    
-Individual: GNU
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Gurobi
-
-    Types: 
-        Solver
-    
-    
-Individual: Hybrid
-
-    Types: 
-        AnalyticalApproach
-    
-    
-Individual: Inactive
-
-    Types: 
-        Modus
-    
-    
-Individual: Java
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: LinearProgramming
-
-    Types: 
-        MathematicalConcept
-    
-    
-Individual: MOSEK
-
-    Types: 
-        Solver
-    
-    
-Individual: MS_Excel
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Macro-Economic
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: MathProg
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Matlab
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: MixedIntegerLinearProgramming
-
-    Types: 
-        MathematicalConcept
-    
-    
-Individual: Modellca
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: MonteCarlo
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: MultiCriteria
-
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: Optimization
+Class: OEO_00000436
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en
+        rdfs:label "variable operation cost"
     
-    Types: 
-        MethodicalFocus
-    
-    
-Individual: Other
-
-    Types: 
-        AnalyticalApproach
+    SubClassOf: 
+        OEO_00000112
     
     
-Individual: PHP
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Passive
-
-    Types: 
-        Modus
-    
-    
-Individual: Python
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: R
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Ruby
-
-    Types: 
-        SoftwareFramework
-    
-    
-Individual: Simulation
+Class: OEO_00000445
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behavior from the real world."@en
+        rdfs:label "website"
     
-    Types: 
-        MethodicalFocus
+    SubClassOf: 
+        OEO_00000111
     
     
-Individual: Spreadsheet
+Individual: OEO_00000046
 
+    Annotations: 
+        rdfs:label "accounting"
+    
     Types: 
-        MethodicalFocus
+        OEO_00000270
     
     
-Individual: Stochastic
+Individual: OEO_00000049
 
+    Annotations: 
+        rdfs:label "active"
+    
     Types: 
-        MethodicalFocus
+        OEO_00000281
     
     
-Individual: Toolbox
+Individual: OEO_00000052
 
+    Annotations: 
+        rdfs:label "agent based programming"
+    
     Types: 
-        MethodicalFocus
+        OEO_00000265
     
     
-Individual: TopDown
+Individual: OEO_00000067
 
+    Annotations: 
+        rdfs:label "back casting"
+    
     Types: 
-        AnalyticalApproach
+        OEO_00000270
     
     
-Individual: True
+Individual: OEO_00000079
 
+    Annotations: 
+        rdfs:label "bottom up"
+    
     Types: 
-        BooleanVariable
+        OEO_00000057
     
     
-Individual: Txt
+Individual: OEO_00000081
 
+    Annotations: 
+        rdfs:label "c++"
+    
     Types: 
-        DataFormat
+        OEO_00000382
     
     
-Individual: XLSX
+Individual: OEO_00000092
 
+    Annotations: 
+        rdfs:label "coin- or_cbc"
+    
     Types: 
-        DataFormat
+        OEO_00000392
     
     
-Individual: XML
+Individual: OEO_00000114
 
+    Annotations: 
+        rdfs:label "cplex"
+    
     Types: 
-        DataFormat
+        OEO_00000392
     
     
-Individual: gdx
+Individual: OEO_00000116
 
+    Annotations: 
+        rdfs:label "csv"
+    
     Types: 
-        DataFormat
+        OEO_00000120
+    
+    
+Individual: OEO_00000121
+
+    Annotations: 
+        rdfs:label "data frame"
+    
+    Types: 
+        OEO_00000120
+    
+    
+Individual: OEO_00000130
+
+    Annotations: 
+        rdfs:label "dict"
+    
+    Types: 
+        OEO_00000120
+    
+    
+Individual: OEO_00000134
+
+    Annotations: 
+        rdfs:label "dynamic programming"
+    
+    Types: 
+        OEO_00000265
+    
+    
+Individual: OEO_00000136
+
+    Annotations: 
+        rdfs:label "econometric"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000138
+
+    Annotations: 
+        rdfs:label "economic equilibrium"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000163
+
+    Annotations: 
+        rdfs:label "false"
+    
+    Types: 
+        OEO_00000078
+    
+    
+Individual: OEO_00000170
+
+    Annotations: 
+        rdfs:label "fortran"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000179
+
+    Annotations: 
+        rdfs:label "fuzzy logic"
+    
+    Types: 
+        OEO_00000265
+    
+    
+Individual: OEO_00000180
+
+    Annotations: 
+        rdfs:label "gams"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000187
+
+    Annotations: 
+        rdfs:label "gdx"
+    
+    Types: 
+        OEO_00000120
+    
+    
+Individual: OEO_00000195
+
+    Annotations: 
+        rdfs:label "glpk"
+    
+    Types: 
+        OEO_00000392
+    
+    
+Individual: OEO_00000196
+
+    Annotations: 
+        rdfs:label "gnu"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000203
+
+    Annotations: 
+        rdfs:label "gurobi"
+    
+    Types: 
+        OEO_00000392
+    
+    
+Individual: OEO_00000215
+
+    Annotations: 
+        rdfs:label "hybrid"
+    
+    Types: 
+        OEO_00000057
+    
+    
+Individual: OEO_00000225
+
+    Annotations: 
+        rdfs:label "inactive"
+    
+    Types: 
+        OEO_00000281
+    
+    
+Individual: OEO_00000244
+
+    Annotations: 
+        rdfs:label "java"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000254
+
+    Annotations: 
+        rdfs:label "linear programming"
+    
+    Types: 
+        OEO_00000265
+    
+    
+Individual: OEO_00000262
+
+    Annotations: 
+        rdfs:label "macro- economic"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000266
+
+    Annotations: 
+        rdfs:label "math prog"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000267
+
+    Annotations: 
+        rdfs:label "matlab"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000273
+
+    Annotations: 
+        rdfs:label "mixed integer linear programming"
+    
+    Types: 
+        OEO_00000265
+    
+    
+Individual: OEO_00000280
+
+    Annotations: 
+        rdfs:label "modellca"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000284
+
+    Annotations: 
+        rdfs:label "monte carlo"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000285
+
+    Annotations: 
+        rdfs:label "mosek"
+    
+    Types: 
+        OEO_00000392
+    
+    
+Individual: OEO_00000287
+
+    Annotations: 
+        rdfs:label "ms_ excel"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000288
+
+    Annotations: 
+        rdfs:label "vba"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000289
+
+    Annotations: 
+        rdfs:label "multi criteria"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000313
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
+        rdfs:label "optimization"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000317
+
+    Annotations: 
+        rdfs:label "other"
+    
+    Types: 
+        OEO_00000057
+    
+    
+Individual: OEO_00000319
+
+    Annotations: 
+        rdfs:label "passive"
+    
+    Types: 
+        OEO_00000281
+    
+    
+Individual: OEO_00000325
+
+    Annotations: 
+        rdfs:label "php"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000349
+
+    Annotations: 
+        rdfs:label "python"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000351
+
+    Annotations: 
+        rdfs:label "r"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000362
+
+    Annotations: 
+        rdfs:label "ruby"
+    
+    Types: 
+        OEO_00000382
+    
+    
+Individual: OEO_00000370
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behavior from the real world."@en,
+        rdfs:label "simulation"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000393
+
+    Annotations: 
+        rdfs:label "spatial(gis)"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000394
+
+    Annotations: 
+        rdfs:label "spreadsheet"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000397
+
+    Annotations: 
+        rdfs:label "stochastic"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000416
+
+    Annotations: 
+        rdfs:label "toolbox"
+    
+    Types: 
+        OEO_00000270
+    
+    
+Individual: OEO_00000417
+
+    Annotations: 
+        rdfs:label "top down"
+    
+    Types: 
+        OEO_00000057
+    
+    
+Individual: OEO_00000424
+
+    Annotations: 
+        rdfs:label "true"
+    
+    Types: 
+        OEO_00000078
+    
+    
+Individual: OEO_00000426
+
+    Annotations: 
+        rdfs:label "txt"
+    
+    Types: 
+        OEO_00000120
+    
+    
+Individual: OEO_00000450
+
+    Annotations: 
+        rdfs:label "xlsx"
+    
+    Types: 
+        OEO_00000120
+    
+    
+Individual: OEO_00000451
+
+    Annotations: 
+        rdfs:label "xml"
+    
+    Types: 
+        OEO_00000120
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1649,7 +1649,7 @@ Individual: OEO_00000254
 Individual: OEO_00000262
 
     Annotations: 
-        rdfs:label "macro-economic"
+        rdfs:label "macroeconomic"
     
     Types: 
         OEO_00000270

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1218,7 +1218,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000101
 
     Annotations: 
-        rdfs:label "commerical demand"
+        rdfs:label "commercial demand"
     
     SubClassOf: 
         OEO_00000127
@@ -1411,7 +1411,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
 Class: OEO_00000144
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is a part of an electrical grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a part of an electrical grid."@en,
         rdfs:label "electricity grid component"
     
     SubClassOf: 
@@ -1705,7 +1705,7 @@ Class: OEO_00000185
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustiuon turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustion turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
         rdfs:label "gas turbine"
@@ -2176,8 +2176,7 @@ Class: OEO_00000245
         <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "KeroseneTypeJetFuel"@en,
-        rdfs:label "jet fuel",
-        rdfs:label "jet fuel"@en
+        rdfs:label "jet fuel"
     
     SubClassOf: 
         OEO_00000246
@@ -2509,7 +2508,7 @@ Class: OEO_00000299
 Class: OEO_00000300
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear power is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
@@ -2591,7 +2590,7 @@ Class: OEO_00000308
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
-        rdfs:label "off shore wind farm"
+        rdfs:label "offshore wind farm"
     
     SubClassOf: 
         OEO_00000447
@@ -2632,7 +2631,7 @@ Class: OEO_00000311
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
-        rdfs:label "on shore wind farm"
+        rdfs:label "onshore wind farm"
     
     SubClassOf: 
         OEO_00000447
@@ -2789,7 +2788,7 @@ Class: OEO_00000335
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
-        rdfs:label "power to gas system"
+        rdfs:label "power-to-gas system"
     
     SubClassOf: 
         OEO_00000159

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1669,7 +1669,7 @@ Class: OEO_00000178
 Class: OEO_00000181
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an OilAndPetroleumProduct that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil-and-petroleum-product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "gas diesel oil"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -19,8 +19,8 @@ Import: <http://purl.obolibrary.org/obo/uo/releases/2019-04-01/uo.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production."
+    <http://purl.org/dc/terms/title> "Open energy Ontology (Physical module)",
+    rdfs:comment "The Open energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production."
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -91,13 +91,13 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 ObjectProperty: applies_technology
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an ArtificialObject to apply to a Technology."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology."
     
     Domain: 
-        ArtificialObject
+        OEO_00000061
     
     Range: 
-        Technology
+        OEO_00000407
     
     InverseOf: 
         is_applied_to_object
@@ -118,7 +118,7 @@ ObjectProperty: covers_energycarrier
         covers
     
     Range: 
-        EnergyCarrierDisposition
+        OEO_00000151
     
     
 ObjectProperty: has_globalwarmingpotential
@@ -127,10 +127,10 @@ ObjectProperty: has_globalwarmingpotential
         owl:topObjectProperty
     
     Domain: 
-        GreenhouseEffectDisposition
+        OEO_00000198
     
     Range: 
-        GlobalWarmingPotential
+        OEO_00000194
     
     
 ObjectProperty: has_normal_state_of_matter
@@ -165,7 +165,7 @@ ObjectProperty: has_physical_input
         Asymmetric
     
     Range: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
     
     
 ObjectProperty: has_physical_output
@@ -183,10 +183,10 @@ ObjectProperty: has_pollutant
         owl:topObjectProperty
     
     Domain: 
-        Emission
+        OEO_00000147
     
     Range: 
-        Pollution
+        OEO_00000330
     
     
 ObjectProperty: has_sink
@@ -216,13 +216,13 @@ ObjectProperty: has_state_of_matter
 ObjectProperty: is_applied_to_object
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an ArtificialObject."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object."
     
     Domain: 
-        Technology
+        OEO_00000407
     
     Range: 
-        ArtificialObject
+        OEO_00000061
     
     InverseOf: 
         applies_technology
@@ -265,463 +265,6 @@ ObjectProperty: uses
     
     InverseOf: 
         is_used_by
-    
-    
-Class: <http://openenergy-platform.org/ontology/FuelRole>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerUnit is a PowerGeneratingUnit using biofuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some Biofuel
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BioGasPowerUnit is a BiofuelPowerUnit using biogas as fuel."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>,
-        uses some Biogas
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/BiogasPowerplant>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiogasPowerplant is a BiofuelPowerplant having an aggregate of BiogasPowerUnits as its PowerGeneratingUnits."
-    
-    SubClassOf: 
-        BiofuelPowerplant
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/CarbonDioxide>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It is a gas that occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/ChemicalEnergy>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214"
-    
-    SubClassOf: 
-        Energy
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerUnit is a PowerGeneratingUnit using coal as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some Coal
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectricHeatPump>
-
-    Annotations: 
-        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy."
-    
-    SubClassOf: 
-        HeatPump
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/ElectroMotiveGenerator>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ElectroMotiveGenerator is a Generator that converts kinetic energy into electric energy."
-    
-    SubClassOf: 
-        Generator
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "formerly called EnergyTransformer"
-    
-    SubClassOf: 
-        ArtificialObject
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "EnergyStorage is a function of an ArtificialObject that has been engineered to contain energy for conversion as usable energy later.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
-    
-    SubClassOf: 
-        EnergyCarrierDisposition,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FluorinatedGreenhouseGas>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FluorinatedGreenhouseGas is a GreenhouseGas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin."
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo-physical/NitrogenTrifluoride> or <http://openenergy-platform.org/ontology/oeo-physical/SulphurHexafluoride> or Hydrofluorocarbon or Perfluorocarbon
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilCombustionFuel>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilCombustionFuel is a CombustionFuel with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic."
-    
-    EquivalentTo: 
-        CombustionFuel
-         and (has_origin value fossil)
-    
-    SubClassOf: 
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FossilPortionOfMatter>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FossilPortionOfMatter is a PortionOfMatter with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic."
-    
-    EquivalentTo: 
-        PortionOfMatter
-         and (has_origin value fossil)
-    
-    SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/FuelCell>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FuelCell is a Generator that converts chemical energy into electricity using redox reactions."
-    
-    SubClassOf: 
-        Generator
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasFiredPowerUnit is a PowerGeneratingUnit using gas as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some 
-            (Fuel
-             and (has_normal_state_of_matter value gaseous))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerGeneratingUnit is a PowerUnit using geothermal heat."
-    
-    SubClassOf: 
-        PowerGeneratingUnit
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/GreenhouseGas>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GreenhouseGas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
-    
-    EquivalentTo: 
-        PortionOfMatter
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition)
-    
-    SubClassOf: 
-        PortionOfMatter
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HardCoalPowerUnit is a CoalPowerUnit using HardCoal as Fuel."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
-        uses some HardCoal
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydroPowerUnit is a PowerGeneratingUnit using the potential and/or kinetic energy of water.",
-        rdfs:comment "will be discussed later"
-    
-    SubClassOf: 
-        PowerGeneratingUnit
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydrogenPowerUnit is a PowerGeneratingUnit using hydrogen as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some Hydrogen
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A LignitePowerUnit is a CoalPowerUnit using Lignite as Fuel."
-    
-    EquivalentTo: 
-        uses some Lignite
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/Methane>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It is a gas that occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be usede as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NitrogenTrifluoride>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NitrousOxide>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It is a gas that occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000091> some GreenhouseEffectDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
-    
-    SubClassOf: 
-        EnergyCarrierDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerUnit is a PowerGeneratingUnit using nuclear fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some NuclearFuel
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A OilPowerUnit is a PowerGeneratingUnit using oil as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some OilAndPetroleumProducts
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/PVCell>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVCell is a Generator that converts light into electrical energy."
-    
-    SubClassOf: 
-        Generator
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Powerplant is an aggregate of PowerGeneratingUnits that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
-    
-    SubClassOf: 
-        ArtificialObject
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A RenewableFuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel."
-    
-    EquivalentTo: 
-        Fuel
-         and (has_origin value renewable)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerUnit is a PowerGeneratingUnit using solar power."
-    
-    SubClassOf: 
-        PowerGeneratingUnit
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerUnit is a SolarPowerUnit that has SolarThermalCollectors as parts."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SolarThermalCollector
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerUnit is a BiomassPowerUnit using solid biomass as fuel."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>,
-        uses some PortionOfSolidBiomass
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SolidBiomassPowerplant>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolidBiomassPowerplant is a BiomassPowerplant having an aggregate of SolidBiomassPowerUnits as its PowerGeneratingUnits."
-    
-    SubClassOf: 
-        BiofuelPowerplant
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/SulphurHexafluoride>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/ThermalEnergyStorage>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ThermalEnergyStorage is an EnergyStorage that stores thermal energy for later use."
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/Uranium>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a PortionOfMatter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
-    
-    SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>,
-        has_normal_state_of_matter value solid,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerUnit is a PowerGeneratingUnit using waste as fuel."
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        uses some WasteFuel
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteRole is a role of an object aggregate that has been discarded after primary use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/Wind>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
-
-    Annotations: 
-        definition "A WindEnergyConvertingUnit is a PowerGeneratingUnit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"
-    
-    SubClassOf: 
-        PowerGeneratingUnit,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Turbine
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -784,7 +327,506 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Class: ACLine
+Class: OEO_00000001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
+        rdfs:label "biofuel power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000072
+    
+    
+Class: OEO_00000004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
+        rdfs:label "biogas powerplant"
+    
+    SubClassOf: 
+        OEO_00000073
+    
+    
+Class: OEO_00000005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
+        rdfs:label "biogas power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        uses some OEO_00000074
+    
+    
+Class: OEO_00000006
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It is a gas that occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        rdfs:label "carbon dioxide"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198
+    
+    
+Class: OEO_00000007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
+        rdfs:label "chemical energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        rdfs:label "coal power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000088
+    
+    
+Class: OEO_00000009
+
+    Annotations: 
+        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy.",
+        rdfs:label "electric heat pump"
+    
+    SubClassOf: 
+        OEO_00000212
+    
+    
+Class: OEO_00000010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
+        rdfs:label "electro motive generator"
+    
+    SubClassOf: 
+        OEO_00000188
+    
+    
+Class: OEO_00000011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:comment "formerly called EnergyTransformer",
+        rdfs:label "energy converting device"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage"
+    
+    SubClassOf: 
+        OEO_00000151,
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+Class: OEO_00000013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
+        rdfs:label "fluorinated greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000026 or OEO_00000038 or OEO_00000219 or OEO_00000322
+    
+    SubClassOf: 
+        OEO_00000020
+    
+    
+Class: OEO_00000014
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (has_origin value OEO_00000171)
+    
+    SubClassOf: 
+        has_origin value OEO_00000018
+    
+    
+Class: OEO_00000015
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil portion of matter is a portion of matter with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil portion of matter"
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (has_origin value OEO_00000171)
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin value OEO_00000018
+    
+    
+Class: OEO_00000016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
+        rdfs:label "fuel cell"
+    
+    SubClassOf: 
+        OEO_00000188
+    
+    
+Class: OEO_00000017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
+        rdfs:label "gas fired power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some 
+            (OEO_00000173
+             and (has_normal_state_of_matter value OEO_00000182))
+    
+    
+Class: OEO_00000019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        rdfs:label "geothermal power unit"
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00000021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
+        rdfs:label "hard coal power unit"
+    
+    SubClassOf: 
+        OEO_00000008,
+        uses some OEO_00000204
+    
+    
+Class: OEO_00000022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        rdfs:label "hydrogen power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000220
+    
+    
+Class: OEO_00000023
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit using the potential and/or kinetic energy of water.",
+        rdfs:comment "will be discussed later",
+        rdfs:label "hydro power unit"
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000024
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
+        rdfs:label "lignite power unit"
+    
+    EquivalentTo: 
+        uses some OEO_00000251
+    
+    SubClassOf: 
+        OEO_00000008
+    
+    
+Class: OEO_00000025
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It is a gas that occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be usede as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
+        rdfs:label "methane"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198
+    
+    
+Class: OEO_00000026
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
+        rdfs:label "nitrogen trifluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin value OEO_00000002
+    
+    
+Class: OEO_00000027
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It is a gas that occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        rdfs:label "nitrous oxide"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198
+    
+    
+Class: OEO_00000028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00000029
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        rdfs:label "nuclear power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000302
+    
+    
+Class: OEO_00000030
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
+        rdfs:label "oil power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000309
+    
+    
+Class: OEO_00000031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an aggregate of power generating units that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "powerplant"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV cell is a generator that converts light into electrical energy.",
+        rdfs:label "PV cell"
+    
+    SubClassOf: 
+        OEO_00000188
+    
+    
+Class: OEO_00000033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel.",
+        rdfs:label "renewable fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (has_origin value OEO_00000354)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000034
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
+        rdfs:label "solar power unit"
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000035
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has SolarThermalCollectors as parts.",
+        rdfs:label "solar thermal power unit"
+    
+    SubClassOf: 
+        OEO_00000034,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
+    
+    
+Class: OEO_00000036
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
+        rdfs:label "solid biomass powerplant"
+    
+    SubClassOf: 
+        OEO_00000073
+    
+    
+Class: OEO_00000037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
+        rdfs:label "solid biomass power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        uses some OEO_00000332
+    
+    
+Class: OEO_00000038
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
+        rdfs:label "sulphur hexafluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin value OEO_00000002
+    
+    
+Class: OEO_00000039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        rdfs:label "thermal energy storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00000040
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "uranium"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000018
+    
+    
+Class: OEO_00000041
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        rdfs:label "waste power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000439
+    
+    
+Class: OEO_00000042
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:label "waste role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000043
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000044
+
+    Annotations: 
+        definition "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        rdfs:label "wind energy converting unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000425
+    
+    
+Class: OEO_00000047
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Alternating current high voltage transmission line. Can comprise multiple cables and multiple circuits.
@@ -793,396 +835,459 @@ Generally, flows in the model can not be controlled but are a function of the re
         rdfs:label "AC-Line"@en
     
     SubClassOf: 
-        Line
+        OEO_00000253
     
     
-Class: AdditionalToAddress
-
-    SubClassOf: 
-        Land
-    
-    
-Class: AgriculturalDemand
-
-    SubClassOf: 
-        Demand
-    
-    
-Class: Air
+Class: OEO_00000050
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)"
+        rdfs:label "additional to address"
     
     SubClassOf: 
-        PortionOfMatter,
-        is_used_by some StorageUnit,
-        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition
+        OEO_00000247
     
     
-Class: AirPollution
+Class: OEO_00000053
+
+    Annotations: 
+        rdfs:label "agricultural demand"
+    
+    SubClassOf: 
+        OEO_00000127
+    
+    
+Class: OEO_00000054
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
+        rdfs:label "air"
+    
+    SubClassOf: 
+        OEO_00000331,
+        is_used_by some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
+    
+    
+Class: OEO_00000055
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
+        rdfs:label "air pollution"
     
     SubClassOf: 
-        Pollution
+        OEO_00000330
     
     
-Class: AmbientHeat
+Class: OEO_00000056
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
+        rdfs:label "ambient heat"
     
     SubClassOf: 
-        Heat
+        OEO_00000207
     
     
-Class: Anthracite
+Class: OEO_00000058
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite"
     
     SubClassOf: 
-        HardCoal
+        OEO_00000204
     
     
-Class: Appliance
-
-    SubClassOf: 
-        ResidentialDemand
-    
-    
-Class: ArtificialObject
+Class: OEO_00000060
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ArtificialObject is an object that was deliberately manufactured by humans to address a particular purpose.",
+        rdfs:label "appliance"
+    
+    SubClassOf: 
+        OEO_00000358
+    
+    
+Class: OEO_00000061
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (ArtificialObject definition),
- https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)"
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition),
+ https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)",
+        rdfs:label "artificial object"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
     
     
-Class: AssociatedGas
+Class: OEO_00000062
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "associated gas"
     
     SubClassOf: 
-        NaturalGas
+        OEO_00000292
     
     
-Class: Aviation
-
-    SubClassOf: 
-        TransportDemand
-    
-    
-Class: AviationGasoline
+Class: OEO_00000065
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        rdfs:label "aviation"
     
     SubClassOf: 
-        Gasoline
+        OEO_00000421
     
     
-Class: Battery
+Class: OEO_00000066
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Battery is a device using different chemical or physical reactions to store energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "aviation gasoline"
     
     SubClassOf: 
-        EnergyStorageObject,
-        <http://purl.obolibrary.org/obo/RO_0000085> some BatteryStorage
+        OEO_00000183
     
     
-Class: BatteryElectric
-
-    SubClassOf: 
-        TransportDemand
-    
-    
-Class: BatteryStorage
+Class: OEO_00000068
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is a device using different chemical or physical reactions to store energy."@en,
+        rdfs:label "battery"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
+        OEO_00000159,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
+    
+    
+Class: OEO_00000069
+
+    Annotations: 
+        rdfs:label "battery electric"
+    
+    SubClassOf: 
+        OEO_00000421
+    
+    
+Class: OEO_00000070
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
+        rdfs:label "battery storage"
+    
+    SubClassOf: 
+        OEO_00000012
     
     DisjointWith: 
-        MethanationGasStorage
+        OEO_00000269
     
     
-Class: Biodiesel
+Class: OEO_00000071
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "biodiesel"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value liquid,
-        has_origin value biogenic
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000256,
+        has_origin value OEO_00000076
     
     
-Class: Biofuel
+Class: OEO_00000072
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a fuel that is produced through contemporary biological processes, such as agriculture and anaerobic digestion, rather than a fuel produced by geological processes such as those involved in the formation of fossil fuels, such as coal and petroleum, from prehistoric biological matter.
 
 Biofuels can be derived directly from plants (i.e. energy crops), or indirectly from agricultural, commercial, domestic, and/or industrial wastes.[1] Renewable biofuels generally involve contemporary carbon fixation, such as those that occur in plants or microalgae through the process of photosynthesis. Other renewable biofuels are made through the use or conversion of biomass (referring to recently living organisms, most often referring to plants or plant-derived materials). This biomass can be converted to convenient energy-containing substances in three different ways: thermal conversion, chemical conversion, and biochemical conversion. This biomass conversion can result in fuel in solid, liquid, or gas form. This new biomass can also be used directly for biofuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109",
+        rdfs:label "biofuel"
     
     EquivalentTo: 
-        Fuel
-         and (has_origin value biogenic)
+        OEO_00000173
+         and (has_origin value OEO_00000076)
     
     SubClassOf: 
-        Fuel,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_origin value biogenic,
-        has_origin value renewable
+        OEO_00000173,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_origin value OEO_00000076,
+        has_origin value OEO_00000354
     
     
-Class: BiofuelPowerplant
+Class: OEO_00000073
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A BiofuelPowerplant is a Powerplant having an aggregate of BiofuelPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
+        rdfs:label "biofuel powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/BiofuelPowerUnit>
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000003
     
     
-Class: Biogas
+Class: OEO_00000074
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a Biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
+        rdfs:label "biogas"
     
     SubClassOf: 
-        Biofuel,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_origin value biogenic
+        OEO_00000072,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_origin value OEO_00000076
     
     
-Class: Biogasoline
+Class: OEO_00000075
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bioethanol"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "Biogasoline"@en
+        rdfs:label "biogasoline",
+        rdfs:label "biogasoline"@en
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value liquid,
-        has_origin value biogenic
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000256,
+        has_origin value OEO_00000076
     
     
-Class: BlastFurnaceGas
+Class: OEO_00000077
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "blast furnace gas"
     
     SubClassOf: 
-        ManufacturedCoalBasedGas
+        OEO_00000263
     
     
-Class: Bus
+Class: OEO_00000080
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A node in an electrical network."@en,
-        rdfs:label "Bus"@en
+        rdfs:label "bus"
     
     SubClassOf: 
-        NetworkNode
+        OEO_00000294
     
     
-Class: CarbonDioxideEmission
+Class: OEO_00000082
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission quantity is a quantity that is about carbon dioxide."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission quantity is a quantity that is about carbon dioxide."@en,
+        rdfs:label "carbon dioxide emission"
     
     SubClassOf: 
-        GreenhousegasEmission
+        OEO_00000199
     
     
-Class: Charcoal
+Class: OEO_00000084
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "charcoal"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value solid,
-        has_origin value biogenic
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000076
     
     
-Class: City
+Class: OEO_00000086
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A city is a large human settlement."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A city is a large human settlement."@en,
+        rdfs:label "city"
     
     SubClassOf: 
-        Land
+        OEO_00000247
     
     
-Class: Coal
+Class: OEO_00000088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.Coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:label "coal"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value solid,
-        has_origin value fossil
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000171
     
     
-Class: CoalPowerplant
+Class: OEO_00000089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CoalPowerplant is a Powerplant having an aggregate of CoalPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
+        rdfs:label "coal powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/CoalPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: CokeOvenGas
+Class: OEO_00000093
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coke oven gas"
     
     SubClassOf: 
-        ManufacturedCoalBasedGas
+        OEO_00000263
     
     
-Class: CokingCoal
+Class: OEO_00000094
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "CokingCoal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coking coal"
     
     SubClassOf: 
-        HardCoal
+        OEO_00000204
     
     
-Class: CollieryGas
+Class: OEO_00000096
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
+        rdfs:label "colliery gas"
     
     SubClassOf: 
-        NaturalGas
+        OEO_00000292
     
     
-Class: CombustibleEnergyCarrierDisposition
+Class: OEO_00000097
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"
     
     SubClassOf: 
-        EnergyCarrierDisposition,
-        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition
+        OEO_00000151,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
     
     
-Class: Combustion
+Class: OEO_00000098
 
+    Annotations: 
+        rdfs:label "combustion"
+    
     SubClassOf: 
-        TransportDemand
+        OEO_00000421
     
     
-Class: CombustionFuel
+Class: OEO_00000099
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "combustion fuel"
     
     EquivalentTo: 
-        Fuel
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition)
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
     
     SubClassOf: 
-        Fuel
+        OEO_00000173
     
     
-Class: CommericalDemand
-
-    SubClassOf: 
-        Demand
-    
-    
-Class: CompressedAir
+Class: OEO_00000101
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en
+        rdfs:label "commerical demand"
     
     SubClassOf: 
-        Air
+        OEO_00000127
     
     
-Class: ConsumptionQuantity
+Class: OEO_00000102
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumption quantity is a quantity that describes the amount of consumption of some resource."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        rdfs:label "compressed air"
     
     SubClassOf: 
-        Quantity
+        OEO_00000054
     
     
-Class: Continent
+Class: OEO_00000106
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A continent is a large landmass on the earth."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumption quantity is a quantity that describes the amount of consumption of some resource."@en,
+        rdfs:label "consumption quantity"
     
     SubClassOf: 
-        Land
+        OEO_00000350
     
     
-Class: Country
+Class: OEO_00000109
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A country is a geographic region that is an distinct political entity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A continent is a large landmass on the earth."@en,
+        rdfs:label "continent"
     
     SubClassOf: 
-        Land
+        OEO_00000247
     
     
-Class: CrudeOil
+Class: OEO_00000113
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A country is a geographic region that is an distinct political entity."@en,
+        rdfs:label "country"
+    
+    SubClassOf: 
+        OEO_00000247
+    
+    
+Class: OEO_00000115
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an OilAndPetroleumProduct of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "crude oil"
     
     SubClassOf: 
-        OilAndPetroleumProducts
+        OEO_00000309
     
     
-Class: DCLine
+Class: OEO_00000117
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en,
+        rdfs:label "dammed water"
+    
+    SubClassOf: 
+        OEO_00000441,
+        is_used_by some OEO_00000399
+    
+    
+Class: OEO_00000126
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Transmission system usind high voltage direct current.
@@ -1191,1027 +1296,1119 @@ Genreally, flows in the model can be controlled/optimized."@en,
         rdfs:label "HVDC-Line"@en
     
     SubClassOf: 
-        Line
+        OEO_00000253
     
     
-Class: DammedWater
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en
-    
-    SubClassOf: 
-        Water,
-        is_used_by some StorageUnit
-    
-    
-Class: Demand
+Class: OEO_00000127
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Demand is generally the need for energy, colloquially referred to as energy consumption.
-Source: https://wiki.openmod-initiative.org/wiki/Demand"@en
+Source: https://wiki.openmod-initiative.org/wiki/Demand"@en,
+        rdfs:label "demand"
     
     SubClassOf: 
-        ConsumptionQuantity
+        OEO_00000106
     
     
-Class: DerivedHeat
+Class: OEO_00000129
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Derived heat covers the total heat production in heating plants and in combined heat and power plants. It includes the heat used by the auxiliaries of the installation which use hot fluid (space heating, liquid fuel heating, etc.) And losses in the installation/network heat exchanges. For autoproducing entities (= entities generating electricity and/or heat wholly or partially for their own use as an activity which supports their primary activity) the heat used by the undertaking for its own processes is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en,
+        rdfs:label "derived heat"
     
     EquivalentTo: 
-        DistrictHeat
+        OEO_00000132
     
     SubClassOf: 
-        Heat
+        OEO_00000207
     
     
-Class: DieselFuel
+Class: OEO_00000131
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "DieselFuel"@en
+        rdfs:label "diesel fuel",
+        rdfs:label "diesel fuel"@en
     
     SubClassOf: 
-        GasDieselOil
+        OEO_00000181
     
     
-Class: DistrictHeat
+Class: OEO_00000132
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
+        rdfs:label "district heat"
     
     EquivalentTo: 
-        DerivedHeat
+        OEO_00000129
     
     SubClassOf: 
-        Heat
+        OEO_00000207
     
     
-Class: ElectricVehicle
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle, also called an EV, uses one or more electric motors or traction motors for propulsion. An electric vehicle may be powered through a collector system by electricity from off-vehicle sources, or may be self-contained with a battery, solar panels or an electric generator to convert fuel to electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Electric_vehicle&oldid=906776214"@en
-    
-    SubClassOf: 
-        ArtificialObject
-    
-    
-Class: ElectricalEnergy
+Class: OEO_00000139
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is energy derived from electric potential energy or kinetic energy. [...] This energy is supplied by the combination of electric current and electric potential that is delivered by an electrical circuit"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        rdfs:label "electrical energy"
     
     SubClassOf: 
-        Energy
+        OEO_00000150
     
     
-Class: ElectricalLoad
+Class: OEO_00000140
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical load is an electrical component or portion of a circuit that consumes (active) electric power. This is opposed to a power source, such as a battery or generator, which produces power. In electric power circuits examples of loads are appliances and lights. The term may also refer to the power consumed by a circuit.
 
     Source: https://en.wikipedia.org/wiki/Electrical_load"@en,
-        rdfs:label "ElectricalDemand"@en,
-        rdfs:label "ElectricalLoad"@en
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical load"@en,
+        rdfs:label "electrical demand"@en
     
     SubClassOf: 
-        Demand
+        OEO_00000127
     
     
-Class: ElectricityConsumption
+Class: OEO_00000141
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity consumption quantity is a consumption quantity about electricity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity consumption quantity is a consumption quantity about electricity."@en,
+        rdfs:label "electricity consumption"
     
     SubClassOf: 
-        ConsumptionQuantity
+        OEO_00000106
     
     
-Class: ElectricityExport
+Class: OEO_00000142
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export quantity is a quantity that describes the amount of electricity that is exported from a geographic region."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export quantity is a quantity that describes the amount of electricity that is exported from a geographic region."@en,
+        rdfs:label "electricity export"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: ElectricityGrid
+Class: OEO_00000143
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a grid that distributes electrical energy / electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
+        rdfs:label "electricity grid"
     
     SubClassOf: 
-        Grid,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some ElectricityGridComponent
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144
     
     
-Class: ElectricityGridComponent
+Class: OEO_00000144
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is a part of an electrical grid."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is a part of an electrical grid."@en,
+        rdfs:label "electricity grid component"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some ElectricityGrid
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
     
     
-Class: Emission
+Class: OEO_00000146
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle, also called an EV, uses one or more electric motors or traction motors for propulsion. An electric vehicle may be powered through a collector system by electricity from off-vehicle sources, or may be self-contained with a battery, solar panels or an electric generator to convert fuel to electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Electric_vehicle&oldid=906776214"@en,
+        rdfs:label "electric vehicle"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000147
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "emission"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: EmissionFactor
+Class: OEO_00000148
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission factors assume a linear relation between the intensity of the activity and the emission resulting from this activity:
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission factors assume a linear relation between the intensity of the activity and the emission resulting from this activity:
 
 Emission (pollutant) = Activity * Emission Factor (pollutant)",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Emission_intensity&oldid=881841342"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Emission_intensity&oldid=881841342",
+        rdfs:label "emission factor"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: Energy
+Class: OEO_00000150
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The property of matter and radiation which is manifest as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.lexico.com/en/definition/energy"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.lexico.com/en/definition/energy",
+        rdfs:label "energy"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: EnergyCarrierDisposition
+Class: OEO_00000151
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EnergyCarrierDisposition is a disposition of an object or objectAggregate that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy carrier disposition"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
     
     
-Class: EnergyCarrierQuantity
+Class: OEO_00000152
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier quantity is a quantity about the amount of energy from a certain energy carrier."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier quantity is a quantity about the amount of energy from a certain energy carrier."@en,
+        rdfs:label "energy carrier quantity"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: EnergyConsumption
+Class: OEO_00000153
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption quantity is a consumption quantity about energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption quantity is a consumption quantity about energy."@en,
+        rdfs:label "energy consumption"
     
     SubClassOf: 
-        ConsumptionQuantity
+        OEO_00000106
     
     
-Class: EnergyFromAlternativeFuelsAndPropulsionInTraffic
+Class: OEO_00000154
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from alternative fuels and populsion in traffic quantity is a energy carrier quantity that describes the amount alternative energy carriers are used in the traffic sector."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from alternative fuels and populsion in traffic quantity is a energy carrier quantity that describes the amount alternative energy carriers are used in the traffic sector."@en,
+        rdfs:label "energy from alternative fuels and propulsion in traffic"
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        OEO_00000152
     
     
-Class: EnergyFromBioFuelInTraffic
+Class: OEO_00000155
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from bio fuel in traffic quantity is a energy carrier quantity that describes the amount of bio fuel as energy carrier in traffic."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from bio fuel in traffic quantity is a energy carrier quantity that describes the amount of bio fuel as energy carrier in traffic."@en,
+        rdfs:label "energy from bio fuel in traffic"
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        OEO_00000152
     
     
-Class: EnergyFromElectricityInTraffic
+Class: OEO_00000156
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from electricity in traffic quantity is a energy carrier quantity that describes the amount of electricity used as energy carrier in traffic."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A energy from electricity in traffic quantity is a energy carrier quantity that describes the amount of electricity used as energy carrier in traffic."@en,
+        rdfs:label "energy from electricity in traffic"
     
     SubClassOf: 
-        EnergyCarrierQuantity
+        OEO_00000152
     
     
-Class: EnergyProduction
+Class: OEO_00000157
 
+    Annotations: 
+        rdfs:label "energy production"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: EnergyStorageObject
+Class: OEO_00000159
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EnergyStorageObject is an artificial object that has the function EnergyStorage.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage object"
     
     SubClassOf: 
-        ArtificialObject
+        OEO_00000061
     
     
-Class: FederalState
+Class: OEO_00000164
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A federal state is a geographic region that is a political entity within a country. It is partially self governing."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A federal state is a geographic region that is a political entity within a country. It is partially self governing."@en,
+        rdfs:label "federal state"
     
     SubClassOf: 
-        Land
+        OEO_00000247
     
     
-Class: FieldPhotovoltaicPowerplant
+Class: OEO_00000165
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FieldPhotovoltaicPowerplant (also: solar farm, solar park) is a PhotovoltaicPowerplant that is installed out in the open on the ground."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
+        rdfs:label "field photovoltaic powerplant"
     
     SubClassOf: 
-        PhotovoltaicPowerplant
+        OEO_00000324
     
     DisjointWith: 
-        RooftopPhotovoltaicPowerplant
+        OEO_00000361
     
     
-Class: Fission
+Class: OEO_00000166
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In nuclear physics and nuclear chemistry, nuclear fission is a nuclear reaction or a radioactive decay process in which the nucleus of an atom splits into smaller, lighter nuclei. The fission process often produces free neutrons and gamma photons, and releases a very large amount of energy even by the energetic standards of radioactive decay. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_fission&oldid=905727345"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_fission&oldid=905727345"@en,
+        rdfs:label "fission"
     
     SubClassOf: 
-        NuclearEnergyProduction
+        OEO_00000301
     
     
-Class: Flow
+Class: OEO_00000168
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "the motion of a gas or liquid",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Flow"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Flow",
+        rdfs:label "flow"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     DisjointWith: 
-        Ocean
+        OEO_00000305
     
     
-Class: FlowBattery
+Class: OEO_00000169
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery, or redox flow battery (after reduction–oxidation), is a type of electrochemical cell where chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
+        rdfs:label "flow battery"
     
     SubClassOf: 
-        Battery
+        OEO_00000068
     
     
-Class: Fuel
+Class: OEO_00000173
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel"
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition)
+        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
     
     SubClassOf: 
-        PortionOfMatter
+        OEO_00000331
     
     
-Class: FueledPowerUnit
+Class: OEO_00000174
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerUnit is a PowerGeneratingUnit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled powerplant"
     
     EquivalentTo: 
-        uses some Fuel
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
     
     SubClassOf: 
-        PowerGeneratingUnit
+        OEO_00000031
     
     
-Class: FueledPowerplant
+Class: OEO_00000175
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A FueledPowerplant is a Powerplant that has FueledPowerUnits as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power unit"
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000051> some FueledPowerUnit
+        uses some OEO_00000173
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>
+        OEO_00000334
     
     
-Class: Fusion
+Class: OEO_00000178
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In nuclear chemistry, nuclear fusion is a reaction in which two or more atomic nuclei are combined to form one or more different atomic nuclei and subatomic particles (neutrons or protons). The difference in mass between the reactants and products is manifested as either the release or absorption of energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_fusion&oldid=906947069"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_fusion&oldid=906947069"@en,
+        rdfs:label "fusion"
     
     SubClassOf: 
-        NuclearEnergyProduction
+        OEO_00000301
     
     
-Class: GasDieselOil
+Class: OEO_00000181
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an OilAndPetroleumProduct that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gas diesel oil"
     
     SubClassOf: 
-        OilAndPetroleumProducts,
-        has_normal_state_of_matter value liquid
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
     
     
-Class: GasPowerplant
+Class: OEO_00000183
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GasPowerplant is a Powerplant having an aggregate of GasFiredPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "gasoline (American English) or petrol (British English) is an OilAndPetroleumProduct in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        rdfs:label "gasoline"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GasFiredPowerUnit>
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
     
     
-Class: GasTurbine
+Class: OEO_00000184
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
+        rdfs:label "gas powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000017
+    
+    
+Class: OEO_00000185
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Combustiuon turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "Gas turbine"
+        rdfs:label "gas turbine"
     
     SubClassOf: 
-        Turbine,
-        has_physical_output some Power,
-        has_physical_input only NaturalGas
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000292
     
     
-Class: Gasoline
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an OilAndPetroleumProduct in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640"
-    
-    SubClassOf: 
-        OilAndPetroleumProducts,
-        has_normal_state_of_matter value liquid
-    
-    
-Class: GasworksGas
+Class: OEO_00000186
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
 
 The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gasworks gas"
     
     SubClassOf: 
-        ManufacturedCoalBasedGas
+        OEO_00000263
     
     
-Class: Generator
+Class: OEO_00000188
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "generator"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>,
-        has_physical_output some ElectricalEnergy
+        OEO_00000011,
+        has_physical_output some OEO_00000139
     
     
-Class: GeographicCoordinate
+Class: OEO_00000189
 
+    Annotations: 
+        rdfs:label "geographic coordinate"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Class: GeographicRegion
+Class: OEO_00000190
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic region is a delimited part of the earth."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic region is a delimited part of the earth."@en,
+        rdfs:label "geographic region"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
-Class: GeothermalHeat
+Class: OEO_00000191
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
+        <http://purl.obolibrary.org/obo/IAO_0000115> "energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
 — for electricity generation using dry steam or high enthalpy brine after flashing,
 — directly as heat for district heating, agriculture etc"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "geothermal heat"
     
     SubClassOf: 
-        Heat,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
+        OEO_00000207,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
     
     
-Class: GeothermalPowerplant
+Class: OEO_00000192
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GeothermalPowerplant is a Powerplant having an aggregate of GeothermalPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
+        rdfs:label "geothermal powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/GeothermalPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: GlobalWarmingPotential
+Class: OEO_00000194
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a measure of how much heat a greenhouse gas traps in the atmosphere up to a specific time horizon, relative to carbon dioxide. It compares the amount of heat trapped by a certain mass of the gas in question to the amount of heat trapped by a similar mass of carbon dioxide and is expressed as a factor of carbon dioxide (whose GWP is standardized to 1).
 
 A GWP is calculated over a specific time horizon, commonly 20, 100, or 500 years. User related choices such as the time horizon can greatly affect the numerical values obtained for carbon dioxide equivalents.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Global_warming_potential&oldid=878160191"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Global_warming_potential&oldid=878160191",
+        rdfs:label "global warming potential"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: Graph
+Class: OEO_00000197
 
+    Annotations: 
+        rdfs:label "graph"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000024>
     
     
-Class: GreenhouseEffectDisposition
+Class: OEO_00000198
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse effect disposition"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
     
     
-Class: GreenhousegasEmission
+Class: OEO_00000199
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "GreenhousegasEmission is an Emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas emission"
     
     SubClassOf: 
-        Emission
+        OEO_00000147
     
     
-Class: Grid
+Class: OEO_00000200
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:comment "Synonym: Network"@en
+        rdfs:comment "Synonym: Network"@en,
+        rdfs:label "grid"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
-Class: HardCoal
+Class: OEO_00000204
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "hard coal"
     
     SubClassOf: 
-        Coal
+        OEO_00000088
     
     DisjointWith: 
-        Lignite
+        OEO_00000251
     
     
-Class: HardCoalPowerplant
+Class: OEO_00000205
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HardCoalPowerplant is a CoalPowerplant having an aggregate of HardCoalPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
+        rdfs:label "hard coal powerplant"
     
     SubClassOf: 
-        CoalPowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HardCoalPowerUnit>
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
     
     
-Class: Hardware
+Class: OEO_00000206
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
        The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "hardware"
     
     SubClassOf: 
-        ArtificialObject
+        OEO_00000061
     
     
-Class: Heat
+Class: OEO_00000207
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
        The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "heat"
     
     SubClassOf: 
-        Energy
+        OEO_00000150
     
     
-Class: HeatConsumption
+Class: OEO_00000208
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat consumption quantity is a consumption quantity about heat."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat consumption quantity is a consumption quantity about heat."@en,
+        rdfs:label "heat consumption"
     
     SubClassOf: 
-        ConsumptionQuantity
+        OEO_00000106
     
     
-Class: HeatDemand
+Class: OEO_00000209
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The heat demand describes the needed amount of heat."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The heat demand describes the needed amount of heat."@en,
+        rdfs:label "heat demand"
     
     SubClassOf: 
-        Demand
+        OEO_00000127
     
     
-Class: HeatPump
+Class: OEO_00000210
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en
-    
-    SubClassOf: 
-        Heater
-    
-    
-Class: Heater
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Heater is an energy converting device that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "heater"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>,
-        has_physical_output some Heat
+        OEO_00000011,
+        has_physical_output some OEO_00000207
     
     
-Class: HeatingOil
+Class: OEO_00000211
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "HeatingOil"@en
+        rdfs:label "heating oil",
+        rdfs:label "heating oil"@en
     
     SubClassOf: 
-        GasDieselOil
+        OEO_00000181
     
     
-Class: HydroEnergy
+Class: OEO_00000212
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
+        rdfs:label "heat pump"
+    
+    SubClassOf: 
+        OEO_00000210
+    
+    
+Class: OEO_00000216
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "hydroelectricity"
+    
+    SubClassOf: 
+        OEO_00000218
+    
+    
+Class: OEO_00000217
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydroelectric powerplant uses water to generate electricity."@en,
+        rdfs:label "hydroelectric powerplant"
+    
+    SubClassOf: 
+        OEO_00000224,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442
+    
+    
+Class: OEO_00000218
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "hydro energy"
     
     SubClassOf: 
-        Energy
+        OEO_00000150
     
     
-Class: HydroPowerplant
-
-    Annotations: 
-        rdfs:comment "will be discussed later"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydroPowerUnit>
-    
-    
-Class: HydroelectricPowerplant
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydroelectric powerplant uses water to generate electricity."@en
-    
-    SubClassOf: 
-        HydroPowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some WaterTurbine
-    
-    
-Class: Hydroelectricity
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
-    
-    SubClassOf: 
-        HydroEnergy
-    
-    
-Class: Hydrofluorocarbon
+Class: OEO_00000219
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
+        rdfs:label "hydrofluorocarbon"
     
     SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
+        OEO_00000331,
+        has_origin value OEO_00000002
     
     
-Class: Hydrogen
+Class: OEO_00000220
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical symbol H and atomic number 1. It is used in water electrolysis during the power-to-gas process as a storage medium for excess electricty."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Hydrogen"@en,
+        rdfs:label "hydrogen"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_origin value synthetic
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_origin value OEO_00000404
     
     
-Class: HydrogenPowerplant
+Class: OEO_00000221
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A HydrogenPowerplant is a Powerplant having an aggregate of HydrogenPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
+        rdfs:label "hydrogen powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/HydrogenPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some HydrogenTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
     
     
-Class: HydrogenTurbine
+Class: OEO_00000222
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "hydrogen turbine"
     
     SubClassOf: 
-        GasTurbine,
-        has_physical_output some Power,
-        has_physical_input only Hydrogen
+        OEO_00000185,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000220
     
     
-Class: HydrogenVehicle
-
-    SubClassOf: 
-        TransportDemand
-    
-    
-Class: IndustrialWasteFuel
+Class: OEO_00000223
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "IndustrialWasteFuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        rdfs:label "hydrogen vehicle"
     
     SubClassOf: 
-        WasteFuel
+        OEO_00000421
     
     
-Class: InstalledHeatFromHeatPump
+Class: OEO_00000224
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from heat pump quantity is a installed power quantity restricted to heat pump power plants."@en
+        rdfs:comment "will be discussed later",
+        rdfs:label "hydro powerplant"
     
     SubClassOf: 
-        InstalledPowerQuantity
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000023
     
     
-Class: InstalledHeatFromSolar
+Class: OEO_00000226
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from solar quantity is a installed power quantity restricted to solar heat power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromBiomass
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from biomass quantity is a installed power quantity restricted to biomass power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromCoalPowerPlants
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from coal power plants quantity is a installed power quantity restricted to coal power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromGas
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from gas quantity is a installed power quantity restricted to gas power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromPhotovoltaics
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from photovoltaics quantity is a installed power quantity restricted to photovoltaic power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromThermalPowerPlants
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from thermal power plants quantity is a installed power quantity restricted to thermal power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerFromWind
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from wind quantity is a installed power quantity restricted to wind power plants."@en
-    
-    SubClassOf: 
-        InstalledPowerQuantity
-    
-    
-Class: InstalledPowerQuantity
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power quantity is a quantity that describes the amount of power that some generators can generate."@en
-    
-    SubClassOf: 
-        Quantity
-    
-    
-Class: InternalCombustionVehicle
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An InternalCombustionVehicle is an ArtificialObject that is a vehicle powered by internal combustion engine."
-    
-    SubClassOf: 
-        ArtificialObject
-    
-    
-Class: JetFuel
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International Air Transport Association (IATA)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste fuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "JetFuel"@en,
-        rdfs:label "KeroseneTypeJetFuel"@en
+        rdfs:label "industrial waste fuel"
     
     SubClassOf: 
-        Kerosene
+        OEO_00000439
     
     
-Class: Kerosene
+Class: OEO_00000229
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an OilAndPetroleumProduct consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from heat pump quantity is a installed power quantity restricted to heat pump power plants."@en,
+        rdfs:label "installed heat from heat pump"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000230
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from solar quantity is a installed power quantity restricted to solar heat power plants."@en,
+        rdfs:label "installed heat from solar"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000231
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from biomass quantity is a installed power quantity restricted to biomass power plants."@en,
+        rdfs:label "installed power from biomass"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000232
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from coal power plants quantity is a installed power quantity restricted to coal power plants."@en,
+        rdfs:label "installed power from coal power plants"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000233
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from gas quantity is a installed power quantity restricted to gas power plants."@en,
+        rdfs:label "installed power from gas"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000234
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from photovoltaics quantity is a installed power quantity restricted to photovoltaic power plants."@en,
+        rdfs:label "installed power from photovoltaics"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000235
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from thermal power plants quantity is a installed power quantity restricted to thermal power plants."@en,
+        rdfs:label "installed power from thermal power plants"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000236
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power from wind quantity is a installed power quantity restricted to wind power plants."@en,
+        rdfs:label "installed power from wind"
+    
+    SubClassOf: 
+        OEO_00000237
+    
+    
+Class: OEO_00000237
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installed power quantity is a quantity that describes the amount of power that some generators can generate."@en,
+        rdfs:label "installed power quantity"
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00000240
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is an artificial object that is a vehicle powered by internal combustion engine.",
+        rdfs:label "internal combustion vehicle"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000245
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "KeroseneTypeJetFuel"@en,
+        rdfs:label "jet fuel",
+        rdfs:label "jet fuel"@en
+    
+    SubClassOf: 
+        OEO_00000246
+    
+    
+Class: OEO_00000246
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an OilAndPetroleumProduct consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
 [...]
 
 Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        rdfs:label "kerosene"
     
     SubClassOf: 
-        OilAndPetroleumProducts,
-        has_normal_state_of_matter value liquid
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
     
     
-Class: Land
+Class: OEO_00000247
 
+    Annotations: 
+        rdfs:label "land"
+    
     SubClassOf: 
-        GeographicRegion
+        OEO_00000190
     
     
-Class: Li-ionBattery
+Class: OEO_00000248
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery or Li-ion battery (abbreviated as LIB) is a type of rechargeable battery [...] In the batteries lithium ions move from the negative electrode to the positive electrode during discharge and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material, compared to the metallic lithium used in a non-rechargeable lithium battery. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
+        rdfs:label "lithium-ion battery"
     
     SubClassOf: 
-        Battery
+        OEO_00000068
     
     
-Class: Lignite
+Class: OEO_00000251
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
+        <http://purl.obolibrary.org/obo/IAO_0000115> "lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
 
 Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
 
 This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "lignite"
     
     SubClassOf: 
-        Coal,
-        has_normal_state_of_matter value solid,
-        has_origin value fossil
+        OEO_00000088,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000171
     
     DisjointWith: 
-        HardCoal
+        OEO_00000204
     
     
-Class: LignitePowerplant
+Class: OEO_00000252
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A LignitePowerplant is a CoalPowerplant having an aggregate of LignitePowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
+        rdfs:label "lignite powerplant"
     
     SubClassOf: 
-        CoalPowerplant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/LignitePowerUnit>
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000024
     
     
-Class: Line
+Class: OEO_00000253
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An uninterrupted transmission system between two nodes in the electric grid."@en,
-        rdfs:label "PowerLine"@en
+        rdfs:label "power line"@en
     
     SubClassOf: 
-        Link
+        OEO_00000255
     
     
-Class: Link
+Class: OEO_00000255
 
+    Annotations: 
+        rdfs:label "link"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000024>
     
     DisjointWith: 
-        Node
+        OEO_00000296
     
     
-Class: LiquidAir
+Class: OEO_00000257
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en,
+        rdfs:label "liquid air"
     
     SubClassOf: 
-        Air
+        OEO_00000054
     
     
-Class: LiquidBiofuel
+Class: OEO_00000258
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
+        rdfs:label "liquid biofuel"
     
     EquivalentTo: 
-        Fuel
-         and (has_normal_state_of_matter value liquid)
-         and (has_origin value biogenic)
+        OEO_00000173
+         and (has_normal_state_of_matter value OEO_00000256)
+         and (has_origin value OEO_00000076)
     
     SubClassOf: 
-        Biofuel,
-        has_normal_state_of_matter value liquid,
-        has_origin value biogenic,
-        has_origin value renewable
+        OEO_00000072,
+        has_normal_state_of_matter value OEO_00000256,
+        has_origin value OEO_00000076,
+        has_origin value OEO_00000354
     
     
-Class: LiquidMetalBattery
+Class: OEO_00000259
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rechargeable liquid-metal batteries are used for electric vehicles and potentially also for grid energy storage, to balance out intermittent renewable power sources such as solar panels and wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "liquid-metal battery"
     
     SubClassOf: 
-        MoltenStateBattery
+        OEO_00000283
     
     
-Class: LoadArea
+Class: OEO_00000260
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A load area is an area that contains energy consumption.
 
-Source: https://wiki.openmod-initiative.org/wiki/Load_area"@en
+Source: https://wiki.openmod-initiative.org/wiki/Load_area"@en,
+        rdfs:label "load area"
     
     SubClassOf: 
-        Land
+        OEO_00000247
     
     
-Class: ManufacturedCoalBasedGas
+Class: OEO_00000263
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
+        rdfs:label "manufactured coal based gas"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value gaseous,
-        has_origin value fossil
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182,
+        has_origin value OEO_00000171
     
     
-Class: MethanationGasStorage
+Class: OEO_00000269
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
+        rdfs:label "methanation gas storage"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
+        OEO_00000012
     
     DisjointWith: 
-        BatteryStorage
+        OEO_00000070
     
     
-Class: Microgrid
+Class: OEO_00000271
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A microgrid is a localized group of electricity sources and loads that normally operates connected to and synchronous with the traditional wide area synchronous grid (macrogrid), but can also disconnect to \"island mode\" — and function autonomously as physical or economic conditions dictate. In this way, a microgrid can effectively integrate various sources of distributed generation (DG), especially Renewable Energy Sources (RES) - renewable electricity, and can supply emergency power, changing between island and connected modes. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Microgrid&oldid=906195407"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A microgrid is a localized group of electricity sources and loads that normally operates connected to and synchronous with the traditional wide area synchronous grid (macrogrid), but can also disconnect to \"island mode\" — and function autonomously as physical or economic conditions dictate. In this way, a microgrid can effectively integrate various sources of distributed generation (DG), especially Renewable energy Sources (RES) - renewable electricity, and can supply emergency power, changing between island and connected modes. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Microgrid&oldid=906195407"@en,
+        rdfs:label "microgrid"
     
     SubClassOf: 
-        ElectricityGrid,
-        Subgrid
+        OEO_00000143,
+        OEO_00000402
     
     
-Class: MoltenSaltBattery
+Class: OEO_00000282
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-salt batteries are a class of battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "molten-salt battery"
     
     SubClassOf: 
-        MoltenStateBattery
+        OEO_00000283
     
     
-Class: MoltenStateBattery
+Class: OEO_00000283
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-state batteries consist of two molten metal alloys separated by an electrolyte."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wastes produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "molten state battery"
     
     SubClassOf: 
-        Battery
+        OEO_00000068
     
     
-Class: MotorGasoline
+Class: OEO_00000286
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
 
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "motor gasoline"
     
     SubClassOf: 
-        Gasoline
+        OEO_00000183
     
     
-Class: MunicipalWasteFuel
+Class: OEO_00000290
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "MunicipalWwasteFuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Municipal waste fuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "municipal waste fuel"
     
     SubClassOf: 
-        WasteFuel
+        OEO_00000439
     
     
-Class: NaturalGas
+Class: OEO_00000292
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
@@ -2219,744 +2416,871 @@ Class: NaturalGas
 It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
 
 It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "natural gas"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value gaseous,
-        has_origin value fossil
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182,
+        has_origin value OEO_00000171
     
     
-Class: NegativeEmission
+Class: OEO_00000293
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "NegativeEmission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "negative emission"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: NetworkNode
+Class: OEO_00000294
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A network node is a node in an electrical grid."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A network node is a node in an electrical grid."@en,
+        rdfs:label "network node"
     
     SubClassOf: 
-        Node
+        OEO_00000296
     
     
-Class: NewPowerFromPhotovoltaics
+Class: OEO_00000295
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A new power from photovoltaics quantity is a quantity that describes the amount of power from photovoltaic power plants that are going to be build in the future."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A new power from photovoltaics quantity is a quantity that describes the amount of power from photovoltaic power plants that are going to be build in the future."@en,
+        rdfs:label "new power from photovoltaics"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: Node
+Class: OEO_00000296
 
+    Annotations: 
+        rdfs:label "node"
+    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000024>
     
     DisjointWith: 
-        Link
+        OEO_00000255
     
     
-Class: NonAssociatedGas
+Class: OEO_00000297
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "non associated gas"
     
     SubClassOf: 
-        NaturalGas
+        OEO_00000292
     
     
-Class: NonMethaneVolatileOrganicCompound
+Class: OEO_00000298
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-methane volatile organic compounds (NMVOCs) are volatile organic compounds of a large variety of chemically different compounds, such as benzene, ethanol, formaldehyde, cyclohexane, 1,1,1-trichloroethane or acetone.
-       Essentially, NMVOCs are identical to volatile organic compounds (VOCs), but with methane excluded. An important subset of NMVOCs are the non-methane hydrocarbons (NMHCs). Methane is excluded in air-pollution contexts because it is not harmful. Its low reactivity and thus long lifetime in the atmosphere, however, makes it an important greenhouse gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Non-methane_volatile_organic_compound&oldid=890812257"@en
+       Essentially, NMVOCs are identical to volatile organic compounds (VOCs), but with methane excluded. An important subset of NMVOCs are the non-methane hydrocarbons (NMHCs). methane is excluded in air-pollution contexts because it is not harmful. Its low reactivity and thus long lifetime in the atmosphere, however, makes it an important greenhouse gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Non-methane_volatile_organic_compound&oldid=890812257"@en,
+        rdfs:label "non methane volatile organic compound"
     
     SubClassOf: 
-        VolatileOrganicCompound
+        OEO_00000437
     
     
-Class: NonRenewableMunicipalWasteFuel
+Class: OEO_00000299
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non renewable municipal waste fuel is municipal waste fuel of non-biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "non renewable municipal waste fuel"
     
     SubClassOf: 
-        MunicipalWasteFuel,
-        has_origin value fossil
+        OEO_00000290,
+        has_origin value OEO_00000171
     
     
-Class: NuclearEnergy
+Class: OEO_00000300
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear power is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "nuclear energy"
     
     SubClassOf: 
-        Energy
+        OEO_00000150
     
     
-Class: NuclearEnergyProduction
+Class: OEO_00000301
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "ways to produce energy through the use of nuclear power"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "ways to produce energy through the use of nuclear power",
+        rdfs:label "nuclear energy production"
     
     SubClassOf: 
-        EnergyProduction
+        OEO_00000157
     
     
-Class: NuclearFuel
+Class: OEO_00000302
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear fuel"
     
     EquivalentTo: 
-        Fuel
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearEnergyCarrierDisposition>)
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
     
     SubClassOf: 
-        Fuel
+        OEO_00000173
     
     
-Class: NuclearPowerplant
+Class: OEO_00000303
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A NuclearPowerplant is a Powerplant having an aggregate of NuclearPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
+        rdfs:label "nuclear powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/NuclearPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: Ocean
-
-    SubClassOf: 
-        Water
-    
-    DisjointWith: 
-        Flow
-    
-    
-Class: OceanPowerplant
-
-    SubClassOf: 
-        HydroPowerplant
-    
-    
-Class: OffShoreWindFarm
+Class: OEO_00000305
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a WindFarm that is build in a body of water, usually the ocean."@en
+        rdfs:label "ocean"
     
     SubClassOf: 
-        WindFarm
+        OEO_00000441
     
     DisjointWith: 
-        OnShoreWindFarm
+        OEO_00000168
     
     
-Class: Office
+Class: OEO_00000306
 
+    Annotations: 
+        rdfs:label "ocean powerplant"
+    
     SubClassOf: 
-        CommericalDemand
+        OEO_00000224
     
     
-Class: OilAndPetroleumProducts
+Class: OEO_00000307
+
+    Annotations: 
+        rdfs:label "office"
+    
+    SubClassOf: 
+        OEO_00000101
+    
+    
+Class: OEO_00000308
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
+        rdfs:label "off shore wind farm"
+    
+    SubClassOf: 
+        OEO_00000447
+    
+    DisjointWith: 
+        OEO_00000311
+    
+    
+Class: OEO_00000309
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
 
 It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
+        rdfs:label "oil and petroleum products"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_origin value fossil
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_origin value OEO_00000171
     
     
-Class: OilPowerplant
+Class: OEO_00000310
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An OilPowerplant is a Powerplant having an aggregate of OilPowerUnits as its PowerGeneratingUnits."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
+        rdfs:label "oil powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/OilPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: OnShoreWindFarm
+Class: OEO_00000311
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a WindFarm that is build on land."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
+        rdfs:label "on shore wind farm"
     
     SubClassOf: 
-        WindFarm
+        OEO_00000447
     
     DisjointWith: 
-        OffShoreWindFarm
+        OEO_00000308
     
     
-Class: PVPanel
+Class: OEO_00000316
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PVPanel (photovoltaic panel) is a SolarPowerUnit absorbing sunlight as a source of energy to generate electricity."@en,
-        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "origin"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/SolarPowerUnit>,
-        has_physical_output some Power,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/PVCell>,
-        has_physical_input only SolarPhotovoltaic
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
-Class: ParticulateMatter
+Class: OEO_00000318
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Atmospheric aerosol particles – also known as atmospheric particulate matter, particulate matter (PM), particulates, or suspended particulate matter (SPM) – are portions of matter consisting of microscopic solid or liquid matter suspended in the atmosphere of Earth. The term aerosol commonly refers to the particulate/air mixture, as opposed to the particulate matter alone.Sources of particulate matter can be natural or anthropogenic.They have impacts on climate and precipitation that adversely affect human health, in addition to direct inhalation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Particulates&oldid=906795232"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Particulates&oldid=906795232"@en,
+        rdfs:label "particulate matter"
     
     SubClassOf: 
-        PortionOfMatter
+        OEO_00000331
     
     
-Class: Peat
+Class: OEO_00000320
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. peat used for non-energy purposes is not included.
 
 This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "peat"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value solid,
-        has_origin value fossil
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000171
     
     
-Class: Percentage
+Class: OEO_00000321
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A percentage is a ratio given as a fraction of 100."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A percentage is a ratio given as a fraction of 100."@en,
+        rdfs:label "percentage"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: Perfluorocarbon
+Class: OEO_00000322
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
+        rdfs:label "perfluorocarbon"
     
     SubClassOf: 
-        PortionOfMatter,
-        has_origin value <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
+        OEO_00000331,
+        has_origin value OEO_00000002
     
     
-Class: PhotovoltaicPowerplant
+Class: OEO_00000324
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PhotovoltaicPowerplant is a Powerplant having an aggregate of PVPanels as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
+        rdfs:label "photovoltaic powerplant"
     
     SubClassOf: 
-        SolarPowerPlant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
     
     
-Class: Pollution
+Class: OEO_00000330
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an Emission with a negative effect on the environment or organisms."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution"
     
     SubClassOf: 
-        Emission
+        OEO_00000147
     
     
-Class: PortionOfMatter
+Class: OEO_00000331
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "portion of matter"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
-Class: PortionOfSolidBiomass
+Class: OEO_00000332
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "SolidBiofuel"@en,
-        rdfs:label "SolidBiomass"@en
+        rdfs:label "solid biofuel"@en
     
     EquivalentTo: 
-        (has_normal_state_of_matter value solid)
-         and (has_origin value biogenic)
+        (has_normal_state_of_matter value OEO_00000390)
+         and (has_origin value OEO_00000076)
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition,
-        has_normal_state_of_matter value solid,
-        has_origin value biogenic,
-        has_origin value renewable
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000076,
+        has_origin value OEO_00000354
     
     
-Class: Power
+Class: OEO_00000333
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the rate of doing work, the amount of energy transferred per unit time.
-Source: https://en.wikipedia.org/wiki/Power_(physics)"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "power is the rate of doing work, the amount of energy transferred per unit time.
+Source: https://en.wikipedia.org/wiki/Power_(physics)"@en,
+        rdfs:label "power"
     
     SubClassOf: 
-        Quantity
+        OEO_00000350
     
     
-Class: PowerGeneratingUnit
+Class: OEO_00000334
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "power generating unit"
     
     SubClassOf: 
-        ArtificialObject,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Generator
+        OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188
     
     
-Class: PowerToGasSystem
+Class: OEO_00000335
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
+        rdfs:label "power to gas system"
     
     SubClassOf: 
-        EnergyStorageObject
+        OEO_00000159
     
     
-Class: PumpedStorage
+Class: OEO_00000343
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
+        rdfs:label "pumped storage"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyStorage>
+        OEO_00000012
     
     
-Class: PumpedStoragePlant
+Class: OEO_00000344
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage plant pumps water using surplus energy from a lower level to a higher reservoir. The reservoir functions as a storage unit. If needed, energy can be generated by letting the water flow back to the lower level"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage plant pumps water using surplus energy from a lower level to a higher reservoir. The reservoir functions as a storage unit. If needed, energy can be generated by letting the water flow back to the lower level"@en,
+        rdfs:label "pumped storage plant"
     
     SubClassOf: 
-        HydroelectricPowerplant
+        OEO_00000217
     
     
-Class: PumpedWater
+Class: OEO_00000345
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        rdfs:label "pumped water"
     
     SubClassOf: 
-        Water,
-        is_used_by some StorageUnit
+        OEO_00000441,
+        is_used_by some OEO_00000399
     
     
-Class: PumpstoragePowerplant
+Class: OEO_00000346
 
+    Annotations: 
+        rdfs:label "pumpstorage powerplant"
+    
     SubClassOf: 
-        ReservoirPowerplant
+        OEO_00000357
     
     
-Class: PumpstoragePowerplantWithNaturalInflux
+Class: OEO_00000347
 
+    Annotations: 
+        rdfs:label "pumpstorage powerplant with natural influx"
+    
     SubClassOf: 
-        ReservoirPowerplant
+        OEO_00000357
     
     
-Class: Quantity
+Class: OEO_00000348
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
+        rdfs:label "PV panel"
+    
+    SubClassOf: 
+        OEO_00000034,
+        has_physical_output some OEO_00000333,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032,
+        has_physical_input only OEO_00000385
+    
+    
+Class: OEO_00000350
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Idea: A quantity is a property that is quantifiable by measurement."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Other Idea: A number together with a unit of measurement to quantify an entity."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "other Idea: A number together with a unit of measurement to quantify an entity."@en,
+        rdfs:label "quantity"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: Rail
+Class: OEO_00000352
 
+    Annotations: 
+        rdfs:label "rail"
+    
     SubClassOf: 
-        TransportDemand
+        OEO_00000421
     
     
-Class: RenewableMunicipalWasteFuel
+Class: OEO_00000356
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable municipal waste fuel is municipal waste fuel of biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "renewable municipal waste fuel"
     
     SubClassOf: 
-        MunicipalWasteFuel,
-        has_origin value biogenic,
-        has_origin value renewable
+        OEO_00000290,
+        has_origin value OEO_00000076,
+        has_origin value OEO_00000354
     
     
-Class: ReservoirPowerplant
-
-    SubClassOf: 
-        HydroPowerplant
-    
-    DisjointWith: 
-        RunOfRiverPowerplant
-    
-    
-Class: ResidentialDemand
-
-    SubClassOf: 
-        Demand
-    
-    
-Class: Retail
-
-    SubClassOf: 
-        CommericalDemand
-    
-    
-Class: RooftopPhotovoltaicPowerplant
+Class: OEO_00000357
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en
+        rdfs:label "reservoir powerplant"
     
     SubClassOf: 
-        PhotovoltaicPowerplant
+        OEO_00000224
     
     DisjointWith: 
-        FieldPhotovoltaicPowerplant
+        OEO_00000363
     
     
-Class: RunOfRiverPowerplant
+Class: OEO_00000358
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "water turbine installed on naturally running streams (in contrast to pump storage lakes)"@en
+        rdfs:label "residential demand"
     
     SubClassOf: 
-        HydroelectricPowerplant,
-        uses some Flow
+        OEO_00000127
+    
+    
+Class: OEO_00000359
+
+    Annotations: 
+        rdfs:label "retail"
+    
+    SubClassOf: 
+        OEO_00000101
+    
+    
+Class: OEO_00000361
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic powerplant"
+    
+    SubClassOf: 
+        OEO_00000324
     
     DisjointWith: 
-        ReservoirPowerplant, TidalPowerPlant
+        OEO_00000165
     
     
-Class: SMES
+Class: OEO_00000363
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical SMES system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine installed on naturally running streams (in contrast to pump storage lakes)"@en,
+        rdfs:label "run of river powerplant"
     
     SubClassOf: 
-        EnergyStorageObject
+        OEO_00000217,
+        uses some OEO_00000168
+    
+    DisjointWith: 
+        OEO_00000357, OEO_00000409
     
     
-Class: Sea
+Class: OEO_00000366
 
+    Annotations: 
+        rdfs:label "sea"
+    
     SubClassOf: 
-        GeographicRegion
+        OEO_00000190
     
     
-Class: ShuntImpedance
+Class: OEO_00000369
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In electronics, a shunt is a device which allows electric current to pass around another point in the circuit by creating a low resistance path. The term is also widely used in photovoltaics to describe an unwanted short circuit between the front and back surface contacts of a solar cell, usually caused by wafer damage.
 
-Source: https://en.wikipedia.org/wiki/Shunt_%28electrical%29"@en
+Source: https://en.wikipedia.org/wiki/Shunt_%28electrical%29"@en,
+        rdfs:label "shunt impedance"
     
     SubClassOf: 
-        NetworkNode
+        OEO_00000294
     
     
-Class: Sodium-IonBattery
+Class: OEO_00000374
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
+          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
+        rdfs:label "SMES"
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00000376
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sodium-ion batteries (SIB) are a type of rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
+        rdfs:label "sodium-ion battery"
     
     SubClassOf: 
-        Battery
+        OEO_00000068
     
     
-Class: Sodium-SulfurBattery
+Class: OEO_00000377
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
+        rdfs:label "sodium-sulfur battery"
     
     SubClassOf: 
-        MoltenStateBattery
+        OEO_00000283
     
     
-Class: SolarEnergy
+Class: OEO_00000384
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "solar energy"
     
     SubClassOf: 
-        Energy,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
+        OEO_00000150,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
     
     
-Class: SolarPhotovoltaic
+Class: OEO_00000385
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sunlight converted into electricity by the use of solar cells usually made of semi-conducting material which exposed to light will generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "solar photovoltaic"
     
     SubClassOf: 
-        EnergyProduction
+        OEO_00000157
     
     
-Class: SolarPowerPlant
+Class: OEO_00000386
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarPowerplant is a Powerplant having an aggregate of SolarPowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
+        rdfs:label "solar power plant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some PVPanel
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
     
     
-Class: SolarThermalCollector
+Class: OEO_00000387
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        rdfs:label "solar thermal collector"
     
     SubClassOf: 
-        Heater,
-        has_physical_input only SolarThermalHeat
+        OEO_00000210,
+        has_physical_input only OEO_00000388
     
     
-Class: SolarThermalHeat
+Class: OEO_00000388
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
+        <http://purl.obolibrary.org/obo/IAO_0000115> "heat from solar radiation; can consist of:
 (a) solar thermal-electric plants; or
 (b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "solar thermal heat"
     
     SubClassOf: 
-        Heat
+        OEO_00000207
     
     
-Class: SolarThermalPowerplant
+Class: OEO_00000389
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SolarThermalPowerplant is a Powerplant consisting of SolarThermalPowerUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
+        rdfs:label "solar thermal powerplant"
     
     SubClassOf: 
-        SolarPowerPlant,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/SolarThermalPowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000035,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: SolidFossilFuel
+Class: OEO_00000391
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
+        rdfs:label "solid fossil fuel"
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition)
-         and (has_normal_state_of_matter value solid)
-         and (has_origin value fossil)
+        (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+         and (has_normal_state_of_matter value OEO_00000390)
+         and (has_origin value OEO_00000171)
     
     SubClassOf: 
-        Fuel,
-        has_normal_state_of_matter value solid,
-        has_origin value fossil
+        OEO_00000173,
+        has_normal_state_of_matter value OEO_00000390,
+        has_origin value OEO_00000171
     
     
-Class: SteamTurbine
+Class: OEO_00000395
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+        rdfs:label "state of matter"
     
     SubClassOf: 
-        Turbine,
-        has_physical_output some Power
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
-Class: StorageHydropowerplant
-
-    SubClassOf: 
-        ReservoirPowerplant
-    
-    
-Class: StorageUnit
+Class: OEO_00000396
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores electrical energy."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
+        rdfs:label "steam turbine"
     
     SubClassOf: 
-        ElectricityGridComponent,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some ElectricityGrid
+        OEO_00000425,
+        has_physical_output some OEO_00000333
     
     
-Class: SubBituminousCoal
+Class: OEO_00000398
+
+    Annotations: 
+        rdfs:label "storage hydropowerplant"
+    
+    SubClassOf: 
+        OEO_00000357
+    
+    
+Class: OEO_00000399
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores electrical energy."@en,
+        rdfs:label "storage unit"
+    
+    SubClassOf: 
+        OEO_00000144,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
+    
+Class: OEO_00000401
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal"
     
     SubClassOf: 
-        Coal
+        OEO_00000088
     
     
-Class: Subgrid
+Class: OEO_00000402
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A subgrid is a grid component that is a grid itself."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subgrid is a grid component that is a grid itself."@en,
+        rdfs:label "subgrid"
     
     SubClassOf: 
-        ElectricityGrid,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some ElectricityGrid,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some ElectricityGridComponent
+        OEO_00000143,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144
     
     
-Class: Technology
+Class: OEO_00000407
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technology is an entity that is created by mental or phisical efford and used to help society?"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A technology is an entity that is created by mental or phisical efford and used to help society?"@en,
+        rdfs:label "technology"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: TidalPowerPlant
+Class: OEO_00000409
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Mechanical energy derived from tidal movement, wave motion or ocean current and exploited for electricity generation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "tidal power plant"
     
     SubClassOf: 
-        OceanPowerplant,
-        uses some Tide
+        OEO_00000306,
+        uses some OEO_00000411
     
     DisjointWith: 
-        RunOfRiverPowerplant
+        OEO_00000363
     
     
-Class: TidalStreamPowerplant
+Class: OEO_00000410
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tidal stream generator uses tidal movement, wave motion or water current for electricity generation."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tidal stream generator uses tidal movement, wave motion or water current for electricity generation."@en,
+        rdfs:label "tidal stream powerplant"
     
     SubClassOf: 
-        HydroelectricPowerplant
+        OEO_00000217
     
     
-Class: Tide
+Class: OEO_00000411
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tides are rise and fall of sea levels caused by the combined effects of the gravitational forces exerted by the moon and the sun, and the rotation of the earth.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Tide"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Tide",
+        rdfs:label "tide"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: TideWaveOcean
+Class: OEO_00000412
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Mechanical energy derived from tidal movement, wave motion or ocean current and exploited for electricity generation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "tide wave ocean"
     
     SubClassOf: 
-        EnergyProduction
+        OEO_00000157
     
     
-Class: Transformer
+Class: OEO_00000420
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "1. A transformer is an electrical device that transfers electrical energy between two or more circuits through electromagnetic induction. A varying current in one coil of the transformer produces a varying magnetic field, which in turn induces a voltage in a second coil. Transformers are used to increase or decrease the alternating voltages in electric power applications.
-2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. Transformer operates on ac supply. Transformer works on the principle of mutual induction.
+2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. transformer operates on ac supply. transformer works on the principle of mutual induction.
 
-Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en
+Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en,
+        rdfs:label "transformer"
     
     SubClassOf: 
-        NetworkNode
+        OEO_00000294
     
     
-Class: TransportDemand
-
-    SubClassOf: 
-        Demand
-    
-    
-Class: Turbine
+Class: OEO_00000421
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en
+        rdfs:label "transport demand"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/EnergyConvertingDevice>
+        OEO_00000127
     
     
-Class: UndergroundHydrogenStorage
+Class: OEO_00000425
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
+        rdfs:label "turbine"
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
+Class: OEO_00000429
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Underground hydrogen storage is the practice of hydrogen storage in underground caverns,salt domes and depleted oil/gas fields."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        rdfs:label "underground hydrogen storage"
     
     SubClassOf: 
-        ArtificialObject
+        OEO_00000061
     
     
-Class: UndirectedEdge
+Class: OEO_00000430
 
+    Annotations: 
+        rdfs:label "undirected edge"
+    
     SubClassOf: 
-        Link
+        OEO_00000255
     
     
-Class: V2Grid
+Class: OEO_00000433
 
+    Annotations: 
+        rdfs:label "v2 grid"
+    
     SubClassOf: 
-        TransportDemand
+        OEO_00000421
     
     
-Class: VolatileOrganicCompound
+Class: OEO_00000437
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Volatile organic compounds (VOCs) are portions of matter consisting of organic chemicals that have a high vapor pressure at ordinary room temperature. Their high vapor pressure results from a low boiling point, which causes large numbers of molecules to evaporate or sublimate from the liquid or solid form of the compound and enter the surrounding air, a trait known as volatility.
@@ -2968,112 +3292,125 @@ VOCs are numerous, varied, and ubiquitous. They include both human-made and natu
 [...]
 
 Some VOCs are dangerous to human health or cause harm to the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Volatile_organic_compound&oldid=880677383"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Volatile_organic_compound&oldid=880677383",
+        rdfs:label "volatile organic compound"
     
     SubClassOf: 
-        PortionOfMatter
+        OEO_00000331
     
     
-Class: Warehouse
-
-    SubClassOf: 
-        CommericalDemand
-    
-    
-Class: WasteFuel
+Class: OEO_00000438
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "WasteFuel is a fuel in which the material entity is waste."@en,
+        rdfs:label "warehouse"
+    
+    SubClassOf: 
+        OEO_00000101
+    
+    
+Class: OEO_00000439
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:comment "The energy content of WasteFuel is typically released by incineration or gasification."
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification.",
+        rdfs:label "waste fuel"
     
     EquivalentTo: 
-        Fuel
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo-physical/WasteRole>)
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000042)
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some CombustibleEnergyCarrierDisposition
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
-Class: WastePowerplant
+Class: OEO_00000440
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WastePowerplant is a Powerplant having an aggregate of WastePowerUnits as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
+        rdfs:label "waste powerplant"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WastePowerUnit>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some SteamTurbine
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
-Class: Water
+Class: OEO_00000441
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
+        rdfs:label "water"
     
     SubClassOf: 
-        PortionOfMatter,
-        <http://purl.obolibrary.org/obo/RO_0000091> some EnergyCarrierDisposition
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
     
     
-Class: WaterTurbine
+Class: OEO_00000442
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "water turbine"
     
     SubClassOf: 
-        Turbine,
-        has_physical_output some Power,
-        has_physical_input only HydroEnergy
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000218
     
     
-Class: Wave
+Class: OEO_00000443
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "(wind-)waves are water surface waves that occur on the free surface of the oceans.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Wind_wave"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Wind_wave",
+        rdfs:label "wave"
     
     SubClassOf: 
-        Water
+        OEO_00000441
     
     
-Class: WavePowerPlant
-
-    SubClassOf: 
-        OceanPowerplant,
-        uses some Wave
-    
-    
-Class: WindEnergy
+Class: OEO_00000444
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines.",
+        rdfs:label "wave power plant"
+    
+    SubClassOf: 
+        OEO_00000306,
+        uses some OEO_00000443
+    
+    
+Class: OEO_00000446
+
+    Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind energy"
     
     SubClassOf: 
-        Energy,
-        uses some <http://openenergy-platform.org/ontology/oeo-physical/Wind>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo-physical/RenewableFuel>
+        OEO_00000150,
+        uses some OEO_00000043,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
     
     
-Class: WindFarm
+Class: OEO_00000447
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A WindFarm is a Powerplant having an aggregate of WindEnergyConverters as its PowerGeneratingUnits."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
+        rdfs:label "wind farm"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo-physical/Powerplant>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo-physical/WindEnergyConvertingUnit>
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000044
     
     
-Class: WindTurbine
+Class: OEO_00000448
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
@@ -3083,171 +3420,170 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
         rdfs:label "wind rotor"
     
     SubClassOf: 
-        Turbine,
-        has_physical_output some Power,
-        uses some WindEnergy,
-        has_physical_input only WindEnergy
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        uses some OEO_00000446,
+        has_physical_input only OEO_00000446
     
     
-Class: WoodAndOther
+Class: OEO_00000449
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "WoodAndOther is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "wood and other"
     
     SubClassOf: 
-        PortionOfSolidBiomass,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/FuelRole>
+        OEO_00000332,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
     
     
-Class: origin
+Individual: OEO_00000002
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is anthropogenic if it was created by human activity.",
+        rdfs:label "anthropogenic"
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+    Types: 
+        OEO_00000316
     
     
-Class: state_of_matter
+Individual: OEO_00000018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is geogenic if it is the result of geological processes.",
+        rdfs:label "geogenic"
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+    Types: 
+        OEO_00000316
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo-physical/anthropogenic>
+Individual: OEO_00000076
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is anthropogenic if it was created by human activity."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is biogenic if it is made by or produce from life forms.",
+        rdfs:label "biogenic"
     
     Types: 
-        origin
+        OEO_00000316,
+        has_origin some OEO_00000316
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo-physical/geogenic>
+Individual: OEO_00000110
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is geogenic if it is the result of geological processes."
+        rdfs:label "cooking"
     
     Types: 
-        origin
+        OEO_00000358
     
     
-Individual: Cooking
-
-    Types: 
-        ResidentialDemand
-    
-    
-Individual: Heat
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
-       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en
-    
-    Types: 
-        ResidentialDemand
-    
-    
-Individual: Light
-
-    Types: 
-        ResidentialDemand
-    
-    
-Individual: SmartMetre
-
-    Types: 
-        Appliance
-    
-    
-Individual: biogenic
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is biogenic if it is made by or produce from life forms."
-    
-    Types: 
-        origin,
-        has_origin some origin
-    
-    
-Individual: fossil
+Individual: OEO_00000171
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created from organic material by geolocial processes lasting thousands or millions of years.
 
-In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain."
+In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        rdfs:label "fossil"
     
     Types: 
-        origin,
-        has_origin some origin
+        OEO_00000316,
+        has_origin some OEO_00000316
     
     
-Individual: gaseous
+Individual: OEO_00000182
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
+        rdfs:label "gaseous"
     
     Types: 
-        state_of_matter
+        OEO_00000395
     
     
-Individual: liquid
+Individual: OEO_00000207
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure)."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "heat"
     
     Types: 
-        state_of_matter
+        OEO_00000358
     
     
-Individual: plasmatic
+Individual: OEO_00000250
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive."
+        rdfs:label "light"
     
     Types: 
-        state_of_matter
+        OEO_00000358
     
     
-Individual: renewable
+Individual: OEO_00000256
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
+        rdfs:label "liquid"
+    
+    Types: 
+        OEO_00000395
+    
+    
+Individual: OEO_00000326
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
+        rdfs:label "plasmatic"
+    
+    Types: 
+        OEO_00000395
+    
+    
+Individual: OEO_00000354
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "x is renewable if will replenish to replace the portion depleted in a finite amount of time in a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Adapted from https://en.wikipedia.org/w/index.php?title=Renewable_resource&oldid=926207362"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Adapted from https://en.wikipedia.org/w/index.php?title=Renewable_resource&oldid=926207362",
+        rdfs:label "renewable"
     
     Types: 
-        origin,
-        has_origin some origin
+        OEO_00000316,
+        has_origin some OEO_00000316
     
     
-Individual: solid
+Individual: OEO_00000373
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure)."
+        rdfs:label "smart metre"
     
     Types: 
-        state_of_matter
+        OEO_00000060
     
     
-Individual: synthetic
+Individual: OEO_00000390
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is synthetic if it was created artifically by a chemical process."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
+        rdfs:label "solid"
     
     Types: 
-        origin,
-        has_origin some origin
+        OEO_00000395
+    
+    
+Individual: OEO_00000404
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x is synthetic if it was created artifically by a chemical process.",
+        rdfs:label "synthetic"
+    
+    Types: 
+        OEO_00000316,
+        has_origin some OEO_00000316
     
     
 DisjointClasses: 
-    Generator,Heater,Turbine
+    OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1683,6 +1683,7 @@ Class: OEO_00000183
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "gasoline (American English) or petrol (British English) is an OilAndPetroleumProduct in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         rdfs:label "gasoline"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3223,7 +3223,7 @@ Class: OEO_00000420
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "1. A transformer is an electrical device that transfers electrical energy between two or more circuits through electromagnetic induction. A varying current in one coil of the transformer produces a varying magnetic field, which in turn induces a voltage in a second coil. Transformers are used to increase or decrease the alternating voltages in electric power applications.
-2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. transformer operates on ac supply. transformer works on the principle of mutual induction.
+2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. transformer operates on ac supply. Transformer works on the principle of mutual induction.
 
 Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en,
         rdfs:label "transformer"
@@ -3366,7 +3366,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
 Class: OEO_00000443
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "(wind-)waves are water surface waves that occur on the free surface of the oceans.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "(Wind-)waves are water surface waves that occur on the free surface of the oceans.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Wind_wave",
         rdfs:label "wave"
     
@@ -3586,4 +3586,3 @@ Individual: OEO_00000404
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1267,7 +1267,7 @@ Class: OEO_00000113
 Class: OEO_00000115
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an OilAndPetroleumProduct of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "crude oil"
     
@@ -1669,7 +1669,7 @@ Class: OEO_00000178
 Class: OEO_00000181
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil-and-petroleum-product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "gas diesel oil"
     
@@ -1681,7 +1681,7 @@ Class: OEO_00000181
 Class: OEO_00000183
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an OilAndPetroleumProduct in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         rdfs:label "gasoline"
@@ -2186,7 +2186,7 @@ Class: OEO_00000245
 Class: OEO_00000246
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an OilAndPetroleumProduct consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
 [...]
 
 Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
@@ -3586,3 +3586,4 @@ Individual: OEO_00000404
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -712,7 +712,7 @@ Class: OEO_00000034
 Class: OEO_00000035
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has SolarThermalCollectors as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
         rdfs:label "solar thermal power unit"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1123,7 +1123,7 @@ Class: OEO_00000086
 Class: OEO_00000088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
         rdfs:label "coal"
     
@@ -2486,7 +2486,7 @@ Class: OEO_00000298
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-methane volatile organic compounds (NMVOCs) are volatile organic compounds of a large variety of chemically different compounds, such as benzene, ethanol, formaldehyde, cyclohexane, 1,1,1-trichloroethane or acetone.
-       Essentially, NMVOCs are identical to volatile organic compounds (VOCs), but with methane excluded. An important subset of NMVOCs are the non-methane hydrocarbons (NMHCs). methane is excluded in air-pollution contexts because it is not harmful. Its low reactivity and thus long lifetime in the atmosphere, however, makes it an important greenhouse gas."@en,
+       Essentially, NMVOCs are identical to volatile organic compounds (VOCs), but with methane excluded. An important subset of NMVOCs are the non-methane hydrocarbons (NMHCs). Methane is excluded in air-pollution contexts because it is not harmful. Its low reactivity and thus long lifetime in the atmosphere, however, makes it an important greenhouse gas."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Non-methane_volatile_organic_compound&oldid=890812257"@en,
         rdfs:label "non methane volatile organic compound"
     
@@ -3223,7 +3223,7 @@ Class: OEO_00000420
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "1. A transformer is an electrical device that transfers electrical energy between two or more circuits through electromagnetic induction. A varying current in one coil of the transformer produces a varying magnetic field, which in turn induces a voltage in a second coil. Transformers are used to increase or decrease the alternating voltages in electric power applications.
-2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. transformer operates on ac supply. Transformer works on the principle of mutual induction.
+2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. Transformer operates on ac supply. Transformer works on the principle of mutual induction.
 
 Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en,
         rdfs:label "transformer"
@@ -3340,7 +3340,7 @@ Class: OEO_00000440
 Class: OEO_00000441
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
         rdfs:label "water"
     
@@ -3429,7 +3429,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
 Class: OEO_00000449
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "wood and other"
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -205,7 +205,7 @@ Class: OEO_00000045
 Class: OEO_00000051
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
         rdfs:label "agent"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -18,8 +18,8 @@ Import: <http://open-energy-ontology.org/ontology/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (Social module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Social' module covers entities that relate to people and the social, organisational and economic environment in which energy is produced and consumed, including sector, organisation, and various roles."
+    <http://purl.org/dc/terms/title> "Open energy Ontology (social module)",
+    rdfs:comment "The Open energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Social' module covers entities that relate to people and the social, organisational and economic environment in which energy is produced and consumed, including sector, organisation, and various roles."
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -69,10 +69,10 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 ObjectProperty: conforms_to
 
     Domain: 
-        conforms_to some SectorDivision
+        conforms_to some OEO_00000368
     
     Range: 
-        Sector
+        OEO_00000367
     
     
 ObjectProperty: covers
@@ -87,7 +87,7 @@ ObjectProperty: covers_sector
         covers
     
     Range: 
-        Sector
+        OEO_00000367
     
     
 ObjectProperty: has_author
@@ -99,7 +99,7 @@ ObjectProperty: has_author
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     Range: 
-        Agent
+        OEO_00000051
     
     
 ObjectProperty: has_client
@@ -111,7 +111,7 @@ ObjectProperty: has_client
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     Range: 
-        Agent
+        OEO_00000051
     
     
 ObjectProperty: has_contact
@@ -132,7 +132,7 @@ ObjectProperty: has_funding_source
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     Range: 
-        Agent
+        OEO_00000051
     
     
 ObjectProperty: has_institution
@@ -146,15 +146,6 @@ ObjectProperty: has_institution
     
 ObjectProperty: owl:topObjectProperty
 
-    
-Class: <http://openenergy-platform.org/ontology/oeo-social/Producer>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods to sell them."
-    
-    SubClassOf: 
-        Agent
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
@@ -201,119 +192,139 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
-Class: Agent
+Class: OEO_00000045
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods to sell them.",
+        rdfs:label "producer"
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00000051
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
+        rdfs:label "agent"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: Author
+Class: OEO_00000064
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
+        rdfs:label "author"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Class: CarbonDioxideEmissionTrafficSector
+Class: OEO_00000083
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission traffic sector quantity is a carbon dioxide emission quantity that is restricted to carbon dioxide from the traffic sector."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide emission traffic sector quantity is a carbon dioxide emission quantity that is restricted to carbon dioxide from the traffic sector."@en,
+        rdfs:label "carbon dioxide emission traffic sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: Client
+Class: OEO_00000087
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
+        rdfs:label "client"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Class: CommerceSector
+Class: OEO_00000100
 
     Annotations: 
-        rdfs:label "ServiceSector"@en
+        rdfs:label "service sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: Consumer
+Class: OEO_00000105
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
+        rdfs:label "consumer"
     
     SubClassOf: 
-        User
+        OEO_00000431
     
     
-Class: ContactPerson
+Class: OEO_00000107
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A ContactPerson is an agent that can be contacted for help or information about a specific service or good."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
+        rdfs:label "contact person"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Class: DemandSector
+Class: OEO_00000128
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand sector is a general term for different consumptions (households; industry; commercial sector; transport). It includes only energy demand sectors."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand sector is a general term for different consumptions (households; industry; commercial sector; transport). It includes only energy demand sectors."@en,
+        rdfs:label "demand sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: ElectricitySector
+Class: OEO_00000145
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Covers all areas that deal with electrical energy (power generation; electricity transmission; electricity storage; electricity use)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Electricity_sector"@en
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://wiki.openmod-initiative.org/wiki/Electricity_sector"@en,
+        rdfs:label "electricity sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: EnergySector
+Class: OEO_00000158
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy sector is a sector that contains the energy production."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy sector is a sector that contains the energy production."@en,
+        rdfs:label "energy sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: HeatSector
+Class: OEO_00000213
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy used for heating and cooling for buildings and industry"@en,
-        rdfs:label "HeatingCoolingSector"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "energy used for heating and cooling for buildings and industry"@en,
+        rdfs:label "heating and cooling sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: HouseholdSector
+Class: OEO_00000214
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The household sector covers all private entities. A household is a  shared living unit."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The household sector covers all private entities. A household is a  shared living unit."@en,
+        rdfs:label "household sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: IndustrySector
+Class: OEO_00000227
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industry consumption is specified as follows (energy used for transport by industry is not included here but is reported under transport):
@@ -330,112 +341,123 @@ Class: IndustrySector
 * Wood and wood products (other than pulp and paper)
 * Construction
 * Textile and leather
-* Non-specified (any manufacturing industry not included above)"@en
+* Non-specified (any manufacturing industry not included above)"@en,
+        rdfs:label "industry sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: Institution
+Class: OEO_00000238
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organization that serve a social purpose."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organization that serve a social purpose."@en,
+        rdfs:label "institution"
     
     SubClassOf: 
-        Organization
+        OEO_00000315
     
     
-Class: Organization
+Class: OEO_00000315
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is a structure with multiple people that has a collective goal."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is a structure with multiple people that has a collective goal."@en,
+        rdfs:label "organization"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some Person
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000323
     
     DisjointWith: 
-        Person
+        OEO_00000323
     
     
-Class: Person
+Class: OEO_00000323
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human beeing."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
+        rdfs:label "person"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
     
     DisjointWith: 
-        Organization
+        OEO_00000315
     
     
-Class: PoliticalParty
+Class: OEO_00000329
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organization of a group of people with common views or goals that wants to have influence in politics."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organization of a group of people with common views or goals that wants to have influence in politics."@en,
+        rdfs:label "political party"
     
     SubClassOf: 
-        Organization
+        OEO_00000315
     
     
-Class: Prosumer
+Class: OEO_00000341
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
+        rdfs:label "prosumer"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Class: Sector
+Class: OEO_00000367
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is a subdivision in an economic system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30"
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
+        rdfs:label "sector"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
-Class: SectorDivision
+Class: OEO_00000368
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SectorDivision is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
+        rdfs:label "sector division"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: SoftwareDeveloper
+Class: OEO_00000379
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A SoftwareDeveloper is an agent that creates computer software."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
+        rdfs:label "software developer"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Class: TCSSector
+Class: OEO_00000405
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A TCS sector is a demand sector that includes the energy consumption from trade, commerce and services."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A TCS sector is a demand sector that includes the energy consumption from trade, commerce and services."@en,
+        rdfs:label "TCS sector"
     
     SubClassOf: 
-        DemandSector
+        OEO_00000128
     
     
-Class: TrafficSector
+Class: OEO_00000418
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A traffic sector is a demand sector that includes the energy consumption from traffic."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A traffic sector is a demand sector that includes the energy consumption from traffic."@en,
+        rdfs:label "traffic sector"
     
     SubClassOf: 
-        DemandSector
+        OEO_00000128
     
     
-Class: TransportSector
+Class: OEO_00000422
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption in transport covers all transport activity (in mobile engines) regardless of the economic sector to which it is contributing, and is specified as follows:
@@ -445,35 +467,38 @@ Class: TransportSector
 * Rail, including industrial railways.
 * Pipeline transport
 * Domestic navigation
-* Non-specified: includes all transport not elsewhere specified."@en
+* Non-specified: includes all transport not elsewhere specified."@en,
+        rdfs:label "transport sector"
     
     SubClassOf: 
-        Sector
+        OEO_00000367
     
     
-Class: User
+Class: OEO_00000431
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit."
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
+        rdfs:label "user"
     
     SubClassOf: 
-        Agent
+        OEO_00000051
     
     
-Individual: Eurostat_Energy_Balances
+Individual: OEO_00000160
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This is a general description of an energy balance. A link to a complete Eurostat energy balance is provided under the URL for 'definition source'",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php/Energy_balance#What_is_an_energy_balance.3F"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php/Energy_balance#What_is_an_energy_balance.3F",
+        rdfs:label "eurostat_ energy_ balances"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
-Individual: German_Energy_Balances
+Individual: OEO_00000193
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
@@ -503,60 +528,65 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
     Hochseebunkerungen (Heizöl, Dieselkraftstoff und Schmierstoffe für die nationale und internationale Seeschifffahrt in deutschen Häfen. Ohne Lieferungen an Binnen- und Küstenmotorschiffe und Fischerei, die zum Sektor Verkehr (Endenergieverbrauch) zählen.)
     Bestandsveränderungen, getrennt erfasst nach Bestandsentnahmen und -aufstockungen",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115",
+        rdfs:label "german_ energy_ balances"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
-Individual: IPCC_1996_Guidelines
+Individual: OEO_00000242
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The sectoral approach taken for reporting greenhouse gas inventories under UNFCCC; version of 1996 (revised).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.ipcc-nggip.iges.or.jp/public/gl/invs6.html"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.ipcc-nggip.iges.or.jp/public/gl/invs6.html",
+        rdfs:label "ipcc_1996_ guidelines"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
-Individual: IPCC_2006_Guidelines
+Individual: OEO_00000243
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The sectoral approach taken for reporting greenhouse gas inventories under UNFCCC; version of 2006.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.ipcc-nggip.iges.or.jp/public/2006gl/index.html"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.ipcc-nggip.iges.or.jp/public/2006gl/index.html",
+        rdfs:label "ipcc_2006_ guidelines"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
-Individual: NACE_Sectors
+Individual: OEO_00000291
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Statistical_classification_of_economic_activities_in_the_European_Community_(NACE)"
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Statistical_classification_of_economic_activities_in_the_European_Community_(NACE)",
+        rdfs:label "nace_ sectors"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
-Individual: Renewable_Energy_Directive_Sectors
+Individual: OEO_00000355
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable Energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
+        rdfs:label "renewable_ energy_ directive_ sectors"
     
     Types: 
-        SectorDivision
+        OEO_00000368
     
     
 DisjointClasses: 
-    CommerceSector,HouseholdSector,IndustrySector
+    OEO_00000100,OEO_00000214,OEO_00000227
 
 DisjointClasses: 
-    ElectricitySector,HeatSector,TransportSector
+    OEO_00000145,OEO_00000213,OEO_00000422
 
 DisjointClasses: 
-    HouseholdSector,IndustrySector,TCSSector,TrafficSector
+    OEO_00000214,OEO_00000227,OEO_00000405,OEO_00000418
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -529,7 +529,7 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
     Bestandsveränderungen, getrennt erfasst nach Bestandsentnahmen und -aufstockungen",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115",
-        rdfs:label "german_ energy_ balances"
+        rdfs:label "german energy balances"
     
     Types: 
         OEO_00000368

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -492,7 +492,7 @@ Individual: OEO_00000160
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This is a general description of an energy balance. A link to a complete Eurostat energy balance is provided under the URL for 'definition source'",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php/Energy_balance#What_is_an_energy_balance.3F",
-        rdfs:label "eurostat_ energy_ balances"
+        rdfs:label "eurostat energy balances"
     
     Types: 
         OEO_00000368

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -573,7 +573,7 @@ NACE is a four-digit classification providing the framework for collecting and p
 Individual: OEO_00000355
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
         rdfs:label "renewable_ energy_ directive_ sectors"
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -307,7 +307,7 @@ Class: OEO_00000158
 Class: OEO_00000213
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "energy used for heating and cooling for buildings and industry"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy used for heating and cooling for buildings and industry"@en,
         rdfs:label "heating and cooling sector"
     
     SubClassOf: 
@@ -589,4 +589,3 @@ DisjointClasses:
 
 DisjointClasses: 
     OEO_00000214,OEO_00000227,OEO_00000405,OEO_00000418
-


### PR DESCRIPTION
Update the ontology (all three modules) to use numeric identifiers of the form OEO_xxxxxxxx -- with generated sequential numbers for the xxx... -- for classes and individuals. 

Add rdfs:label with the old class name converted from camel case to lower case with space separating words. 

Correct all mentions of the class name in _annotations_ to use the _label_.

Correct all mentions of the class in _axioms_ to use the new _IRI_.

Closes #133 . 

Note that I did *not* change the object properties, these should be treated separately. 