### PR TITLE
delete unused properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Here is a template for new release sections
 -
 
 ### Removed
--
+- unused object properties (#66)
 
 ## [1.0.0] - 2020-06-11
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -600,7 +600,8 @@ Class: OEO_00000275
         rdfs:label "model calculation"
     
     SubClassOf: 
-        OEO_00000419
+        OEO_00000419,
+        uses some OEO_00000274
     
     
 Class: OEO_00000276

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -190,15 +190,6 @@ ObjectProperty: has_physical_output
         Asymmetric
     
     
-ObjectProperty: has_programvariable
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a model and a program variable it uses."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
 ObjectProperty: has_resolution
 
     Annotations: 
@@ -223,44 +214,11 @@ ObjectProperty: has_temporal_resolution
         has_resolution
     
     
-ObjectProperty: has_tool
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that  holds between a model calculation and the model it is using."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    Domain: 
-        OEO_00000275
-    
-    Range: 
-        OEO_00000274
-    
-    
-ObjectProperty: makes_assumption
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and and an assumption made for its execution."@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
 ObjectProperty: uses
 
-    
-ObjectProperty: uses_dataset
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and a dataset it uses as input."@en
-    
-    SubPropertyOf: 
-        uses
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
@@ -642,8 +600,7 @@ Class: OEO_00000275
         rdfs:label "model calculation"
     
     SubClassOf: 
-        OEO_00000419,
-        has_tool some OEO_00000274
+        OEO_00000419
     
     
 Class: OEO_00000276

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -265,15 +265,6 @@ ObjectProperty: is_connected_to
         Symmetric
     
     
-ObjectProperty: is_equivalent_to
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an definition and its synonym."@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
 ObjectProperty: is_used_by
 
     SubPropertyOf: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -56,6 +56,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000116>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
@@ -110,7 +113,9 @@ ObjectProperty: conforms_to
 ObjectProperty: covers
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)"
     
     
 ObjectProperty: has_author
@@ -213,6 +218,10 @@ ObjectProperty: owl:topObjectProperty
     
 ObjectProperty: uses
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)"
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -113,33 +113,6 @@ ObjectProperty: covers
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
     
     
-ObjectProperty: covers_region
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the region it covers."@en
-    
-    SubPropertyOf: 
-        covers
-    
-    
-ObjectProperty: covers_technology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the technology it models."@en
-    
-    SubPropertyOf: 
-        covers
-    
-    
-ObjectProperty: covers_timeframe
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the timeframe it covers."@en
-    
-    SubPropertyOf: 
-        covers
-    
-    
 ObjectProperty: has_author
 
     SubPropertyOf: 
@@ -217,12 +190,6 @@ ObjectProperty: has_physical_output
         Asymmetric
     
     
-ObjectProperty: has_programvariable
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
 ObjectProperty: has_resolution
 
     
@@ -235,16 +202,7 @@ ObjectProperty: has_state_of_matter
 ObjectProperty: has_temporal_resolution
 
     
-ObjectProperty: has_tool
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
-    
-    
 ObjectProperty: is_applied_to_object
-
-    
-ObjectProperty: is_equivalent_to
 
     
 ObjectProperty: is_used_by
@@ -254,9 +212,6 @@ ObjectProperty: owl:topObjectProperty
 
     
 ObjectProperty: uses
-
-    
-ObjectProperty: uses_dataset
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>


### PR DESCRIPTION
This PR is a part of #66 

the following unused properties are deleted:  is_equivalent_to, uses_dataset, makes_assumption, covers_region, covers_technology, covers_timeframe, has_program_variable, has_tool