### PR TITLE
Feature/templates #332

### DIFF
--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -23,6 +23,5 @@ If you already have ideas for the solution describe them here
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that
-- [ ] every new entry in the ontology should have an annotation
+- [ ] every entry in the ontology should have a definition
 - [ ] classes should arise from concepts rather than from words
-- [ ] class or property names should follow the [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case)

--- a/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
+++ b/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
@@ -23,6 +23,5 @@ If you already have ideas for the solution describe them here
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that
-- [ ] every entry in the ontology should have an annotation
+- [ ] every entry in the ontology should have a definition
 - [ ] classes should arise from concepts rather than from words
-- [ ] class or property names should follow the [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case)

--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -23,6 +23,5 @@ If you already have ideas for the solution describe them here
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that
-- [ ] every entry in the ontology should have an annotation
+- [ ] every entry in the ontology should have a definition
 - [ ] classes should arise from concepts rather than from words
-- [ ] class or property names should follow the [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ### Prerequisites
 
 - [Git](https://git-scm.com/)
+- please make sure you changed your protégé settings to [numerical identifiers](https://github.com/OpenEnergyPlatform/ontology/wiki/Numerical-Identifiers) and got a personal ID to add new classes.
 
 ### Contribution of OEO content
 Please read the [OEO best practices](https://github.com/OpenEnergyPlatform/ontology/wiki/Best-Practice-Principles) carefully.


### PR DESCRIPTION
closes #332 
- deletes CamelCase reminder from issue templates
- specifies that every entry in the ontology should have a definition (not just any annotation)