### PR TITLE
Restore deleted label and def to class heat

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1542,6 +1542,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    Annotations:
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "heat"
 
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000150>


### PR DESCRIPTION
Restores the deleted label and definition for class OEO:00000207 (heat). 

Closes #378 .