### PR TITLE
Use https for OEP urls

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl" uri="imports/iao-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl" uri="imports/uo-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="imports/iao-minimal-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl" uri="imports/ro-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn" uri="edits/oeo-social.omn"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn" uri="edits/oeo-physical.omn"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn" uri="edits/oeo-model.omn"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/" uri="oeo.omn"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl" uri="imports/iao-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl" uri="imports/uo-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="imports/iao-minimal-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl" uri="imports/ro-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn" uri="edits/oeo-social.omn"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn" uri="edits/oeo-physical.omn"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn" uri="edits/oeo-model.omn"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/" uri="oeo.omn"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl" uri="http://purl.obolibrary.org/obo/bfo.owl"/>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="../imports/iao-minimal-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="../imports/iao-annotation-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl" uri="../imports/iao-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl" uri="../imports/ro-module.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="../imports/iao-minimal-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="../imports/iao-annotation-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl" uri="../imports/iao-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl" uri="../imports/ro-module.owl"/>
+    <uri id="Imports Wizard Entry" name="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <https://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -10,11 +10,11 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model/>
-<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
+Ontology: <https://openenergy-platform.org/ontology/oeo/oeo-model/>
+<https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <https://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -10,12 +10,12 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
-<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl>
+Ontology: <https://openenergy-platform.org/ontology/oeo/oeo-physical/>
+<https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <https://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -10,10 +10,10 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social/>
-<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
+Ontology: <https://openenergy-platform.org/ontology/oeo/oeo-social/>
+<https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 

--- a/src/ontology/imports/iao-annotation-module.owl
+++ b/src/ontology/imports/iao-annotation-module.owl
@@ -12,8 +12,8 @@
      xmlns:dcterms="dcterms:"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/iao-annotation-module.owl">
-        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl"/>
+    <owl:Ontology rdf:about="https://openenergy-platform.org/ontology/oeo/imports/iao-annotation-module.owl">
+        <owl:versionIRI rdf:resource="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl"/>
         <rdfs:comment>This file contains externally imported content from the Information Artifact Ontology (IAO) for import into the Open Energy Ontology (OEO). 
 It&apos;s a subset of the iao containing all annotations.</rdfs:comment>
     </owl:Ontology>

--- a/src/ontology/imports/iao-minimal-module.owl
+++ b/src/ontology/imports/iao-minimal-module.owl
@@ -8,8 +8,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/iao-minimal-module.owl">
-        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl"/>
+    <owl:Ontology rdf:about="https://openenergy-platform.org/ontology/oeo/imports/iao-minimal-module.owl">
+        <owl:versionIRI rdf:resource="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This file contains externally imported content from the Information Artifact Ontology (IAO) for import into the Open Energy Ontology (OEO). It is a minimal version of the iao-module.</rdfs:comment>
     </owl:Ontology>
     

--- a/src/ontology/imports/iao-module.owl
+++ b/src/ontology/imports/iao-module.owl
@@ -8,8 +8,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/iao-module.owl">
-        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl"/>
+    <owl:Ontology rdf:about="https://openenergy-platform.org/ontology/oeo/imports/iao-module.owl">
+        <owl:versionIRI rdf:resource="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This file contains externally imported content from the Information Artifact Ontology (IAO) for import into the Open Energy Ontology (OEO). It is automatically extracted using ROBOT.</rdfs:comment>
     </owl:Ontology>
     

--- a/src/ontology/imports/ro-module.owl
+++ b/src/ontology/imports/ro-module.owl
@@ -11,8 +11,8 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/ro-module.owl">
-        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl"/>
+    <owl:Ontology rdf:about="https://openenergy-platform.org/ontology/oeo/imports/ro-module.owl">
+        <owl:versionIRI rdf:resource="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This file contains externally imported content from the Relations Ontology (RO) for import into the Open Energy Ontology (OEO). It is automatically extracted using ROBOT from the term list ro-terms.txt.</rdfs:comment>
     </owl:Ontology>
     

--- a/src/ontology/imports/uo-module.owl
+++ b/src/ontology/imports/uo-module.owl
@@ -9,8 +9,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/uo-module.owl">
-        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl"/>
+    <owl:Ontology rdf:about="https://openenergy-platform.org/ontology/oeo/imports/uo-module.owl">
+        <owl:versionIRI rdf:resource="https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Filtered by Ancestor ID equals &quot;UO:0000000&quot;</rdfs:comment>
         <rdfs:comment>This is a sub-module of the Unit Ontology (http://purl.obolibrary.org/obo/uo.owl) that has been extracted for re-use in the Open Energy Ontology.</rdfs:comment>
     </owl:Ontology>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <https://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -10,11 +10,11 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/>
-<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn>
+Ontology: <https://openenergy-platform.org/ontology/oeo/>
+<https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
+Import: <https://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 


### PR DESCRIPTION
It seems that protogé does not follow redirects (HTTP 301) when importing ontologies. Therefore importing the OEO without a catalog failed, despite correct URLS. We had explicitely use the HTTPS protocol.