### PR TITLE
add state of matter equivalent classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - RenewableEnergyCarrier (#206)
 - ChemicalEnergy (#214)
 - scenario subclasses (#344)
+- state of matter defined classes (#354)
 
 ### Changed
 - Restructured the repository to add a 'src' folder with an 'ontology' sub-folder with sub-folders for editable modules and import modules (#200)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3239,6 +3239,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
 Class: OEO_00030011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gaseous portion of matter is portion of matter with its normal state of matter being gaseous.",
         rdfs:label "gaseous portion of matter"@de
     
     EquivalentTo: 
@@ -3252,6 +3253,7 @@ Class: OEO_00030011
 Class: OEO_00030012
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid portion of matter is portion of matter with its normal state of matter being solid.",
         rdfs:label "solid portion of matter"@de
     
     EquivalentTo: 
@@ -3265,6 +3267,7 @@ Class: OEO_00030012
 Class: OEO_00030013
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid portion of matter is portion of matter with its normal state of matter being liquid.",
         rdfs:label "liquid portion of matter"@de
     
     EquivalentTo: 
@@ -3278,6 +3281,7 @@ Class: OEO_00030013
 Class: OEO_00030014
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plasmatic portion of matter is portion of matter with its normal state of matter being plasmatic.",
         rdfs:label "plasmatic portion of matter"@de
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3240,6 +3240,8 @@ Class: OEO_00030011
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gaseous portion of matter is portion of matter with its normal state of matter being gaseous.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/354",
         rdfs:label "gaseous portion of matter"@de
     
     EquivalentTo: 
@@ -3254,6 +3256,8 @@ Class: OEO_00030012
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid portion of matter is portion of matter with its normal state of matter being solid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/354",
         rdfs:label "solid portion of matter"@de
     
     EquivalentTo: 
@@ -3268,6 +3272,8 @@ Class: OEO_00030013
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid portion of matter is portion of matter with its normal state of matter being liquid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/354",
         rdfs:label "liquid portion of matter"@de
     
     EquivalentTo: 
@@ -3282,6 +3288,8 @@ Class: OEO_00030014
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plasmatic portion of matter is portion of matter with its normal state of matter being plasmatic.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/354",
         rdfs:label "plasmatic portion of matter"@de
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3236,6 +3236,58 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
         OEO_00000316
     
     
+Class: OEO_00030011
+
+    Annotations: 
+        rdfs:label "gaseous portion of matter"@de
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (has_normal_state_of_matter value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00030012
+
+    Annotations: 
+        rdfs:label "solid portion of matter"@de
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (has_normal_state_of_matter value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00030013
+
+    Annotations: 
+        rdfs:label "liquid portion of matter"@de
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (has_normal_state_of_matter value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00030014
+
+    Annotations: 
+        rdfs:label "plasmatic portion of matter"@de
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (has_normal_state_of_matter value OEO_00000326)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
 Individual: OEO_00000110
 
     Annotations: 


### PR DESCRIPTION
closes #255.
Add equivalent classes for all the states of matter to get the portion of matter classes sorted by their state. 

gaseous portion of matter: "portion of matter its normal state of matter being gaseus"
- defined as: "'portion of matter' and 'has normal state of matter' gaseous"

same structure for liquid, solid, plasmatic.