### PR TITLE
Add dc:license and use dc:description in ontology headers

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -18,8 +18,9 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation."
+    dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation.",
+    dc:license "http://creativecommons.org/publicdomain/zero/1.0/",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -43,6 +44,12 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: dc:contributor
+
+    
+AnnotationProperty: dc:description
+
+    
+AnnotationProperty: dc:license
 
     
 AnnotationProperty: definition

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -19,8 +19,9 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production."
+    dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production.",
+    dc:license "http://creativecommons.org/publicdomain/zero/1.0/",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -44,6 +45,12 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: dc:contributor
+
+    
+AnnotationProperty: dc:description
+
+    
+AnnotationProperty: dc:license
 
     
 AnnotationProperty: definition

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -17,8 +17,9 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    <http://purl.org/dc/terms/title> "Open Energy Ontology (social module)",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Social' module covers entities that relate to people and the social, organisational and economic environment in which energy is produced and consumed, including sector, organisation, and various roles."
+    dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Social' module covers entities that relate to people and the social, organisational and economic environment in which energy is produced and consumed, including sector, organisation, and various roles.",
+    dc:license "http://creativecommons.org/publicdomain/zero/1.0/",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology (social module)"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -39,6 +40,12 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: dc:contributor
+
+    
+AnnotationProperty: dc:description
+
+    
+AnnotationProperty: dc:license
 
     
 AnnotationProperty: definition
@@ -652,3 +659,4 @@ DisjointClasses:
 
 DisjointClasses: 
     OEO_00000214,OEO_00000227,OEO_00000405,OEO_00000418
+

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -37,10 +37,11 @@ Annotations:
     dc:contributor "Pierre-Francois Duc (@Bachibouzouk)",
     dc:contributor "Sebastian Cordes (@sebcordes)",
     dc:contributor "Ulrich Frey (@ufrey)",
-    <http://purl.org/dc/terms/title> "Open Energy Ontology",
-    rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. 
+    dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. 
 
-It is developed in three modules: 'oeo-model', a module for all entities related to models and modelling; 'oeo-physical', a module for all entities related to the world of energy and energy generation, and 'oeo-social' for all relevant social and economic aspects of the energy domain."
+It is developed in three modules: 'oeo-model', a module for all entities related to models and modelling; 'oeo-physical', a module for all entities related to the world of energy and energy generation, and 'oeo-social' for all relevant social and economic aspects of the energy domain.",
+    dc:license "http://creativecommons.org/publicdomain/zero/1.0/",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
@@ -58,6 +59,12 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: dc:contributor
+
+    
+AnnotationProperty: dc:description
+
+    
+AnnotationProperty: dc:license
 
     
 AnnotationProperty: definition


### PR DESCRIPTION
This adds dc:license and uses dc:description instead of rdfs:comment in the metadata annotation in the ontology headers for the main ontology file and the three edits sub-modules. 

Partial implementation of  #429 