### PR TITLE
delete wrong axiom of combustible energy carrier disposition

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1052,8 +1052,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
         rdfs:label "combustible energy carrier disposition"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000099>


### PR DESCRIPTION
closes #413.

Deletes "combustible energy carrier disposition": SubClassOf: "has disposition" some "energy carrier disposition"