### PR TITLE
add shared module and make energy transformation subclass of transformation

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -5,6 +5,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="imports/iao-minimal-module.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="imports/iao-annotation-module.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl" uri="imports/ro-module.owl"/>
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn" uri="edits/oeo-shared.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn" uri="edits/oeo-social.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn" uri="edits/oeo-physical.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn" uri="edits/oeo-model.omn"/>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn" uri="oeo-shared.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl" uri="../imports/iao-minimal-module.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl" uri="../imports/iao-annotation-module.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl" uri="../imports/iao-module.owl"/>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -12,10 +12,8 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-model.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
-Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Model' module covers entities for models, assumptions, parameters, data, software and all the processes that transform these, including model execution and data transformation.",

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -928,16 +928,7 @@ Class: OEO_00000408
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
     
-    
-Class: OEO_00000419
-
-    Annotations: 
-        definition "A transformation is a process that transforms one or more inputs into at least one output."@en,
-        rdfs:label "transformation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
+ Class: OEO_00000419      
     
 Class: OEO_00000423
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3020,6 +3020,8 @@ Class: OEO_00020003
 
     Annotations: 
         definition "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
         rdfs:label "energy transformation"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12,11 +12,9 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl>
-Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production.",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2571,6 +2571,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00000419
+
+    
 Class: OEO_00000420
 
     Annotations: 
@@ -3022,7 +3025,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
         rdfs:label "energy transformation"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        OEO_00000419
     
     
 Class: OEO_00020004

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -22,3 +22,11 @@ Annotations:
 AnnotationProperty: dc:description
 
     
+Class: OEO_00000419
+
+    Annotations: 
+       <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        rdfs:label "transformation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -17,16 +17,30 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
-    dc:description "\"The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The\"Shared\" module covers all entities that are relevant for all our other modules. This includes shared imports like the BFO, IAO-annotation and RO- module."
+    dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The\"Shared\" module covers all entities that are relevant for all our other modules. This includes shared imports like the BFO, IAO-annotation and RO- module."
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
+
+    
 AnnotationProperty: dc:description
+
+    
+AnnotationProperty: rdfs:label
+
+    
+Datatype: rdf:PlainLiteral
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
     
 Class: OEO_00000419
 
     Annotations: 
-       <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
         rdfs:label "transformation"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1,0 +1,24 @@
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
+Prefix: dc: <http://purl.org/dc/elements/1.1/>
+Prefix: obda: <https://w3id.org/obda/vocabulary#>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
+<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
+Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
+
+Annotations: 
+    dc:description "\"The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The\"Shared\" module covers all entities that are relevant for all our other modules. This includes shared imports like the BFO, IAO-annotation and RO- module."
+
+AnnotationProperty: dc:description
+
+    

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -22,6 +22,9 @@ Annotations:
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: dc:description
 
     
@@ -38,6 +41,8 @@ Class: OEO_00000419
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         rdfs:label "transformation"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -12,9 +12,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-social.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
-Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Social' module covers entities that relate to people and the social, organisational and economic environment in which energy is produced and consumed, including sector, organisation, and various roles.",


### PR DESCRIPTION
closes #435 

- adds shared module "oeo-shared" which will provide all classes needed in all other edit modules, as well as imports like bfo, iao-annotation and ro.
- rewrites the imports of the other modules accordingly.
- moves "Transformation" into this module
- makes "energy transformation" subclass of "transformation"

Maybe the description of the new module can be refined?