### PR TITLE
add wiki link to mass nouns

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2550,6 +2550,7 @@ Class: OEO_00000331
         <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
         rdfs:label "portion of matter"
     
     SubClassOf: 


### PR DESCRIPTION
closes #261
add link from portion of matter to wiki explanation about mass nouns