### PR TITLE
Include grid subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Here is a template for new release sections
 - change model def (#180)
 - change energy class (#224)
 - change power definition (#79)
+- grid, link, node, gris component (#36, #231)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Here is a template for new release sections
 - change model def (#180)
 - change energy class (#224)
 - change power definition (#79)
-- grid, link, node, gris component (#36, #231)
+- grid, link, node, grid component (#36, #231)
 
 ### Removed
 - `ObjectProperty` `has_stateofmatter` (#39)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3005,6 +3005,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020005
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid is a supply grid that distributes thermal energy via circulatring steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "heating grid"@en
@@ -3056,3 +3057,4 @@ Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
     
 DisjointClasses: 
     <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1211,7 +1211,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "electricity grid component"
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>)
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00020006>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1198,7 +1198,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
@@ -1210,7 +1211,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "electricity grid component"
     
     SubClassOf: 
-        OEO_00020006,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
         <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
     
     
@@ -2764,6 +2765,57 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
 
     Annotations: 
@@ -2926,7 +2978,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
     
     
 Class: OEO_00020005
@@ -2938,58 +2990,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
-    
-    
-Class: OEO_00020006
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: OEO_00020007
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid component is a grid component that is part of a gas grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "gas grid component"@en
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020008
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid component is a grid component that is part of a heating grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "heating grid component"@en
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020009
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -768,10 +768,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Alternating current high voltage transmission line. Can comprise multiple cables and multiple circuits.
-Generally, flows in the model can not be controlled but are a function of the resitance and electrochemical potential difference."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:comment "undirected",
-        rdfs:label "AC-Line"@en
+        rdfs:label "AC-line"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
@@ -971,16 +972,6 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000077>
         <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000080>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A node in an electrical network."@en,
-        rdfs:label "bus"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000294>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000082>
 
     Annotations: 
@@ -1129,10 +1120,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transmission system usind high voltage direct current.
-Genreally, flows in the model can be controlled/optimized."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:comment "directed",
-        rdfs:label "HVDC-Line"@en
+        rdfs:label "HVDC-line"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
@@ -1460,15 +1452,6 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000192>
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000197>
-
-    Annotations: 
-        rdfs:label "graph"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000024>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
 
     Annotations: 
@@ -1766,11 +1749,13 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000252>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An uninterrupted transmission system between two nodes in the electric grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerline is a grid component that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "power line"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
@@ -1927,16 +1912,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000294>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A network node is a node in an electrical grid."@en,
-        rdfs:label "network node"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
@@ -2305,18 +2280,6 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
         <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000369>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In electronics, a shunt is a device which allows electric current to pass around another point in the circuit by creating a low resistance path. The term is also widely used in photovoltaics to describe an unwanted short circuit between the front and back surface contacts of a solar cell, usually caused by wafer damage.
-
-Source: https://en.wikipedia.org/wiki/Shunt_%28electrical%29"@en,
-        rdfs:label "shunt impedance"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000294>
-    
-    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000374>
 
     Annotations: 
@@ -2500,7 +2463,7 @@ Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en,
         rdfs:label "transformer"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000294>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
@@ -2522,15 +2485,6 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000429>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000430>
-
-    Annotations: 
-        rdfs:label "undirected edge"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
@@ -2982,13 +2936,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020006
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a part of a supply grid serving a specific purpose."@en,
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "grid component"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: OEO_00020007
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00020008
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    SubClassOf: 
+        OEO_00020006
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -777,6 +777,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
     
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
 
@@ -1128,6 +1131,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
@@ -2456,10 +2462,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "1. A transformer is an electrical device that transfers electrical energy between two or more circuits through electromagnetic induction. A varying current in one coil of the transformer produces a varying magnetic field, which in turn induces a voltage in a second coil. Transformers are used to increase or decrease the alternating voltages in electric power applications.
-2. A transformer is a static machine used for transforming power from one circuit to another without changing frequency. This is a very basic definition of transformer. Since there is no rotating or moving part so transformer is a static device. Transformer operates on ac supply. Transformer works on the principle of mutual induction.
-
-Source: https://wiki.openmod-initiative.org/wiki/Transformer"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
         rdfs:label "transformer"
     
     SubClassOf: 
@@ -2919,7 +2925,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "gas grid"@de
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
     
     
 Class: OEO_00020005
@@ -2930,7 +2937,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "heating grid"@de
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
     
     
 Class: OEO_00020006
@@ -2969,6 +2977,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
     
     SubClassOf: 
         OEO_00020006
+    
+    
+Class: OEO_00020009
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2992,7 +2992,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
 Class: OEO_00020004
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a grid that distributes gaseous fuel, e.g. methane.",
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "gas grid"@en
@@ -3056,4 +3056,3 @@ Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
     
 DisjointClasses: 
     <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2640,7 +2640,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "ammonia"@de
+        rdfs:label "ammonia"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
@@ -2655,7 +2655,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010001>
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@de
+        rdfs:label "carbon monoxide"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
@@ -2670,7 +2670,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@de
+        rdfs:label "nitrogen oxides"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
@@ -2687,7 +2687,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010003>
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitric oxide"@de
+        rdfs:label "nitric oxide"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
@@ -2700,7 +2700,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010004>
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen dioxide"@de
+        rdfs:label "nitrogen dioxide"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
@@ -2713,7 +2713,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010007>
         <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "sulphur dioxide"@de
+        rdfs:label "sulphur dioxide"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
@@ -2728,7 +2728,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010009>
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@de
+        rdfs:label "PM10"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
@@ -2741,7 +2741,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010010>
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@de
+        rdfs:label "PM2.5"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
@@ -2753,7 +2753,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010011>
         <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatility"@de
+        rdfs:label "volatility"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -2765,7 +2765,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
         <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that has the disposition to participates in air pollution.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "air pollutant"@de
+        rdfs:label "air pollutant"@en
     
     EquivalentTo: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
@@ -2828,7 +2828,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
         <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@de
+        rdfs:label "switchyard"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
@@ -2982,7 +2982,7 @@ Class: OEO_00020003
         <http://openenergy-platform.org/ontology/oeo/definition> "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
-        rdfs:label "Energy transformation"@de
+        rdfs:label "Energy transformation"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -2994,7 +2994,7 @@ Class: OEO_00020004
         <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "gas grid"@de
+        rdfs:label "gas grid"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
@@ -3006,7 +3006,7 @@ Class: OEO_00020005
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "heating grid"@de
+        rdfs:label "heating grid"@en
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3005,7 +3005,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020005
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid is a supply grid that distributes thermal energy via circulatring steam or liquids."@en,
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "heating grid"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1199,7 +1199,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
@@ -1210,9 +1210,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "electricity grid component"
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+    EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
@@ -1762,7 +1764,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "power line"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
@@ -2435,12 +2438,12 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
         rdfs:label "storage unit"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000401>
@@ -2476,7 +2479,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "transformer"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
@@ -2793,6 +2797,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "gas grid component"@en
     
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
     
@@ -2805,6 +2813,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "heating grid component"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
@@ -2819,7 +2831,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "switchyard"@de
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1206,11 +1206,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a part of an electrical grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "electricity grid component"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00020006,
         <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
     
     
@@ -1498,7 +1500,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
         <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
         <http://purl.obolibrary.org/obo/IAO_0000118> "network",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/???
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
@@ -2959,7 +2961,7 @@ Class: OEO_00020004
     Annotations: 
         <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/???",
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "gas grid"@de
     
     SubClassOf: 
@@ -2970,11 +2972,23 @@ Class: OEO_00020005
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/???",
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "heating grid"@de
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: OEO_00020006
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
     
     
 Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1762,16 +1762,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "power line"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
 
     Annotations: 
-        rdfs:label "link"
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid component link"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000024>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
     
     DisjointWith: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
@@ -1924,10 +1927,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
 
     Annotations: 
-        rdfs:label "node"
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid node"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000024>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
     
     DisjointWith: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
@@ -2774,7 +2780,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "grid component"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1494,11 +1494,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/???
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:comment "Synonym: Network"@en,
-        rdfs:label "grid"
+        rdfs:label "supply grid"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
@@ -1542,12 +1546,13 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    Annotations:
+
+    Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
        The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
         rdfs:label "heat"
-
+    
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
     
@@ -2948,7 +2953,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
+    
+Class: OEO_00020004
 
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/???",
+        rdfs:label "gas grid"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: OEO_00020005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/???",
+        rdfs:label "heating grid"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
 Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1193,7 +1193,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
         rdfs:label "electricity grid"
@@ -2990,7 +2990,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-
 Class: OEO_00020004
 
     Annotations: 


### PR DESCRIPTION
#36 and #231
* Implement new subclasses of (supply) grid: *gas grid* and *heating grid*
* include *grid component* classify as artificial object, equivalent subclasses for electricity, gas and heating grid
* rename node to *grid node* and provide definition
* rename link to *grid component link* and provide definition
* delete *graph*, *network node*, 
* delete *bus*, *shunt impedance* temporarily
* provide defs for powerline and subclasses and classify as grid component
* include *switchyard* as subclass of grid component