### PR TITLE
delete issue project reminder from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -19,7 +19,6 @@ If you already have ideas for the solution describe them here
 
 - [ ] I discussed the issue with someone else than me before working on a solution
 - [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository
-- [ ] I added this issue to the Project 'Issues'. If suitable, I add it to further Projects. 
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that

--- a/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
+++ b/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
@@ -19,7 +19,6 @@ If you already have ideas for the solution describe them here
 
 - [ ] I discussed the issue with someone else than me before working on a solution
 - [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTE.md) for this repository
-- [ ] I added this issue to the Project 'Issues'. If suitable, I add it to further Projects. 
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that

--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -19,7 +19,6 @@ If you already have ideas for the solution describe them here
 
 - [ ] I discussed the issue with someone else than me before working on a solution
 - [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTING.md) for this repository
-- [ ] I added this issue to the Project 'Issues'. If suitable, I add it to further Projects. 
 - [ ] The [goal](https://github.com/OpenEnergyPlatform/ontology/blob/dev/README.md) of this ontology is clear to me 
 
 I am aware that

--- a/.github/ISSUE_TEMPLATE/-d--normal-issue.md
+++ b/.github/ISSUE_TEMPLATE/-d--normal-issue.md
@@ -18,4 +18,4 @@ If you already have ideas for the solution describe them here
 ## Workflow checklist
 
 - [ ] I am aware of the [workflow](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTING.md) for this repository
-- [ ] I added this issue to the Project 'Issues'. If suitable, I add it to further Projects.
+


### PR DESCRIPTION
closes #388 

deletes reminders to add the issue to the "Issues" project because a script is doing that automatically now.