### PR TITLE
delete type and subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Here is a template for new release sections
   ontology inconsistent (#51)
 - contact and subclasses (#101)
 - subclasses of assumption (#102)
+- type and subclasses (#325)
 
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -700,24 +700,6 @@ source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
         <http://purl.obolibrary.org/obo/IAO_0000028>
     
     
-Class: OEO_00000135
-
-    Annotations: 
-        rdfs:label "ecological"
-    
-    SubClassOf: 
-        OEO_00000427
-    
-    
-Class: OEO_00000137
-
-    Annotations: 
-        rdfs:label "economical"
-    
-    SubClassOf: 
-        OEO_00000427
-    
-    
 Class: OEO_00000149
 
     Annotations: 
@@ -1187,15 +1169,6 @@ Class: OEO_00000372
         OEO_00000201
     
     
-Class: OEO_00000375
-
-    Annotations: 
-        rdfs:label "social"
-    
-    SubClassOf: 
-        OEO_00000427
-    
-    
 Class: OEO_00000378
 
     Annotations: 
@@ -1282,15 +1255,6 @@ Class: OEO_00000403
         OEO_00000149
     
     
-Class: OEO_00000406
-
-    Annotations: 
-        rdfs:label "technical"
-    
-    SubClassOf: 
-        OEO_00000427
-    
-    
 Class: OEO_00000408
 
     Annotations: 
@@ -1345,15 +1309,6 @@ Class: OEO_00000423
     
     SubClassOf: 
         OEO_00000201
-    
-    
-Class: OEO_00000427
-
-    Annotations: 
-        rdfs:label "type"
-    
-    SubClassOf: 
-        OEO_00000119
     
     
 Class: OEO_00000428


### PR DESCRIPTION
part of #249 

leave out (=delete) type and subclasses for now and discuss them later.
Deletes: type, ecological, economical, social, technical.

This PR solves the part relevant for the first release milestone