### PR TITLE
make origin individuals classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Here is a template for new release sections
 - EnergyStorage (#276)
 - Turbine (#299)
 - Change to use numeric identifiers for classes and individuals (#133)
+- change origin individuals to classes (#321)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -474,26 +474,10 @@ Class: OEO_00000014
     
     EquivalentTo: 
         OEO_00000099
-         and (has_origin value OEO_00000171)
+         and (has_origin some OEO_00030002)
     
     SubClassOf: 
-        has_origin value OEO_00000018
-    
-    
-Class: OEO_00000015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil portion of matter is a portion of matter with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil portion of matter"
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (has_origin value OEO_00000171)
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin value OEO_00000018
+        has_origin some OEO_00030003
     
     
 Class: OEO_00000016
@@ -614,7 +598,7 @@ Class: OEO_00000026
     
     SubClassOf: 
         OEO_00000331,
-        has_origin value OEO_00000002
+        has_origin some OEO_00030000
     
     
 Class: OEO_00000027
@@ -693,7 +677,7 @@ Class: OEO_00000033
     
     EquivalentTo: 
         OEO_00000173
-         and (has_origin value OEO_00000354)
+         and (has_origin some OEO_00030004)
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
@@ -750,7 +734,7 @@ Class: OEO_00000038
     
     SubClassOf: 
         OEO_00000331,
-        has_origin value OEO_00000002
+        has_origin some OEO_00030000
     
     
 Class: OEO_00000039
@@ -773,10 +757,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030003,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000018
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000041
@@ -998,10 +982,10 @@ Class: OEO_00000071
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000256,
-        has_origin value OEO_00000076
+        has_normal_state_of_matter value OEO_00000256
     
     
 Class: OEO_00000072
@@ -1015,13 +999,13 @@ Biofuels can be derived directly from plants (i.e. energy crops), or indirectly 
     
     EquivalentTo: 
         OEO_00000173
-         and (has_origin value OEO_00000076)
+         and (has_origin some OEO_00030001)
     
     SubClassOf: 
         OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_origin value OEO_00000076,
-        has_origin value OEO_00000354
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00000073
@@ -1043,8 +1027,8 @@ Class: OEO_00000074
     
     SubClassOf: 
         OEO_00000072,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_origin value OEO_00000076
+        has_origin some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00000075
@@ -1058,10 +1042,10 @@ Class: OEO_00000075
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000256,
-        has_origin value OEO_00000076
+        has_normal_state_of_matter value OEO_00000256
     
     
 Class: OEO_00000077
@@ -1104,10 +1088,10 @@ Class: OEO_00000084
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000076
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000086
@@ -1129,10 +1113,10 @@ Class: OEO_00000088
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000171
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000089
@@ -1996,7 +1980,7 @@ Class: OEO_00000219
     
     SubClassOf: 
         OEO_00000331,
-        has_origin value OEO_00000002
+        has_origin some OEO_00030000
     
     
 Class: OEO_00000220
@@ -2008,9 +1992,9 @@ Class: OEO_00000220
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030005,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_origin value OEO_00000404
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00000221
@@ -2230,8 +2214,8 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
     
     SubClassOf: 
         OEO_00000088,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000171
+        has_origin some OEO_00030002,
+        has_normal_state_of_matter value OEO_00000390
     
     DisjointWith: 
         OEO_00000204
@@ -2288,14 +2272,14 @@ Class: OEO_00000258
     
     EquivalentTo: 
         OEO_00000173
+         and (has_origin some OEO_00030001)
          and (has_normal_state_of_matter value OEO_00000256)
-         and (has_origin value OEO_00000076)
     
     SubClassOf: 
         OEO_00000072,
-        has_normal_state_of_matter value OEO_00000256,
-        has_origin value OEO_00000076,
-        has_origin value OEO_00000354
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
+        has_normal_state_of_matter value OEO_00000256
     
     
 Class: OEO_00000259
@@ -2329,10 +2313,10 @@ Class: OEO_00000263
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182,
-        has_origin value OEO_00000171
+        has_normal_state_of_matter value OEO_00000182
     
     
 Class: OEO_00000269
@@ -2420,10 +2404,10 @@ It does not include gases created by anaerobic digestion of biomass (e.g. munici
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182,
-        has_origin value OEO_00000171
+        has_normal_state_of_matter value OEO_00000182
     
     
 Class: OEO_00000293
@@ -2502,7 +2486,7 @@ Class: OEO_00000299
     
     SubClassOf: 
         OEO_00000290,
-        has_origin value OEO_00000171
+        has_origin some OEO_00030002
     
     
 Class: OEO_00000300
@@ -2610,9 +2594,9 @@ It consists of hydrocarbons of various molecular weights and other organic compo
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_origin value OEO_00000171
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00000310
@@ -2674,10 +2658,10 @@ This definition is without prejudice to the definition of renewable energy sourc
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000171
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000321
@@ -2699,7 +2683,7 @@ Class: OEO_00000322
     
     SubClassOf: 
         OEO_00000331,
-        has_origin value OEO_00000002
+        has_origin some OEO_00030000
     
     
 Class: OEO_00000324
@@ -2747,16 +2731,16 @@ Class: OEO_00000332
         rdfs:label "solid biofuel"@en
     
     EquivalentTo: 
-        (has_normal_state_of_matter value OEO_00000390)
-         and (has_origin value OEO_00000076)
+        (has_origin some OEO_00030001)
+         and (has_normal_state_of_matter value OEO_00000390)
     
     SubClassOf: 
         OEO_00000331,
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000076,
-        has_origin value OEO_00000354
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000333
@@ -2886,8 +2870,8 @@ Class: OEO_00000356
     
     SubClassOf: 
         OEO_00000290,
-        has_origin value OEO_00000076,
-        has_origin value OEO_00000354
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004
     
     
 Class: OEO_00000357
@@ -3084,14 +3068,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
         rdfs:label "solid fossil fuel"
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+        (has_origin some OEO_00030002)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
          and (has_normal_state_of_matter value OEO_00000390)
-         and (has_origin value OEO_00000171)
     
     SubClassOf: 
         OEO_00000173,
-        has_normal_state_of_matter value OEO_00000390,
-        has_origin value OEO_00000171
+        has_origin some OEO_00030002,
+        has_normal_state_of_matter value OEO_00000390
     
     
 Class: OEO_00000395
@@ -3437,35 +3421,66 @@ Class: OEO_00000449
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
     
     
-Individual: OEO_00000002
+Class: OEO_00030000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is anthropogenic if it was created by human activity.",
-        rdfs:label "anthropogenic"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
+        rdfs:label "anthropogenic"@de
     
-    Types: 
+    SubClassOf: 
         OEO_00000316
     
     
-Individual: OEO_00000018
+Class: OEO_00030001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is geogenic if it is the result of geological processes.",
-        rdfs:label "geogenic"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
+        rdfs:label "biogenic"@de
     
-    Types: 
+    SubClassOf: 
         OEO_00000316
     
     
-Individual: OEO_00000076
+Class: OEO_00030002
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is biogenic if it is made by or produce from life forms.",
-        rdfs:label "biogenic"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
+
+In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        rdfs:label "fossil"@de
     
-    Types: 
-        OEO_00000316,
-        has_origin some OEO_00000316
+    SubClassOf: 
+        OEO_00030003
+    
+    
+Class: OEO_00030003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
+        rdfs:label "geogenic"@de
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "renewable is an origin of portions of matter who replenish to replace the portion depleted in a finite amount of time in a human time scale.",
+        rdfs:label "renewable"@de
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
+        rdfs:label "synthetic"@de
+    
+    SubClassOf: 
+        OEO_00000316
     
     
 Individual: OEO_00000110
@@ -3475,19 +3490,6 @@ Individual: OEO_00000110
     
     Types: 
         OEO_00000358
-    
-    
-Individual: OEO_00000171
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is fossil if it was created from organic material by geolocial processes lasting thousands or millions of years.
-
-In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        rdfs:label "fossil"
-    
-    Types: 
-        OEO_00000316,
-        has_origin some OEO_00000316
     
     
 Individual: OEO_00000182
@@ -3541,18 +3543,6 @@ Individual: OEO_00000326
         OEO_00000395
     
     
-Individual: OEO_00000354
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is renewable if will replenish to replace the portion depleted in a finite amount of time in a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Adapted from https://en.wikipedia.org/w/index.php?title=Renewable_resource&oldid=926207362",
-        rdfs:label "renewable"
-    
-    Types: 
-        OEO_00000316,
-        has_origin some OEO_00000316
-    
-    
 Individual: OEO_00000373
 
     Annotations: 
@@ -3570,17 +3560,6 @@ Individual: OEO_00000390
     
     Types: 
         OEO_00000395
-    
-    
-Individual: OEO_00000404
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x is synthetic if it was created artifically by a chemical process.",
-        rdfs:label "synthetic"
-    
-    Types: 
-        OEO_00000316,
-        has_origin some OEO_00000316
     
     
 DisjointClasses: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3426,6 +3426,8 @@ Class: OEO_00030000
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "anthropogenic"@de
     
     SubClassOf: 
@@ -3436,6 +3438,8 @@ Class: OEO_00030001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
         rdfs:label "biogenic"@de
     
     SubClassOf: 
@@ -3448,6 +3452,8 @@ Class: OEO_00030002
         <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
 
 In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
         rdfs:label "fossil"@de
     
     SubClassOf: 
@@ -3458,6 +3464,8 @@ Class: OEO_00030003
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         rdfs:label "geogenic"@de
     
     SubClassOf: 
@@ -3468,6 +3476,8 @@ Class: OEO_00030004
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "renewable is an origin of portions of matter who replenish to replace the portion depleted in a finite amount of time in a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
         rdfs:label "renewable"@de
     
     SubClassOf: 
@@ -3478,6 +3488,8 @@ Class: OEO_00030005
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
         rdfs:label "synthetic"@de
     
     SubClassOf: 
@@ -3565,3 +3577,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3428,7 +3428,7 @@ Class: OEO_00030000
         <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "anthropogenic"@de
+        rdfs:label "anthropogenic"
     
     SubClassOf: 
         OEO_00000316
@@ -3440,7 +3440,7 @@ Class: OEO_00030001
         <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "biogenic"@de
+        rdfs:label "biogenic"
     
     SubClassOf: 
         OEO_00000316
@@ -3454,7 +3454,7 @@ Class: OEO_00030002
 In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "fossil"@de
+        rdfs:label "fossil"
     
     SubClassOf: 
         OEO_00030003
@@ -3466,7 +3466,7 @@ Class: OEO_00030003
         <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "geogenic"@de
+        rdfs:label "geogenic"
     
     SubClassOf: 
         OEO_00000316
@@ -3478,7 +3478,7 @@ Class: OEO_00030004
         <http://purl.obolibrary.org/obo/IAO_0000115> "renewable is an origin of portions of matter who replenish to replace the portion depleted in a finite amount of time in a human time scale.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "renewable"@de
+        rdfs:label "renewable"
     
     SubClassOf: 
         OEO_00000316
@@ -3490,7 +3490,7 @@ Class: OEO_00030005
         <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "synthetic"@de
+        rdfs:label "synthetic"
     
     SubClassOf: 
         OEO_00000316

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -141,6 +141,12 @@ ObjectProperty: has_normal_state_of_matter
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
     
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
     
 ObjectProperty: has_origin
 
@@ -149,6 +155,12 @@ ObjectProperty: has_origin
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000316
     
     
 ObjectProperty: has_physical_input
@@ -211,6 +223,12 @@ ObjectProperty: has_state_of_matter
 
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
     
     
 ObjectProperty: is_applied_to_object


### PR DESCRIPTION
closes #240
this changes all the origin individuals to classes without destroying the relations.

deletes the now obsolete "Fossil portion of matter" class and makes "fossil" subclass of "geogenic" instead.

Defs are fitted to class instead of individual defs