### PR TITLE
add energy producer classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
 - ChemicalEnergy (#214)
 - scenario subclasses (#344)
 - state of matter defined classes (#354)
+- energy producers (#370)
 
 ### Changed
 - Restructured the repository to add a 'src' folder with an 'ontology' sub-folder with sub-folders for editable modules and import modules (#200)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -522,7 +522,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organizational energy producer whose primary activity is energy or heat production.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organizational energy producer whose primary activity is electrical energy and/or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -508,7 +508,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organizational energy producer who produces energy or heat wholly or partly for their own use as an activity which supports their primary activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organizational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
@@ -638,4 +638,3 @@ DisjointClasses:
 
 DisjointClasses: 
     OEO_00000214,OEO_00000227,OEO_00000405,OEO_00000418
-

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -199,6 +199,8 @@ Class: OEO_00000045
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "producer"
     
     SubClassOf: 
@@ -365,6 +367,8 @@ Class: OEO_00000315
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is a role depending on a society that has a collective goal and a set of organization rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "organization"
     
     SubClassOf: 
@@ -492,6 +496,8 @@ Class: OEO_00030016
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organizational energy producer is an organization that undertakes the generation of electricity and/or heat.\"",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "organizational energy producer"@de
     
     SubClassOf: 
@@ -504,6 +510,8 @@ Class: OEO_00030017
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organizational energy producer who produces energy or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:comment "They may be privately or publicly owned.",
         rdfs:label "energy autoproducer"@de
     
@@ -516,6 +524,8 @@ Class: OEO_00030018
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organizational energy producer whose primary activity is energy or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
         rdfs:label "main activity energy producer"@de
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -498,7 +498,7 @@ Class: OEO_00030016
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organizational energy producer"@de
+        rdfs:label "organizational energy producer"
     
     SubClassOf: 
         OEO_00000315,
@@ -513,7 +513,7 @@ Class: OEO_00030017
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:comment "They may be privately or publicly owned.",
-        rdfs:label "energy autoproducer"@de
+        rdfs:label "energy autoproducer"
     
     SubClassOf: 
         OEO_00030016
@@ -527,7 +527,7 @@ Class: OEO_00030018
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
-        rdfs:label "main activity energy producer"@de
+        rdfs:label "main activity energy producer"
     
     SubClassOf: 
         OEO_00030016

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -66,6 +66,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
+
+    
 ObjectProperty: conforms_to
 
     Domain: 
@@ -195,7 +198,7 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 Class: OEO_00000045
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods to sell them.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
         rdfs:label "producer"
     
     SubClassOf: 
@@ -361,11 +364,11 @@ Class: OEO_00000238
 Class: OEO_00000315
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is a structure with multiple people that has a collective goal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is a role depending on a society that has a collective goal and a set of organization rules.",
         rdfs:label "organization"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000323
     
     DisjointWith: 
@@ -484,6 +487,42 @@ Class: OEO_00000431
         OEO_00000051
     
     
+Class: OEO_00030016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organizational energy producer is an organization that undertakes the generation of electricity and/or heat.\"",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        rdfs:label "organizational energy producer"@de
+    
+    SubClassOf: 
+        OEO_00000315,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000045
+    
+    
+Class: OEO_00030017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organizational energy producer who produces energy or heat wholly or partly for their own use as an activity which supports their primary activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        rdfs:comment "They may be privately or publicly owned.",
+        rdfs:label "energy autoproducer"@de
+    
+    SubClassOf: 
+        OEO_00030016
+    
+    
+Class: OEO_00030018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organizational energy producer whose primary activity is energy or heat production.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
+        rdfs:label "main activity energy producer"@de
+    
+    SubClassOf: 
+        OEO_00030016
+    
+    
 Individual: OEO_00000160
 
     Annotations: 
@@ -589,3 +628,4 @@ DisjointClasses:
 
 DisjointClasses: 
     OEO_00000214,OEO_00000227,OEO_00000405,OEO_00000418
+


### PR DESCRIPTION
closes #314

changes definitions:
- **organization:** "An organization is a role depending on a society that has a collective goal and a set of organization rules."
   - accordingly moves this to role
- **producer:** "an agent that makes goods"

adds classes:
- **organizational energy producer:**: "An organization that undertakes generating electricity and/or heat."
SubClassOf: organisation and has_role some 'producer' (role)

- **"main activity energy producer":** "An organizational energy producer whose primary activity is energy or heat production."
Comment: They may be privately or publicly owned. Note that the sale need not take place through the public grid.

- **"energy autoproducer":** "An organizational energy producer who produces energy or heat wholly or partly for their own use as an activity which supports their primary activity."
Comment: They may be privately or publicly owned.