### PR TITLE
delete time step, series and horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,6 @@ Here is a template for new release sections
   ontology inconsistent (#51)
 - contact and subclasses (#101)
 - subclasses of assumption (#102)
-
+- time step, time series, time horizon (#327)
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1301,33 +1301,6 @@ Class: OEO_00000408
         <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
-Class: OEO_00000413
-
-    Annotations: 
-        rdfs:label "time horizon"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    
-Class: OEO_00000414
-
-    Annotations: 
-        rdfs:label "time series"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    
-Class: OEO_00000415
-
-    Annotations: 
-        rdfs:label "time step"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    
 Class: OEO_00000419
 
     Annotations: 


### PR DESCRIPTION
part of #267 

leaves out (= deletes) the classes: time step, time horizon, time series for the first release.

This PR solves the part of the issue relevant for the first release milestone.