### PR TITLE
delete unused and undefined object properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,5 +77,6 @@ Here is a template for new release sections
 - GeographicRegion and subclasses (#322)
 - Validation and subclasses (#347)
 - SoftwareElement (#348)
+- unused object properties (#351)
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -88,41 +88,11 @@ ObjectProperty: conforms_to
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     
-ObjectProperty: data_provided
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
-ObjectProperty: generates_dataset
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    
-ObjectProperty: hasNumeral
-
-    
-ObjectProperty: hasUnitofMeasurement
-
-    
-ObjectProperty: has_approach_to_uncertainty
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
-    
 ObjectProperty: has_author
 
     
 ObjectProperty: has_client
 
-    
-ObjectProperty: has_complexity
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
     
 ObjectProperty: has_constraint
 
@@ -138,25 +108,6 @@ ObjectProperty: has_contact
     
 ObjectProperty: has_funding_source
 
-    
-ObjectProperty: has_license
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
-ObjectProperty: has_logo
-
-    SubPropertyOf: 
-        is_referenced_by,
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
-    
-ObjectProperty: has_mathematical_objective
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
     
 ObjectProperty: has_numercical_input
 
@@ -254,12 +205,6 @@ ObjectProperty: has_spatial_resolution
         has_resolution
     
     
-ObjectProperty: has_support_community_forum
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
 ObjectProperty: has_temporal_resolution
 
     Annotations: 
@@ -284,45 +229,6 @@ ObjectProperty: has_tool
         OEO_00000274
     
     
-ObjectProperty: has_typical_computation_hardware
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: has_typical_computation_time
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: has_website
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
-ObjectProperty: is_available_on_GitHub
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
-ObjectProperty: is_referenced_by
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    InverseOf: 
-        references
-    
-    
-ObjectProperty: link_to_source_code
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
 ObjectProperty: makes_assumption
 
     Annotations: 
@@ -335,21 +241,6 @@ ObjectProperty: makes_assumption
 ObjectProperty: owl:topObjectProperty
 
     
-ObjectProperty: references
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    InverseOf: 
-        is_referenced_by
-    
-    
-ObjectProperty: source_code_available
-
-    SubPropertyOf: 
-        is_referenced_by
-    
-    
 ObjectProperty: uses
 
     
@@ -360,42 +251,6 @@ ObjectProperty: uses_dataset
     
     SubPropertyOf: 
         uses
-    
-    
-ObjectProperty: uses_external_optimizer
-
-    SubPropertyOf: 
-        uses
-    
-    
-ObjectProperty: uses_software
-
-    SubPropertyOf: 
-        uses
-    
-    
-ObjectProperty: uses_software_internal_data_processing
-
-    SubPropertyOf: 
-        uses_software
-    
-    
-ObjectProperty: uses_software_modelling
-
-    SubPropertyOf: 
-        uses_software
-    
-    
-ObjectProperty: utilizes_dataset
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    
-ObjectProperty: utilizes_program_parameter
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -122,18 +122,6 @@ ObjectProperty: covers_energycarrier
         OEO_00000151
     
     
-ObjectProperty: has_globalwarmingpotential
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        OEO_00000198
-    
-    Range: 
-        OEO_00000194
-    
-    
 ObjectProperty: has_normal_state_of_matter
 
     Annotations: 
@@ -187,36 +175,6 @@ ObjectProperty: has_physical_output
         <http://purl.obolibrary.org/obo/RO_0002234>
     
     
-ObjectProperty: has_pollutant
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        OEO_00000147
-    
-    Range: 
-        OEO_00000330
-    
-    
-ObjectProperty: has_sink
-
-    SubPropertyOf: 
-        is_connected_to
-    
-    DisjointWith: 
-        has_source
-    
-    
-ObjectProperty: has_source
-
-    SubPropertyOf: 
-        is_connected_to
-    
-    DisjointWith: 
-        has_sink
-    
-    
 ObjectProperty: has_state_of_matter
 
     SubPropertyOf: 
@@ -242,15 +200,6 @@ ObjectProperty: is_applied_to_object
     
     InverseOf: 
         applies_technology
-    
-    
-ObjectProperty: is_connected_to
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Characteristics: 
-        Symmetric
     
     
 ObjectProperty: is_equivalent_to

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -183,9 +183,6 @@ ObjectProperty: has_physical_input
     
 ObjectProperty: has_physical_output
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en
-    
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -171,6 +171,9 @@ ObjectProperty: has_physical_input
     
 ObjectProperty: has_physical_output
 
+    Annotations: 
+        definition "A relation that holds between a transformation and its output."
+    
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -206,9 +206,6 @@ ObjectProperty: has_physical_output
         Asymmetric
     
     
-ObjectProperty: has_pollutant
-
-    
 ObjectProperty: has_programvariable
 
     SubPropertyOf: 
@@ -218,32 +215,11 @@ ObjectProperty: has_programvariable
 ObjectProperty: has_resolution
 
     
-ObjectProperty: has_sink
-
-    DisjointWith: 
-        has_source
-    
-    
-ObjectProperty: has_source
-
-    DisjointWith: 
-        has_sink
-    
-    
 ObjectProperty: has_spatial_resolution
 
     
 ObjectProperty: has_state_of_matter
 
-    
-ObjectProperty: has_subregion
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a region and a smaller region within."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
     
 ObjectProperty: has_temporal_resolution
 
@@ -256,12 +232,6 @@ ObjectProperty: has_tool
     
 ObjectProperty: is_applied_to_object
 
-    
-ObjectProperty: is_connected_to
-
-    Characteristics: 
-        Symmetric
-    
     
 ObjectProperty: is_equivalent_to
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -90,26 +90,11 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
-ObjectProperty: appliesTo
-
-    
-ObjectProperty: comparesTo
-
-    
 ObjectProperty: conforms_to
 
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
     
-    
-ObjectProperty: considers_User_behaviour_and_demand
-
-    SubPropertyOf: 
-        covers
-    
-    
-ObjectProperty: contains
-
     
 ObjectProperty: covers
 
@@ -144,60 +129,6 @@ ObjectProperty: covers_timeframe
         covers
     
     
-ObjectProperty: distributes
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: example_research_questions
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: further_reference_properties
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: generates_dataset
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    
-ObjectProperty: handles_uncertainty
-
-    
-ObjectProperty: hasMaximum
-
-    SubPropertyOf: 
-        comparesTo
-    
-    
-ObjectProperty: hasMinimum
-
-    SubPropertyOf: 
-        comparesTo
-    
-    
-ObjectProperty: hasYear
-
-    
-ObjectProperty: has_Percentage
-
-    SubPropertyOf: 
-        comparesTo
-    
-    
-ObjectProperty: has_approach_to_uncertainty
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
-    
 ObjectProperty: has_author
 
     SubPropertyOf: 
@@ -219,9 +150,6 @@ ObjectProperty: has_contact
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     
-ObjectProperty: has_documentation
-
-    
 ObjectProperty: has_funding_source
 
     SubPropertyOf: 
@@ -232,30 +160,6 @@ ObjectProperty: has_institution
 
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
-ObjectProperty: has_license
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
-ObjectProperty: has_logo
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
-    
-ObjectProperty: has_mathematical_objective
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-    
-    
-ObjectProperty: has_methodical_Focus
-
-    SubPropertyOf: 
-        owl:topObjectProperty
     
     
 ObjectProperty: has_normal_state_of_matter
@@ -311,9 +215,6 @@ ObjectProperty: has_programvariable
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     
-ObjectProperty: has_quality
-
-    
 ObjectProperty: has_resolution
 
     
@@ -353,12 +254,6 @@ ObjectProperty: has_tool
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     
-ObjectProperty: isEqual
-
-    SubPropertyOf: 
-        comparesTo
-    
-    
 ObjectProperty: is_applied_to_object
 
     
@@ -377,37 +272,10 @@ ObjectProperty: is_used_by
 ObjectProperty: owl:topObjectProperty
 
     
-ObjectProperty: suited_for_many_scenarios
-
-    
-ObjectProperty: transmits
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
 ObjectProperty: uses
 
     
 ObjectProperty: uses_dataset
-
-    
-ObjectProperty: uses_external_optimizer
-
-    
-ObjectProperty: uses_software
-
-    
-ObjectProperty: uses_software_internal_data_processing
-
-    
-ObjectProperty: uses_software_modelling
-
-    
-ObjectProperty: utilizes_dataset
-
-    
-ObjectProperty: utilizes_program_parameter
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>


### PR DESCRIPTION
part of #66.
I deleted all unused and undefined object properties except for "conforms_to" because I think that one is important for sectors and should get a definition instead. I also deleted "has_subregion" even if it had a definition because it is geographical and we want to import that externally.

I also think we should continue in another pull request and delete some of the unused and defined object properties too.

