### PR TITLE
delete cost classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Here is a template for new release sections
   ontology inconsistent (#51)
 - contact and subclasses (#101)
 - subclasses of assumption (#102)
-- delete cost and subclasses (#326)
+- cost and subclasses (#326)
 - GeographicRegion and subclasses (#322)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,6 @@ Here is a template for new release sections
   ontology inconsistent (#51)
 - contact and subclasses (#101)
 - subclasses of assumption (#102)
-
+- delete cost and subclasses (#326)
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -601,15 +601,6 @@ Class: OEO_00000111
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: OEO_00000112
-
-    Annotations: 
-        rdfs:label "cost"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    
 Class: OEO_00000118
 
     Annotations: 
@@ -755,15 +746,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: OEO_00000167
-
-    Annotations: 
-        rdfs:label "fixed operation cost"
-    
-    SubClassOf: 
-        OEO_00000112
-    
-    
 Class: OEO_00000172
 
     Annotations: 
@@ -772,15 +754,6 @@ Class: OEO_00000172
     
     SubClassOf: 
         OEO_00000162
-    
-    
-Class: OEO_00000176
-
-    Annotations: 
-        rdfs:label "fuel price"
-    
-    SubClassOf: 
-        OEO_00000112
     
     
 Class: OEO_00000177
@@ -833,15 +806,6 @@ Class: OEO_00000239
     
     SubClassOf: 
         OEO_00000381
-    
-    
-Class: OEO_00000241
-
-    Annotations: 
-        rdfs:label "investment cost"
-    
-    SubClassOf: 
-        OEO_00000112
     
     
 Class: OEO_00000249
@@ -1392,15 +1356,6 @@ Class: OEO_00000435
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000436
-
-    Annotations: 
-        rdfs:label "variable operation cost"
-    
-    SubClassOf: 
-        OEO_00000112
     
     
 Class: OEO_00000445


### PR DESCRIPTION
part of #268 
leave out cost and subclasses for now to discuss them later.

deletes: cost, fuel price, investment cost, variable operation cost, fixed operation cost

this PR solves the part of the issue needed for the first release milestone