### PR TITLE
delete geographic classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Here is a template for new release sections
   ontology inconsistent (#51)
 - contact and subclasses (#101)
 - subclasses of assumption (#102)
+- GeographicRegion and subclasses (#322)
 
 
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -838,15 +838,6 @@ Generally, flows in the model can not be controlled but are a function of the re
         OEO_00000253
     
     
-Class: OEO_00000050
-
-    Annotations: 
-        rdfs:label "additional to address"
-    
-    SubClassOf: 
-        OEO_00000247
-    
-    
 Class: OEO_00000053
 
     Annotations: 
@@ -1110,16 +1101,6 @@ Class: OEO_00000084
         has_origin value OEO_00000076
     
     
-Class: OEO_00000086
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A city is a large human settlement."@en,
-        rdfs:label "city"
-    
-    SubClassOf: 
-        OEO_00000247
-    
-    
 Class: OEO_00000088
 
     Annotations: 
@@ -1242,26 +1223,6 @@ Class: OEO_00000106
     
     SubClassOf: 
         OEO_00000350
-    
-    
-Class: OEO_00000109
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A continent is a large landmass on the earth."@en,
-        rdfs:label "continent"
-    
-    SubClassOf: 
-        OEO_00000247
-    
-    
-Class: OEO_00000113
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A country is a geographic region that is an distinct political entity."@en,
-        rdfs:label "country"
-    
-    SubClassOf: 
-        OEO_00000247
     
     
 Class: OEO_00000115
@@ -1549,16 +1510,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
         OEO_00000061
     
     
-Class: OEO_00000164
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A federal state is a geographic region that is a political entity within a country. It is partially self governing."@en,
-        rdfs:label "federal state"
-    
-    SubClassOf: 
-        OEO_00000247
-    
-    
 Class: OEO_00000165
 
     Annotations: 
@@ -1593,9 +1544,6 @@ Class: OEO_00000168
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    DisjointWith: 
-        OEO_00000305
     
     
 Class: OEO_00000169
@@ -1750,16 +1698,6 @@ Class: OEO_00000189
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
-    
-    
-Class: OEO_00000190
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic region is a delimited part of the earth."@en,
-        rdfs:label "geographic region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
 Class: OEO_00000191
@@ -2198,15 +2136,6 @@ Kerosene is widely used to power jet engines of aircraft (jet fuel) and some roc
         has_normal_state_of_matter value OEO_00000256
     
     
-Class: OEO_00000247
-
-    Annotations: 
-        rdfs:label "land"
-    
-    SubClassOf: 
-        OEO_00000190
-    
-    
 Class: OEO_00000248
 
     Annotations: 
@@ -2308,18 +2237,6 @@ Class: OEO_00000259
     
     SubClassOf: 
         OEO_00000283
-    
-    
-Class: OEO_00000260
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A load area is an area that contains energy consumption.
-
-Source: https://wiki.openmod-initiative.org/wiki/Load_area"@en,
-        rdfs:label "load area"
-    
-    SubClassOf: 
-        OEO_00000247
     
     
 Class: OEO_00000263
@@ -2555,18 +2472,6 @@ Class: OEO_00000303
         OEO_00000031,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000305
-
-    Annotations: 
-        rdfs:label "ocean"
-    
-    SubClassOf: 
-        OEO_00000441
-    
-    DisjointWith: 
-        OEO_00000168
     
     
 Class: OEO_00000306
@@ -2946,15 +2851,6 @@ Class: OEO_00000363
     
     DisjointWith: 
         OEO_00000357, OEO_00000409
-    
-    
-Class: OEO_00000366
-
-    Annotations: 
-        rdfs:label "sea"
-    
-    SubClassOf: 
-        OEO_00000190
     
     
 Class: OEO_00000369
@@ -3586,3 +3482,4 @@ Individual: OEO_00000404
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+


### PR DESCRIPTION
closes #229
as we want to implement a geographic ontology, this deletes our own classes.
Deletes: GeographicRegion, AdditionalToAdress, City, Continent, Country, FederalState, LoadArea, Sea, Land, Ocean