### PR TITLE
Extend vehicle subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Here is a template for new release sections
 - energy transformation (#77)
 - synthetic fuels and respective energy converting devices (#411)
 - process attribute (#386)
-- vehicle and subclasses (#431)
+- vehicle and subclasses and vehicle related energy converting devices and energy storage objects (#431, #435)
 - natural gas relation to methane (#431)
 
 ### Changed

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -463,7 +463,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
         rdfs:label "fuel cell"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000017>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2933,8 +2933,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        dc:description "A battery electric vehicle is a vehicle that stores energy in an on-board battery.",
+        dc:description "A battery electric vehicle (BEV) is a vehicle that stores energy in an on-board battery.",
         rdfs:label "battery electric vehicle"@de
     
     SubClassOf: 
@@ -2945,9 +2946,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        dc:description "A fuel cell electric vehicle is a vehicle that uses electrical energy from a fuel cell.",
-        rdfs:label "fuel cell vehicle"@de
+        dc:description "A fuel cell electric vehicle (FCEV) is a vehicle that uses electrical energy from a fuel cell.",
+        rdfs:label "fuel cell electric vehicle"@de
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
@@ -3004,8 +3006,9 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        dc:description "A plug-in hybrid electric vehicle is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        dc:description "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
         rdfs:label "plug-in hybrid electric vehicle"@de
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3022,10 +3022,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied vehicle is an electric vehicle that uses electrical energy via a conductor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        rdfs:label "grid supplied vehicle"@de
+        rdfs:label "grid supplied electric vehicle"@de
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
         <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1297,12 +1297,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000146
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle, also called an EV, uses one or more electric motors or traction motors for propulsion. An electric vehicle may be powered through a collector system by electricity from off-vehicle sources, or may be self-contained with a battery, solar panels or an electric generator to convert fuel to electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Electric_vehicle&oldid=906776214"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
         rdfs:label "electric vehicle"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00010023
     
     
 Class: OEO_00000147
@@ -1759,11 +1760,12 @@ Class: OEO_00000226
 Class: OEO_00000240
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is an artificial object that is a vehicle powered by internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
         rdfs:label "internal combustion vehicle"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00010023
     
     
 Class: OEO_00000245

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -22,12 +22,6 @@ Annotations:
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)",
     rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production."
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/definition>
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -55,6 +49,12 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: definition
+
+    SubPropertyOf: 
+        rdfs:comment
+    
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -66,208 +66,6 @@ AnnotationProperty: rdfs:label
     
 Datatype: rdf:PlainLiteral
 
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00030021>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "has_process_attribute"@de
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/process_attribute_of>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/applies_technology>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology."
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/is_applied_to_object>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/covers>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/covers_energycarrier>
-
-    Annotations: 
-        rdfs:comment "A relation that holds between a publication/model calculation/model and the energycarrier it covers."
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/covers>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_globalwarmingpotential>
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has_normal_state_of_matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_origin>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_physical_input>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Characteristics: 
-        Functional,
-        Irreflexive,
-        Asymmetric
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_physical_output>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_sink>
-
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/is_connected_to>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/has_source>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_source>
-
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/is_connected_to>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/has_sink>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_state_of_matter>
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_applied_to_object>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object."
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/applies_technology>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_connected_to>
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Characteristics: 
-        Symmetric
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_equivalent_to>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an definition and its synonym."@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_used_by>
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/uses>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/process_attribute_of>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386"
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030021>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/uses>
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/is_used_by>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -299,2979 +97,209 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
+ObjectProperty: OEO_00030021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "has_process_attribute"@de
+    
+    InverseOf: 
+        process_attribute_of
+    
+    
+ObjectProperty: applies_technology
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology."
+    
+    Domain: 
+        OEO_00000061
+    
+    Range: 
+        OEO_00000407
+    
+    InverseOf: 
+        is_applied_to_object
+    
+    
+ObjectProperty: covers
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
+    
+    
+ObjectProperty: covers_energycarrier
+
+    Annotations: 
+        rdfs:comment "A relation that holds between a publication/model calculation/model and the energycarrier it covers."
+    
+    SubPropertyOf: 
+        covers
+    
+    Range: 
+        OEO_00000151
+    
+    
+ObjectProperty: has_globalwarmingpotential
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00000198
+    
+    
+ObjectProperty: has_normal_state_of_matter
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has_normal_state_of_matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
+    
+ObjectProperty: has_origin
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000316
+    
+    
+ObjectProperty: has_physical_input
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Characteristics: 
+        Functional,
+        Irreflexive,
+        Asymmetric
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
+    
+    
+ObjectProperty: has_physical_output
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    
+ObjectProperty: has_sink
+
+    SubPropertyOf: 
+        is_connected_to
+    
+    DisjointWith: 
+        has_source
+    
+    
+ObjectProperty: has_source
+
+    SubPropertyOf: 
+        is_connected_to
+    
+    DisjointWith: 
+        has_sink
+    
+    
+ObjectProperty: has_state_of_matter
+
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
+    
+ObjectProperty: is_applied_to_object
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object."
+    
+    Domain: 
+        OEO_00000407
+    
+    Range: 
+        OEO_00000061
+    
+    InverseOf: 
+        applies_technology
+    
+    
+ObjectProperty: is_connected_to
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Characteristics: 
+        Symmetric
+    
+    
+ObjectProperty: is_equivalent_to
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an definition and its synonym."@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    
+ObjectProperty: is_used_by
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    InverseOf: 
+        uses
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+ObjectProperty: process_attribute_of
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:label "fuel role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
-        rdfs:label "biofuel power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000004>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
-        rdfs:label "biogas powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
-        rdfs:label "biogas power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
-        rdfs:label "chemical energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
-        rdfs:label "coal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000009>
-
-    Annotations: 
-        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy.",
-        rdfs:label "electric heat pump"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
-        rdfs:label "electro motive generator"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "formerly called energy transformer",
-        rdfs:label "energy converting device"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000013>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
-        rdfs:label "fluorinated greenhouse gas"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000026> or <http://openenergy-platform.org/ontology/oeo/OEO_00000038> or <http://openenergy-platform.org/ontology/oeo/OEO_00000219> or <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
-        rdfs:label "fuel cell"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
-        rdfs:label "gas fired power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-             and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
-        rdfs:label "geothermal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
-        rdfs:label "hard coal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
-        rdfs:label "hydrogen power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
-        rdfs:label "lignite power unit"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
-        rdfs:label "methane"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000026>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
-        rdfs:label "nitrogen trifluoride"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000027>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
-        rdfs:label "nitrous oxide"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000028>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
-        rdfs:label "nuclear power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
-        rdfs:label "oil power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000309>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an aggregate of power generating units that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV cell is a generator that converts light into electrical energy.",
-        rdfs:label "PV cell"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel.",
-        rdfs:label "renewable fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
-        rdfs:label "solar power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000035>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
-        rdfs:label "solar thermal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000036>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
-        rdfs:label "solid biomass powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
-        rdfs:label "solid biomass power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000038>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
-        rdfs:label "sulphur hexafluoride"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000039>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
-        rdfs:label "thermal energy storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000040>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
-        rdfs:label "waste power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000042>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:label "waste role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000043>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A wind energy converting unit is a power generating unit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        rdfs:label "wind energy converting unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "undirected",
-        rdfs:label "AC-line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
-        rdfs:label "air"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000330>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000056>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
-        rdfs:label "ambient heat"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000058>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition),
- https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000062>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "associated gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000066>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "aviation gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is a device using different chemical or physical reactions to store energy."@en,
-        rdfs:label "battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
-        <http://purl.obolibrary.org/obo/RO_0000085> some <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
-        rdfs:label "battery storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000071>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "biodiesel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a fuel that is produced through contemporary biological processes, such as agriculture and anaerobic digestion, rather than a fuel produced by geological processes such as those involved in the formation of fossil fuels, such as coal and petroleum, from prehistoric biological matter.
-
-Biofuels can be derived directly from plants (i.e. energy crops), or indirectly from agricultural, commercial, domestic, and/or industrial wastes.[1] Renewable biofuels generally involve contemporary carbon fixation, such as those that occur in plants or microalgae through the process of photosynthesis. Other renewable biofuels are made through the use or conversion of biomass (referring to recently living organisms, most often referring to plants or plant-derived materials). This biomass can be converted to convenient energy-containing substances in three different ways: thermal conversion, chemical conversion, and biochemical conversion. This biomass conversion can result in fuel in solid, liquid, or gas form. This new biomass can also be used directly for biofuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
-        rdfs:label "biofuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
-        rdfs:label "biofuel powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
-        rdfs:label "biogas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000075>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Bioethanol"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "biogasoline",
-        rdfs:label "biogasoline"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000077>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "blast furnace gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000084>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "charcoal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:label "coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000089>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
-        rdfs:label "coal powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000093>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coke oven gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000094>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coking coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000096>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
-        rdfs:label "colliery gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "combustion fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000102>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
-        rdfs:label "compressed air"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000115>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en,
-        rdfs:label "dammed water"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "directed",
-        rdfs:label "HVDC-line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Derived heat covers the total heat production in heating plants and in combined heat and power plants. It includes the heat used by the auxiliaries of the installation which use hot fluid (space heating, liquid fuel heating, etc.) And losses in the installation/network heat exchanges. For autoproducing entities (= entities generating electricity and/or heat wholly or partially for their own use as an activity which supports their primary activity) the heat used by the undertaking for its own processes is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en,
-        rdfs:label "derived heat"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "diesel fuel",
-        rdfs:label "diesel fuel"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
-        rdfs:label "district heat"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is energy derived from electric potential energy or kinetic energy. [...] This energy is supplied by the combination of electric current and electric potential that is delivered by an electrical circuit"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        rdfs:label "electrical energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "electric vehicle"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of matter and radiation which is manifest as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage object"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
-        rdfs:label "field photovoltaic powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000169>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery, or redox flow battery (after reduction–oxidation), is a type of electrochemical cell where chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
-        rdfs:label "flow battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000174>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled powerplant"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power unit"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gas diesel oil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
-        rdfs:label "gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000184>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
-        rdfs:label "gas powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000185>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustion turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "gas turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000186>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
-
-The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gasworks gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000189>
-
-    Annotations: 
-        rdfs:label "geographic coordinate"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
-— for electricity generation using dry steam or high enthalpy brine after flashing,
-— directly as heat for district heating, agriculture etc"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "geothermal heat"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000192>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
-        rdfs:label "geothermal powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000019>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse effect disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas emission"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "hard coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000205>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
-        rdfs:label "hard coal powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
-       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
-       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
-        rdfs:label "heat"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "heater"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000211>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil",
-        rdfs:label "heating oil"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
-        rdfs:label "heat pump"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000216>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "hydroelectricity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "hydro energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000219>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
-        rdfs:label "hydrofluorocarbon"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000221>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
-        rdfs:label "hydrogen powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000022>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "hydrogen turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste fuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "industrial waste fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000240>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "internal combustion vehicle"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000245>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "KeroseneTypeJetFuel"@en,
-        rdfs:label "jet fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
-[...]
-
-Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        rdfs:label "kerosene"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000248>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery or Li-ion battery (abbreviated as LIB) is a type of rechargeable battery [...] In the batteries lithium ions move from the negative electrode to the positive electrode during discharge and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material, compared to the metallic lithium used in a non-rechargeable lithium battery. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
-        rdfs:label "lithium-ion battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
-
-Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "lignite"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000252>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
-        rdfs:label "lignite powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerline is a grid component that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en,
-        rdfs:label "liquid air"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000258>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
-        rdfs:label "liquid biofuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000259>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rechargeable liquid-metal batteries are used for electric vehicles and potentially also for grid energy storage, to balance out intermittent renewable power sources such as solar panels and wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "liquid-metal battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
-        rdfs:label "manufactured coal based gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
-        rdfs:label "methanation gas storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-salt batteries are a class of battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "molten-salt battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-state batteries consist of two molten metal alloys separated by an electrolyte."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wastes produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "molten state battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000286>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
-
-Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "motor gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Municipal waste fuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "municipal waste fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
-
-It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "natural gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000293>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "negative emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A grid node is a grid component of a supply grid where two or more links meet."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid node"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000297>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "non associated gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "non-methane volatile organic compound"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000299>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non renewable municipal waste fuel is municipal waste fuel of non-biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "non renewable municipal waste fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "nuclear energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000303>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
-        rdfs:label "nuclear powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000029>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
-        rdfs:label "offshore wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000309>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
-
-It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
-        rdfs:label "oil and petroleum products"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000310>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
-        rdfs:label "oil powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
-        rdfs:label "onshore wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>),
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000320>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
-
-This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "peat"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
-        rdfs:label "perfluorocarbon"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
-        rdfs:label "photovoltaic powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000330>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "solid biofuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/process_attribute_of> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "power generating unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000335>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
-        rdfs:label "power-to-gas system"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000343>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
-        rdfs:label "pumped storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en,
-        rdfs:label "pumped water"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
-        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
-        rdfs:label "PV panel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is a generically depenent continuant defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "quantity value"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386"
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    InverseOf: 
+        OEO_00030021
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000356>
+ObjectProperty: uses
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable municipal waste fuel is municipal waste fuel of biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "renewable municipal waste fuel"
+    SubPropertyOf: 
+        owl:topObjectProperty
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
-        rdfs:label "rooftop photovoltaic powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000374>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
-        rdfs:label "SMES"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000376>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sodium-ion batteries (SIB) are a type of rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
-        rdfs:label "sodium-ion battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000377>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        rdfs:label "sodium-sulfur battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "solar energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000386>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
-        rdfs:label "solar power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
-        rdfs:label "solar thermal collector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
-(a) solar thermal-electric plants; or
-(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "solar thermal heat"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000389>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
-        rdfs:label "solar thermal powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000035>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000391>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
-        rdfs:label "solid fossil fuel"
-    
-    EquivalentTo: 
-        (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
-         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
-        rdfs:label "steam turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
-        rdfs:label "storage unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000401>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
-        rdfs:label "technology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
-        rdfs:label "transformer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
-        rdfs:label "turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000429>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Underground hydrogen storage is the practice of hydrogen storage in underground caverns,salt domes and depleted oil/gas fields."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
-        rdfs:label "underground hydrogen storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000025> or <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>),
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification.",
-        rdfs:label "waste fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000042>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000440>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
-        rdfs:label "waste powerplant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000041>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000441>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
-        rdfs:label "water"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000442>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "water turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000043>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
-        rdfs:label "wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000448>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "wind rotor"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
-        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000449>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "wood and other"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000332>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. Synonyms are trihydridonitrogen and nitrogen trihydride.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "ammonia"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010001>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010003>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitric oxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010004>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen dioxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010007>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "sulphur dioxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010009>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010010>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010011>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that has the disposition to participates in air pollution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "air pollutant"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010015>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "fossil hydrogen"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010016>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic hydrogen"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic fuel"@de
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010018>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is synthetic fuel produced in a power-to-gas system from water and carbon dioxide using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic methane"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
-        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010019>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic liquid fuel is synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electric energy applying.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic liquid fuel"@de
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010020>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "power-to-liquid system"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "water electrolyser"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010022>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting device that produces syngas from hydrocarbons such as natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "steam reformer"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A battery electric vehicle (BEV) is a vehicle that stores energy in an on-board battery.",
-        rdfs:label "battery electric vehicle"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A fuel cell electric vehicle (FCEV) is a vehicle that uses electrical energy from a fuel cell.",
-        rdfs:label "fuel cell electric vehicle"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A traction battery is a battery used in vehicles for propulsion.",
-        rdfs:label "traction battery"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "An electric motor is an energy converting device that converts electrical energy into kinetic energy.",
-        rdfs:label "electric motor"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A traction motor is an electric motor used for propulsion.",
-        rdfs:label "traction motor"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        dc:description "An internal combustion engine is an energy converting device that converts chemical energy into into rotational energy using a cyclic combustion process.",
-        rdfs:label "internal combustion engine"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
-        rdfs:label "plug-in hybrid electric vehicle"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "grid supplied electric vehicle"@de
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
-        rdfs:label "energy transformation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "gas grid"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "heating grid"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid component is a grid component that is part of a gas grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "gas grid component"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020004>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid component is a grid component that is part of a heating grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "heating grid component"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "anthropogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "biogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
-
-In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "renewable"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "synthetic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"@de
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "storage capacity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "power rating"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "declared net capacity"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/definition> "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "nameplate capacity"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    InverseOf: 
+        is_used_by
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -3343,46 +371,3018 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+Class: OEO_00000001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
+        rdfs:label "biofuel power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000072
+    
+    
+Class: OEO_00000004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
+        rdfs:label "biogas powerplant"
+    
+    SubClassOf: 
+        OEO_00000073
+    
+    
+Class: OEO_00000005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
+        rdfs:label "biogas power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        uses some OEO_00000074
+    
+    
+Class: OEO_00000006
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        rdfs:label "carbon dioxide"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
+        rdfs:label "chemical energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        rdfs:label "coal power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000088
+    
+    
+Class: OEO_00000009
+
+    Annotations: 
+        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy.",
+        rdfs:label "electric heat pump"
+    
+    SubClassOf: 
+        OEO_00000212
+    
+    
+Class: OEO_00000010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
+        rdfs:label "electro motive generator"
+    
+    SubClassOf: 
+        OEO_00000188
+    
+    
+Class: OEO_00000011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:comment "formerly called energy transformer",
+        rdfs:label "energy converting device"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage"
+    
+    SubClassOf: 
+        OEO_00000151,
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+Class: OEO_00000013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
+        rdfs:label "fluorinated greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000026 or OEO_00000038 or OEO_00000219 or OEO_00000322
+    
+    SubClassOf: 
+        OEO_00000020
+    
+    
+Class: OEO_00000014
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (has_origin some OEO_00030002)
+    
+    SubClassOf: 
+        has_origin some OEO_00030003
+    
+    
+Class: OEO_00000016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
+        rdfs:label "fuel cell"
+    
+    SubClassOf: 
+        OEO_00000188,
+        uses some OEO_00000220
+    
+    
+Class: OEO_00000017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
+        rdfs:label "gas fired power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some 
+            (OEO_00000173
+             and (has_normal_state_of_matter value OEO_00000182))
+    
+    
+Class: OEO_00000019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        rdfs:label "geothermal power unit"
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
+        rdfs:label "hard coal power unit"
+    
+    SubClassOf: 
+        OEO_00000008,
+        uses some OEO_00000204
+    
+    
+Class: OEO_00000022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        rdfs:label "hydrogen power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000220
+    
+    
+Class: OEO_00000024
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
+        rdfs:label "lignite power unit"
+    
+    EquivalentTo: 
+        uses some OEO_00000251
+    
+    SubClassOf: 
+        OEO_00000008
+    
+    
+Class: OEO_00000025
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
+        rdfs:label "methane"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000026
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
+        rdfs:label "nitrogen trifluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030000,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000027
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        rdfs:label "nitrous oxide"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00000029
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        rdfs:label "nuclear power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000302
+    
+    
+Class: OEO_00000030
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
+        rdfs:label "oil power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000309
+    
+    
+Class: OEO_00000031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an aggregate of power generating units that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "powerplant"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV cell is a generator that converts light into electrical energy.",
+        rdfs:label "PV cell"
+    
+    SubClassOf: 
+        OEO_00000188
+    
+    
+Class: OEO_00000033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel.",
+        rdfs:label "renewable fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (has_origin some OEO_00030004)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000034
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
+        rdfs:label "solar power unit"
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000035
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
+        rdfs:label "solar thermal power unit"
+    
+    SubClassOf: 
+        OEO_00000034,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
+    
+    
+Class: OEO_00000036
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
+        rdfs:label "solid biomass powerplant"
+    
+    SubClassOf: 
+        OEO_00000073
+    
+    
+Class: OEO_00000037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
+        rdfs:label "solid biomass power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        uses some OEO_00000332
+    
+    
+Class: OEO_00000038
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
+        rdfs:label "sulphur hexafluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030000,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        rdfs:label "thermal energy storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00000040
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "uranium"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030003,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000041
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        rdfs:label "waste power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        uses some OEO_00000439
+    
+    
+Class: OEO_00000042
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:label "waste role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000043
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000044
+
+    Annotations: 
+        definition "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        rdfs:label "wind energy converting unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000425
+    
+    
+Class: OEO_00000047
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "undirected",
+        rdfs:label "AC-line"@en
+    
+    SubClassOf: 
+        OEO_00000253
+    
+    DisjointWith: 
+        OEO_00000126
+    
+    
+Class: OEO_00000054
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
+        rdfs:label "air"
+    
+    SubClassOf: 
+        OEO_00000331,
+        is_used_by some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000055
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
+        rdfs:label "air pollution"
+    
+    SubClassOf: 
+        OEO_00000330,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010012
+    
+    
+Class: OEO_00000056
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
+        rdfs:label "ambient heat"
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00000058
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite"
+    
+    SubClassOf: 
+        OEO_00000204
+    
+    
+Class: OEO_00000061
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition),
+ https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)",
+        rdfs:label "artificial object"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    
+Class: OEO_00000062
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "associated gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000066
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "aviation gasoline"
+    
+    SubClassOf: 
+        OEO_00000183
+    
+    
+Class: OEO_00000068
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is a device using different chemical or physical reactions to store energy."@en,
+        rdfs:label "battery"
+    
+    SubClassOf: 
+        OEO_00000159,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
+    
+    
+Class: OEO_00000070
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
+        rdfs:label "battery storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    DisjointWith: 
+        OEO_00000269
+    
+    
+Class: OEO_00000071
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "biodiesel"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000072
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a fuel that is produced through contemporary biological processes, such as agriculture and anaerobic digestion, rather than a fuel produced by geological processes such as those involved in the formation of fossil fuels, such as coal and petroleum, from prehistoric biological matter.
+
+Biofuels can be derived directly from plants (i.e. energy crops), or indirectly from agricultural, commercial, domestic, and/or industrial wastes.[1] Renewable biofuels generally involve contemporary carbon fixation, such as those that occur in plants or microalgae through the process of photosynthesis. Other renewable biofuels are made through the use or conversion of biomass (referring to recently living organisms, most often referring to plants or plant-derived materials). This biomass can be converted to convenient energy-containing substances in three different ways: thermal conversion, chemical conversion, and biochemical conversion. This biomass conversion can result in fuel in solid, liquid, or gas form. This new biomass can also be used directly for biofuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
+        rdfs:label "biofuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (has_origin some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000173,
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000073
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
+        rdfs:label "biofuel powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000003
+    
+    
+Class: OEO_00000074
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
+        rdfs:label "biogas"
+    
+    SubClassOf: 
+        OEO_00000072,
+        has_origin some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000075
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Bioethanol"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "biogasoline",
+        rdfs:label "biogasoline"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000077
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "blast furnace gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000084
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "charcoal"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000088
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:label "coal"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000089
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
+        rdfs:label "coal powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000093
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coke oven gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000094
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coking coal"
+    
+    SubClassOf: 
+        OEO_00000204
+    
+    
+Class: OEO_00000096
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
+        rdfs:label "colliery gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000097
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00000099
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+    
+    SubClassOf: 
+        OEO_00000173
+    
+    
+Class: OEO_00000102
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        rdfs:label "compressed air"
+    
+    SubClassOf: 
+        OEO_00000054
+    
+    
+Class: OEO_00000115
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "crude oil"
+    
+    SubClassOf: 
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000117
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en,
+        rdfs:label "dammed water"
+    
+    SubClassOf: 
+        OEO_00000441,
+        is_used_by some OEO_00000399
+    
+    
+Class: OEO_00000126
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "directed",
+        rdfs:label "HVDC-line"@en
+    
+    SubClassOf: 
+        OEO_00000253
+    
+    DisjointWith: 
+        OEO_00000047
+    
+    
+Class: OEO_00000129
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Derived heat covers the total heat production in heating plants and in combined heat and power plants. It includes the heat used by the auxiliaries of the installation which use hot fluid (space heating, liquid fuel heating, etc.) And losses in the installation/network heat exchanges. For autoproducing entities (= entities generating electricity and/or heat wholly or partially for their own use as an activity which supports their primary activity) the heat used by the undertaking for its own processes is not included."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en,
+        rdfs:label "derived heat"
+    
+    EquivalentTo: 
+        OEO_00000132
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00000131
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "diesel fuel",
+        rdfs:label "diesel fuel"@en
+    
+    SubClassOf: 
+        OEO_00000181
+    
+    
+Class: OEO_00000132
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
+        rdfs:label "district heat"
+    
+    EquivalentTo: 
+        OEO_00000129
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00000139
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is energy derived from electric potential energy or kinetic energy. [...] This energy is supplied by the combination of electric current and electric potential that is delivered by an electrical circuit"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        rdfs:label "electrical energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000143
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
+        rdfs:label "electricity grid"
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
+        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 OEO_00000253
+    
+    
+Class: OEO_00000144
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "electricity grid component"
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00000146
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "electric vehicle"
+    
+    SubClassOf: 
+        OEO_00010023,
+        uses some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028
+    
+    
+Class: OEO_00000147
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000150
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of matter and radiation which is manifest as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00000151
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: OEO_00000159
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage object"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000165
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
+        rdfs:label "field photovoltaic powerplant"
+    
+    SubClassOf: 
+        OEO_00000324
+    
+    DisjointWith: 
+        OEO_00000361
+    
+    
+Class: OEO_00000169
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery, or redox flow battery (after reduction–oxidation), is a type of electrochemical cell where chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
+        rdfs:label "flow battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000173
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel"
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00000174
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled powerplant"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
+    
+    SubClassOf: 
+        OEO_00000031
+    
+    
+Class: OEO_00000175
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power unit"
+    
+    EquivalentTo: 
+        uses some OEO_00000173
+    
+    SubClassOf: 
+        OEO_00000334
+    
+    
+Class: OEO_00000181
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gas diesel oil"
+    
+    SubClassOf: 
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000183
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
+        rdfs:label "gasoline"
+    
+    SubClassOf: 
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000184
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
+        rdfs:label "gas powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000017
+    
+    
+Class: OEO_00000185
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustion turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "gas turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000292
+    
+    
+Class: OEO_00000186
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
+
+The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gasworks gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000188
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "generator"
+    
+    SubClassOf: 
+        OEO_00000011,
+        has_physical_output some OEO_00000139
+    
+    
+Class: OEO_00000189
+
+    Annotations: 
+        rdfs:label "geographic coordinate"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    
+Class: OEO_00000191
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
+— for electricity generation using dry steam or high enthalpy brine after flashing,
+— directly as heat for district heating, agriculture etc"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "geothermal heat"
+    
+    SubClassOf: 
+        OEO_00000207,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
+    
+    
+Class: OEO_00000192
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
+        rdfs:label "geothermal powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000198
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse effect disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: OEO_00000199
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas emission"
+    
+    SubClassOf: 
+        OEO_00000147,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020
+    
+    
+Class: OEO_00000200
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
+        rdfs:label "supply grid"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: OEO_00000204
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "hard coal"
+    
+    SubClassOf: 
+        OEO_00000088
+    
+    DisjointWith: 
+        OEO_00000251
+    
+    
+Class: OEO_00000205
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
+        rdfs:label "hard coal powerplant"
+    
+    SubClassOf: 
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
+    
+    
+Class: OEO_00000206
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "hardware"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000207
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "heat"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000210
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "heater"
+    
+    SubClassOf: 
+        OEO_00000011,
+        has_physical_output some OEO_00000207
+    
+    
+Class: OEO_00000211
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "heating oil",
+        rdfs:label "heating oil"@en
+    
+    SubClassOf: 
+        OEO_00000181
+    
+    
+Class: OEO_00000212
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
+        rdfs:label "heat pump"
+    
+    SubClassOf: 
+        OEO_00000210
+    
+    
+Class: OEO_00000216
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "hydroelectricity"
+    
+    SubClassOf: 
+        OEO_00000218
+    
+    
+Class: OEO_00000218
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "hydro energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000219
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
+        rdfs:label "hydrofluorocarbon"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030000
+    
+    
+Class: OEO_00000220
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
+        rdfs:label "hydrogen"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000221
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
+        rdfs:label "hydrogen powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
+    
+    
+Class: OEO_00000222
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "hydrogen turbine"
+    
+    SubClassOf: 
+        OEO_00000185,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000220
+    
+    
+Class: OEO_00000226
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste fuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "industrial waste fuel"
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00000240
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "internal combustion vehicle"
+    
+    SubClassOf: 
+        OEO_00010023,
+        uses some OEO_00000099,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
+    
+    
+Class: OEO_00000245
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "KeroseneTypeJetFuel"@en,
+        rdfs:label "jet fuel"
+    
+    SubClassOf: 
+        OEO_00000246
+    
+    
+Class: OEO_00000246
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+[...]
+
+Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        rdfs:label "kerosene"
+    
+    SubClassOf: 
+        OEO_00000309,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000248
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery or Li-ion battery (abbreviated as LIB) is a type of rechargeable battery [...] In the batteries lithium ions move from the negative electrode to the positive electrode during discharge and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material, compared to the metallic lithium used in a non-rechargeable lithium battery. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
+        rdfs:label "lithium-ion battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000251
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
+
+Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "lignite"
+    
+    SubClassOf: 
+        OEO_00000088,
+        has_origin some OEO_00030002,
+        has_normal_state_of_matter value OEO_00000390
+    
+    DisjointWith: 
+        OEO_00000204
+    
+    
+Class: OEO_00000252
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
+        rdfs:label "lignite powerplant"
+    
+    SubClassOf: 
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000024
+    
+    
+Class: OEO_00000253
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerline is a grid component that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "power line"@en
+    
+    SubClassOf: 
+        OEO_00000255,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
+    
+Class: OEO_00000255
+
+    Annotations: 
+        definition "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid component link"
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    DisjointWith: 
+        OEO_00000296
+    
+    
+Class: OEO_00000257
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en,
+        rdfs:label "liquid air"
+    
+    SubClassOf: 
+        OEO_00000054
+    
+    
+Class: OEO_00000258
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
+        rdfs:label "liquid biofuel"
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (has_normal_state_of_matter value OEO_00000256)
+    
+    SubClassOf: 
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000259
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rechargeable liquid-metal batteries are used for electric vehicles and potentially also for grid energy storage, to balance out intermittent renewable power sources such as solar panels and wind turbines."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "liquid-metal battery"
+    
+    SubClassOf: 
+        OEO_00000283
+    
+    
+Class: OEO_00000263
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
+        rdfs:label "manufactured coal based gas"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000269
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
+        rdfs:label "methanation gas storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    DisjointWith: 
+        OEO_00000070
+    
+    
+Class: OEO_00000282
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-salt batteries are a class of battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "molten-salt battery"
+    
+    SubClassOf: 
+        OEO_00000283
+    
+    
+Class: OEO_00000283
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-state batteries consist of two molten metal alloys separated by an electrolyte."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wastes produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "molten state battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000286
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
+
+Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "motor gasoline"
+    
+    SubClassOf: 
+        OEO_00000183
+    
+    
+Class: OEO_00000290
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Municipal waste fuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "municipal waste fuel"
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00000292
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
+
+It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "natural gas"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00000293
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "negative emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000296
+
+    Annotations: 
+        definition "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid node"
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    DisjointWith: 
+        OEO_00000255
+    
+    
+Class: OEO_00000297
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "non associated gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000298
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "non-methane volatile organic compound"
+    
+    SubClassOf: 
+        OEO_00000437
+    
+    
+Class: OEO_00000299
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non renewable municipal waste fuel is municipal waste fuel of non-biological origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "non renewable municipal waste fuel"
+    
+    SubClassOf: 
+        OEO_00000290,
+        has_origin some OEO_00030002
+    
+    
+Class: OEO_00000300
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "nuclear energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000302
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
+    
+    SubClassOf: 
+        OEO_00000173
+    
+    
+Class: OEO_00000303
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
+        rdfs:label "nuclear powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000308
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
+        rdfs:label "offshore wind farm"
+    
+    SubClassOf: 
+        OEO_00000447
+    
+    DisjointWith: 
+        OEO_00000311
+    
+    
+Class: OEO_00000309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
+
+It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
+        rdfs:label "oil and petroleum products"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000310
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
+        rdfs:label "oil powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000311
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
+        rdfs:label "onshore wind farm"
+    
+    SubClassOf: 
+        OEO_00000447
+    
+    DisjointWith: 
+        OEO_00000308
+    
+    
+Class: OEO_00000316
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "origin"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00000318
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "particulate matter"
+    
+    SubClassOf: 
+        OEO_00000331,
+        (has_normal_state_of_matter value OEO_00000256) or (has_normal_state_of_matter value OEO_00000390),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
+    
+    
+Class: OEO_00000320
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
+
+This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "peat"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000322
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
+        rdfs:label "perfluorocarbon"
+    
+    SubClassOf: 
+        OEO_00000331,
+        has_origin some OEO_00030000
+    
+    
+Class: OEO_00000324
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
+        rdfs:label "photovoltaic powerplant"
+    
+    SubClassOf: 
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
+    
+    
+Class: OEO_00000330
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution"
+    
+    SubClassOf: 
+        OEO_00000147
+    
+    
+Class: OEO_00000331
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: OEO_00000332
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "solid biofuel"@en
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (has_normal_state_of_matter value OEO_00000390)
+    
+    SubClassOf: 
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000333
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"
+    
+    SubClassOf: 
+        OEO_00030019,
+        process_attribute_of some OEO_00020003
+    
+    
+Class: OEO_00000334
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "power generating unit"
+    
+    SubClassOf: 
+        OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188
+    
+    
+Class: OEO_00000335
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
+        rdfs:label "power-to-gas system"
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00000343
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
+        rdfs:label "pumped storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00000345
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        rdfs:label "pumped water"
+    
+    SubClassOf: 
+        OEO_00000441,
+        is_used_by some OEO_00000399
+    
+    
+Class: OEO_00000348
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
+        rdfs:label "PV panel"
+    
+    SubClassOf: 
+        OEO_00000034,
+        has_physical_output some OEO_00000333,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032
+    
+    
+Class: OEO_00000350
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is a generically depenent continuant defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "quantity value"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00000356
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable municipal waste fuel is municipal waste fuel of biological origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "renewable municipal waste fuel"
+    
+    SubClassOf: 
+        OEO_00000290,
+        has_origin some OEO_00030001,
+        has_origin some OEO_00030004
+    
+    
+Class: OEO_00000361
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic powerplant"
+    
+    SubClassOf: 
+        OEO_00000324
+    
+    DisjointWith: 
+        OEO_00000165
+    
+    
+Class: OEO_00000374
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
+          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
+        rdfs:label "SMES"
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00000376
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sodium-ion batteries (SIB) are a type of rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
+        rdfs:label "sodium-ion battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000377
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
+        rdfs:label "sodium-sulfur battery"
+    
+    SubClassOf: 
+        OEO_00000283
+    
+    
+Class: OEO_00000384
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "solar energy"
+    
+    SubClassOf: 
+        OEO_00000150,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
+    
+    
+Class: OEO_00000386
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
+        rdfs:label "solar power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
+    
+    
+Class: OEO_00000387
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        rdfs:label "solar thermal collector"
+    
+    SubClassOf: 
+        OEO_00000210,
+        has_physical_input only OEO_00000388
+    
+    
+Class: OEO_00000388
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
+(a) solar thermal-electric plants; or
+(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "solar thermal heat"
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00000389
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
+        rdfs:label "solar thermal powerplant"
+    
+    SubClassOf: 
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000035,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000391
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
+        rdfs:label "solid fossil fuel"
+    
+    EquivalentTo: 
+        (has_origin some OEO_00030002)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+         and (has_normal_state_of_matter value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00000173,
+        has_origin some OEO_00030002,
+        has_normal_state_of_matter value OEO_00000390
+    
+    
+Class: OEO_00000395
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+        rdfs:label "state of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00000396
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
+        rdfs:label "steam turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        has_physical_output some OEO_00000333
+    
+    
+Class: OEO_00000399
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        rdfs:label "storage unit"
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
+    
+Class: OEO_00000401
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal"
+    
+    SubClassOf: 
+        OEO_00000088
+    
+    
+Class: OEO_00000407
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
+        rdfs:label "technology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000420
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
+        rdfs:label "transformer"
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
+    
+Class: OEO_00000425
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
+        rdfs:label "turbine"
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
+Class: OEO_00000429
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Underground hydrogen storage is the practice of hydrogen storage in underground caverns,salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        rdfs:label "underground hydrogen storage"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000437
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatile organic compound"
+    
+    EquivalentTo: 
+        OEO_00000025 or OEO_00000298
+    
+    SubClassOf: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
+    
+    
+Class: OEO_00000439
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification.",
+        rdfs:label "waste fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000042)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000440
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
+        rdfs:label "waste powerplant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000441
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
+        rdfs:label "water"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        has_normal_state_of_matter value OEO_00000256
+    
+    
+Class: OEO_00000442
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "water turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        has_physical_input only OEO_00000218
+    
+    
+Class: OEO_00000446
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind energy"
+    
+    SubClassOf: 
+        OEO_00000150,
+        uses some OEO_00000043,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
+    
+    
+Class: OEO_00000447
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
+        rdfs:label "wind farm"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000044
+    
+    
+Class: OEO_00000448
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "wind rotor"
+    
+    SubClassOf: 
+        OEO_00000425,
+        has_physical_output some OEO_00000333,
+        uses some OEO_00000446,
+        has_physical_input only OEO_00000446
+    
+    
+Class: OEO_00000449
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "wood and other"
+    
+    SubClassOf: 
+        OEO_00000332,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
+    
+    
+Class: OEO_00010000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. Synonyms are trihydridonitrogen and nitrogen trihydride.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "ammonia"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00010001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "carbon monoxide"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00010002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen oxides"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00010003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitric oxide"@en
+    
+    SubClassOf: 
+        OEO_00010002
+    
+    
+Class: OEO_00010004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen dioxide"@en
+    
+    SubClassOf: 
+        OEO_00010002
+    
+    
+Class: OEO_00010007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "sulphur dioxide"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        has_normal_state_of_matter value OEO_00000182
+    
+    
+Class: OEO_00010009
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM10"@en
+    
+    SubClassOf: 
+        OEO_00000318
+    
+    
+Class: OEO_00010010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM2.5"@en
+    
+    SubClassOf: 
+        OEO_00000318
+    
+    
+Class: OEO_00010011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: OEO_00010012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that has the disposition to participates in air pollution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "air pollutant"@en
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00010015
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "fossil hydrogen"@de
+    
+    SubClassOf: 
+        OEO_00000220,
+        has_origin some OEO_00030002
+    
+    
+Class: OEO_00010016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic hydrogen"@de
+    
+    SubClassOf: 
+        OEO_00000220,
+        has_origin some OEO_00030005
+    
+    
+Class: OEO_00010017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic fuel"@de
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (has_origin some OEO_00030005)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00010018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is synthetic fuel produced in a power-to-gas system from water and carbon dioxide using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic methane"@de
+    
+    SubClassOf: 
+        OEO_00000025,
+        has_origin some OEO_00030005
+    
+    
+Class: OEO_00010019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic liquid fuel is synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electric energy applying.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic liquid fuel"@de
+    
+    EquivalentTo: 
+        OEO_00010017
+         and (has_normal_state_of_matter value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00010017
+    
+    
+Class: OEO_00010020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "power-to-liquid system"@de
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00010021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "water electrolyser"@de
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
+Class: OEO_00010022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting device that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "steam reformer"@de
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
+Class: OEO_00010023
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "vehicle"@de
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00010024
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A battery electric vehicle (BEV) is a vehicle that stores energy in an on-board battery.",
+        rdfs:label "battery electric vehicle"@de
+    
+    SubClassOf: 
+        OEO_00000146,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026
+    
+    
+Class: OEO_00010025
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A fuel cell electric vehicle (FCEV) is a vehicle that uses electrical energy from a fuel cell.",
+        rdfs:label "fuel cell electric vehicle"@de
+    
+    SubClassOf: 
+        OEO_00000146,
+        uses some OEO_00000220,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000016
+    
+    
+Class: OEO_00010026
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A traction battery is a battery used in vehicles for propulsion.",
+        rdfs:label "traction battery"@de
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00010027
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "An electric motor is an energy converting device that converts electrical energy into kinetic energy.",
+        rdfs:label "electric motor"@de
+    
+    SubClassOf: 
+        OEO_00000011,
+        uses some OEO_00000139
+    
+    
+Class: OEO_00010028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A traction motor is an electric motor used for propulsion.",
+        rdfs:label "traction motor"@de
+    
+    SubClassOf: 
+        OEO_00010027
+    
+    
+Class: OEO_00010029
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "An internal combustion engine is an energy converting device that converts chemical energy into into rotational energy using a cyclic combustion process.",
+        rdfs:label "internal combustion engine"@de
+    
+    SubClassOf: 
+        OEO_00000011,
+        uses some OEO_00000099
+    
+    
+Class: OEO_00010030
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        rdfs:label "plug-in hybrid electric vehicle"@de
+    
+    SubClassOf: 
+        OEO_00010023,
+        uses some OEO_00000099,
+        uses some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
+    
+    
+Class: OEO_00010031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "grid supplied electric vehicle"@de
+    
+    SubClassOf: 
+        OEO_00000146
+    
+    
+Class: OEO_00020003
+
+    Annotations: 
+        definition "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
+        rdfs:label "energy transformation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00020004
+
+    Annotations: 
+        definition "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "gas grid"@en
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
+    
+    
+Class: OEO_00020005
+
+    Annotations: 
+        definition "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "heating grid"@en
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
+    
+    
+Class: OEO_00020006
+
+    Annotations: 
+        definition "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
+    
+Class: OEO_00020007
+
+    Annotations: 
+        definition "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00020008
+
+    Annotations: 
+        definition "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00020009
+
+    Annotations: 
+        definition "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@en
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
+    
+    
+Class: OEO_00030000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "anthropogenic"
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "biogenic"
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
+
+In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "fossil"
+    
+    SubClassOf: 
+        OEO_00030003
+    
+    
+Class: OEO_00030003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "geogenic"
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "renewable"
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "synthetic"
+    
+    SubClassOf: 
+        OEO_00000316
+    
+    
+Class: OEO_00030019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "process attribute"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
+Class: OEO_00230000
+
+    Annotations: 
+        definition "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "storage capacity"
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00230001
+
+    Annotations: 
+        definition "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "power rating"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00230002
+
+    Annotations: 
+        definition "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "declared net capacity"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00230003
+
+    Annotations: 
+        definition "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "nameplate capacity"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Individual: OEO_00000182
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
         rdfs:label "gaseous"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+Individual: OEO_00000256
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
         rdfs:label "liquid"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000326>
+Individual: OEO_00000326
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+Individual: OEO_00000390
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
 DisjointClasses: 
-    <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+    OEO_00000188,OEO_00000210,OEO_00000425
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -50,7 +50,7 @@ AnnotationProperty: dc:description
     
 AnnotationProperty: dc:license
 
-
+    
 AnnotationProperty: definition
 
     SubPropertyOf: 
@@ -3058,7 +3058,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         rdfs:label "electric motor"@en
     
     SubClassOf: 
-        OEO_00000011,
+        OEO_00010032,
         uses some OEO_00000139
     
     
@@ -3077,12 +3077,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010029
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "An internal combustion engine is an energy converting device that converts chemical energy into into rotational energy using a cyclic combustion process.",
         rdfs:label "internal combustion engine"@en
     
     SubClassOf: 
-        OEO_00000011,
+        OEO_00010032,
         uses some OEO_00000099
     
     
@@ -3114,7 +3115,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
     
     SubClassOf: 
         OEO_00000146
+    
+    
+Class: OEO_00010032
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A motor is an energy converting device that converts other forms of energy into rotational kinetic energy.",
+        rdfs:label "motor"
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -3126,7 +3140,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445"@en,
     SubClassOf: 
         OEO_00000331,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000075
-
     
     
 Class: OEO_00020003
@@ -3408,3 +3421,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1239,6 +1239,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
     
     
@@ -2938,7 +2939,6 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
     
     
@@ -3025,8 +3025,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
         rdfs:label "grid supplied electric vehicle"@de
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3017,6 +3017,19 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied vehicle is an electric vehicle that uses electrical energy via a conductor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        rdfs:label "grid supplied vehicle"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3055,7 +3055,7 @@ Class: OEO_00010027
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "An electric motor is an energy converting device that converts electrical energy into kinetic energy.",
-        rdfs:label "electric motor"@de
+        rdfs:label "electric motor"@en
     
     SubClassOf: 
         OEO_00000011,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3079,7 +3079,7 @@ Class: OEO_00010029
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
         dc:description "An internal combustion engine is an energy converting device that converts chemical energy into into rotational energy using a cyclic combustion process.",
-        rdfs:label "internal combustion engine"@de
+        rdfs:label "internal combustion engine"@en
     
     SubClassOf: 
         OEO_00000011,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2938,6 +2938,19 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
         <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "A fuel cell electric vehicle is a vehicle that uses electrical energy from an fuel cell.",
+        rdfs:label "fuel cell vehicle"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -52,6 +52,9 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: dc:contributor
 
     
+AnnotationProperty: dc:description
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -2921,6 +2924,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "A battery electric vehicle is a vehicle that stores energy in an on-board battery.",
+        rdfs:label "battery electric vehicle"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -22,6 +22,12 @@ Annotations:
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)",
     rdfs:comment "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production."
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/definition>
+
+    SubPropertyOf: 
+        rdfs:comment
+    
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -46,12 +52,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: dc:contributor
 
     
-AnnotationProperty: definition
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: rdfs:comment
 
     
@@ -63,6 +63,208 @@ AnnotationProperty: rdfs:label
     
 Datatype: rdf:PlainLiteral
 
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00030021>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "has_process_attribute"@de
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/process_attribute_of>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/applies_technology>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology."
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/is_applied_to_object>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/covers>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/covers_energycarrier>
+
+    Annotations: 
+        rdfs:comment "A relation that holds between a publication/model calculation/model and the energycarrier it covers."
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/covers>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_globalwarmingpotential>
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has_normal_state_of_matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_origin>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_physical_input>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Characteristics: 
+        Functional,
+        Irreflexive,
+        Asymmetric
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_physical_output>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_sink>
+
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/is_connected_to>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/has_source>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_source>
+
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/is_connected_to>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/has_sink>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/has_state_of_matter>
+
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_applied_to_object>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object."
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/applies_technology>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_connected_to>
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Characteristics: 
+        Symmetric
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_equivalent_to>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an definition and its synonym."@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/is_used_by>
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/uses>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/process_attribute_of>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386"
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030021>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/uses>
+
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/is_used_by>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -94,209 +296,2866 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
-ObjectProperty: OEO_00030021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "has_process_attribute"@de
-    
-    InverseOf: 
-        process_attribute_of
-    
-    
-ObjectProperty: applies_technology
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology."
-    
-    Domain: 
-        OEO_00000061
-    
-    Range: 
-        OEO_00000407
-    
-    InverseOf: 
-        is_applied_to_object
-    
-    
-ObjectProperty: covers
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers."@en
-    
-    
-ObjectProperty: covers_energycarrier
-
-    Annotations: 
-        rdfs:comment "A relation that holds between a publication/model calculation/model and the energycarrier it covers."
-    
-    SubPropertyOf: 
-        covers
-    
-    Range: 
-        OEO_00000151
-    
-    
-ObjectProperty: has_globalwarmingpotential
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        OEO_00000198
-    
-    
-ObjectProperty: has_normal_state_of_matter
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has_normal_state_of_matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
-    
-ObjectProperty: has_origin
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000316
-    
-    
-ObjectProperty: has_physical_input
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Characteristics: 
-        Functional,
-        Irreflexive,
-        Asymmetric
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
-    
-    
-ObjectProperty: has_physical_output
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    
-ObjectProperty: has_sink
-
-    SubPropertyOf: 
-        is_connected_to
-    
-    DisjointWith: 
-        has_source
-    
-    
-ObjectProperty: has_source
-
-    SubPropertyOf: 
-        is_connected_to
-    
-    DisjointWith: 
-        has_sink
-    
-    
-ObjectProperty: has_state_of_matter
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
-    
-ObjectProperty: is_applied_to_object
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object."
-    
-    Domain: 
-        OEO_00000407
-    
-    Range: 
-        OEO_00000061
-    
-    InverseOf: 
-        applies_technology
-    
-    
-ObjectProperty: is_connected_to
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Characteristics: 
-        Symmetric
-    
-    
-ObjectProperty: is_equivalent_to
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an definition and its synonym."@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    
-ObjectProperty: is_used_by
-
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    InverseOf: 
-        uses
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
-ObjectProperty: process_attribute_of
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel role"
     
-    InverseOf: 
-        OEO_00030021
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-ObjectProperty: uses
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
 
-    SubPropertyOf: 
-        owl:topObjectProperty
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
+        rdfs:label "biofuel power unit"
     
-    InverseOf: 
-        is_used_by
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000004>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
+        rdfs:label "biogas powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
+        rdfs:label "biogas power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        rdfs:label "carbon dioxide"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
+        rdfs:label "chemical energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        rdfs:label "coal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000009>
+
+    Annotations: 
+        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy.",
+        rdfs:label "electric heat pump"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
+        rdfs:label "electro motive generator"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:comment "formerly called energy transformer",
+        rdfs:label "energy converting device"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000013>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
+        rdfs:label "fluorinated greenhouse gas"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000026> or <http://openenergy-platform.org/ontology/oeo/OEO_00000038> or <http://openenergy-platform.org/ontology/oeo/OEO_00000219> or <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
+        rdfs:label "fuel cell"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
+        rdfs:label "gas fired power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+             and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        rdfs:label "geothermal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
+        rdfs:label "hard coal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        rdfs:label "hydrogen power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
+        rdfs:label "lignite power unit"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
+        rdfs:label "methane"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000026>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
+        rdfs:label "nitrogen trifluoride"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000027>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        rdfs:label "nitrous oxide"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000028>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        rdfs:label "nuclear power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
+        rdfs:label "oil power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000309>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an aggregate of power generating units that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV cell is a generator that converts light into electrical energy.",
+        rdfs:label "PV cell"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel.",
+        rdfs:label "renewable fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
+        rdfs:label "solar power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000035>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
+        rdfs:label "solar thermal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000036>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
+        rdfs:label "solid biomass powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
+        rdfs:label "solid biomass power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000038>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
+        rdfs:label "sulphur hexafluoride"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000039>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        rdfs:label "thermal energy storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000040>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "uranium"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        rdfs:label "waste power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000042>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:label "waste role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000043>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        rdfs:label "wind energy converting unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "undirected",
+        rdfs:label "AC-line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
+        rdfs:label "air"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
+        rdfs:label "air pollution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000330>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000056>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
+        rdfs:label "ambient heat"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000058>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition),
+ https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)",
+        rdfs:label "artificial object"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000062>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "associated gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000066>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "aviation gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is a device using different chemical or physical reactions to store energy."@en,
+        rdfs:label "battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
+        <http://purl.obolibrary.org/obo/RO_0000085> some <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
+        rdfs:label "battery storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000071>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "biodiesel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a fuel that is produced through contemporary biological processes, such as agriculture and anaerobic digestion, rather than a fuel produced by geological processes such as those involved in the formation of fossil fuels, such as coal and petroleum, from prehistoric biological matter.
+
+Biofuels can be derived directly from plants (i.e. energy crops), or indirectly from agricultural, commercial, domestic, and/or industrial wastes.[1] Renewable biofuels generally involve contemporary carbon fixation, such as those that occur in plants or microalgae through the process of photosynthesis. Other renewable biofuels are made through the use or conversion of biomass (referring to recently living organisms, most often referring to plants or plant-derived materials). This biomass can be converted to convenient energy-containing substances in three different ways: thermal conversion, chemical conversion, and biochemical conversion. This biomass conversion can result in fuel in solid, liquid, or gas form. This new biomass can also be used directly for biofuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
+        rdfs:label "biofuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
+        rdfs:label "biofuel powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
+        rdfs:label "biogas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000075>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Bioethanol"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "biogasoline",
+        rdfs:label "biogasoline"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000077>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "blast furnace gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000084>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "charcoal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:label "coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000089>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
+        rdfs:label "coal powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000093>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coke oven gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000094>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coking coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000096>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
+        rdfs:label "colliery gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "combustion fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000102>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        rdfs:label "compressed air"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000115>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "crude oil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en,
+        rdfs:label "dammed water"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "directed",
+        rdfs:label "HVDC-line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Derived heat covers the total heat production in heating plants and in combined heat and power plants. It includes the heat used by the auxiliaries of the installation which use hot fluid (space heating, liquid fuel heating, etc.) And losses in the installation/network heat exchanges. For autoproducing entities (= entities generating electricity and/or heat wholly or partially for their own use as an activity which supports their primary activity) the heat used by the undertaking for its own processes is not included."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en,
+        rdfs:label "derived heat"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "diesel fuel",
+        rdfs:label "diesel fuel"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
+        rdfs:label "district heat"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is energy derived from electric potential energy or kinetic energy. [...] This energy is supplied by the combination of electric current and electric potential that is delivered by an electrical circuit"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        rdfs:label "electrical energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
+        rdfs:label "electricity grid"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "electricity grid component"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "electric vehicle"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of matter and radiation which is manifest as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage object"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
+        rdfs:label "field photovoltaic powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000169>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery, or redox flow battery (after reduction–oxidation), is a type of electrochemical cell where chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
+        rdfs:label "flow battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:label "fuel"
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000174>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled powerplant"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power unit"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gas diesel oil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
+        rdfs:label "gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000184>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
+        rdfs:label "gas powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000185>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustion turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "gas turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000186>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
+
+The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gasworks gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "generator"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000189>
+
+    Annotations: 
+        rdfs:label "geographic coordinate"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
+— for electricity generation using dry steam or high enthalpy brine after flashing,
+— directly as heat for district heating, agriculture etc"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "geothermal heat"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000192>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
+        rdfs:label "geothermal powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000019>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse effect disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas emission"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
+        rdfs:label "supply grid"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "hard coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000205>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
+        rdfs:label "hard coal powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "hardware"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
+       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
+        rdfs:label "heat"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "heater"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000211>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "heating oil",
+        rdfs:label "heating oil"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
+        rdfs:label "heat pump"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000216>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "hydroelectricity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "hydro energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000219>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
+        rdfs:label "hydrofluorocarbon"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
+        rdfs:label "hydrogen"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000221>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
+        rdfs:label "hydrogen powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000022>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "hydrogen turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste fuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "industrial waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000240>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "internal combustion vehicle"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000245>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "KeroseneTypeJetFuel"@en,
+        rdfs:label "jet fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+[...]
+
+Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        rdfs:label "kerosene"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000309>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000248>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery or Li-ion battery (abbreviated as LIB) is a type of rechargeable battery [...] In the batteries lithium ions move from the negative electrode to the positive electrode during discharge and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material, compared to the metallic lithium used in a non-rechargeable lithium battery. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
+        rdfs:label "lithium-ion battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
+
+Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "lignite"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000252>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
+        rdfs:label "lignite powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerline is a grid component that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "power line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid component link"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en,
+        rdfs:label "liquid air"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000258>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
+        rdfs:label "liquid biofuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000259>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rechargeable liquid-metal batteries are used for electric vehicles and potentially also for grid energy storage, to balance out intermittent renewable power sources such as solar panels and wind turbines."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "liquid-metal battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
+        rdfs:label "manufactured coal based gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
+        rdfs:label "methanation gas storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-salt batteries are a class of battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        rdfs:label "molten-salt battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-state batteries consist of two molten metal alloys separated by an electrolyte."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wastes produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "molten state battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000286>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
+
+Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "motor gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Municipal waste fuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "municipal waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
+
+It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "natural gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000293>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "negative emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid node"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000297>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "non associated gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "non-methane volatile organic compound"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000299>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non renewable municipal waste fuel is municipal waste fuel of non-biological origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "non renewable municipal waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "nuclear energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000303>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
+        rdfs:label "nuclear powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000029>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
+        rdfs:label "offshore wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000309>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
+
+It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
+        rdfs:label "oil and petroleum products"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000310>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
+        rdfs:label "oil powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000030>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
+        rdfs:label "onshore wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "origin"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "particulate matter"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>),
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000320>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
+
+This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "peat"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
+        rdfs:label "perfluorocarbon"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
+        rdfs:label "photovoltaic powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000330>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "solid biofuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/process_attribute_of> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+        rdfs:label "power generating unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000335>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
+        rdfs:label "power-to-gas system"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000343>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
+        rdfs:label "pumped storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        rdfs:label "pumped water"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://openenergy-platform.org/ontology/oeo/is_used_by> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
+        rdfs:label "PV panel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is a generically depenent continuant defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "quantity value"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000356>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable municipal waste fuel is municipal waste fuel of biological origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "renewable municipal waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000374>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
+          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
+        rdfs:label "SMES"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000376>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sodium-ion batteries (SIB) are a type of rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
+        rdfs:label "sodium-ion battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000377>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
+        rdfs:label "sodium-sulfur battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000283>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "solar energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000386>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
+        rdfs:label "solar power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        rdfs:label "solar thermal collector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
+(a) solar thermal-electric plants; or
+(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "solar thermal heat"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000389>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
+        rdfs:label "solar thermal powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000035>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000391>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
+        rdfs:label "solid fossil fuel"
+    
+    EquivalentTo: 
+        (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
+         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+        rdfs:label "state of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
+        rdfs:label "steam turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        rdfs:label "storage unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000401>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
+        rdfs:label "technology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
+        rdfs:label "transformer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
+        rdfs:label "turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000429>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Underground hydrogen storage is the practice of hydrogen storage in underground caverns,salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        rdfs:label "underground hydrogen storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatile organic compound"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000025> or <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>),
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification.",
+        rdfs:label "waste fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000042>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000440>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
+        rdfs:label "waste powerplant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000041>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000441>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
+        rdfs:label "water"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000442>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "water turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000043>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
+        rdfs:label "wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000448>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "wind rotor"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_output> some <http://openenergy-platform.org/ontology/oeo/OEO_00000333>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
+        <http://openenergy-platform.org/ontology/oeo/has_physical_input> only <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000449>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "wood and other"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000332>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. Synonyms are trihydridonitrogen and nitrogen trihydride.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "ammonia"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010001>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "carbon monoxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen oxides"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010003>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitric oxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010004>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen dioxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010007>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "sulphur dioxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010009>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM10"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010010>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM2.5"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010011>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that has the disposition to participates in air pollution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "air pollutant"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010015>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "fossil hydrogen"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010016>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic hydrogen"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic fuel"@de
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010018>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is synthetic fuel produced in a power-to-gas system from water and carbon dioxide using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic methane"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
+        <http://openenergy-platform.org/ontology/oeo/has_origin> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010019>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic liquid fuel is synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electric energy applying.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic liquid fuel"@de
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+         and (<http://openenergy-platform.org/ontology/oeo/has_normal_state_of_matter> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010020>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "power-to-liquid system"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "water electrolyser"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010022>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting device that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "steam reformer"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "vehicle"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
+        rdfs:label "energy transformation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "gas grid"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "heating grid"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020004>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "anthropogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "biogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
+
+In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "fossil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "geogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "renewable"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
+        rdfs:label "synthetic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "process attribute"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "storage capacity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "power rating"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "declared net capacity"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/definition> "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "nameplate capacity"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -368,2905 +3227,46 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Class: OEO_00000001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:label "fuel role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00000003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
-        rdfs:label "biofuel power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000072
-    
-    
-Class: OEO_00000004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
-        rdfs:label "biogas powerplant"
-    
-    SubClassOf: 
-        OEO_00000073
-    
-    
-Class: OEO_00000005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
-        rdfs:label "biogas power unit"
-    
-    SubClassOf: 
-        OEO_00000003,
-        uses some OEO_00000074
-    
-    
-Class: OEO_00000006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
-        rdfs:label "chemical energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
-        rdfs:label "coal power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000088
-    
-    
-Class: OEO_00000009
-
-    Annotations: 
-        rdfs:comment "An electric heat pump is a heat pump that uses electric energy as drive energy.",
-        rdfs:label "electric heat pump"
-    
-    SubClassOf: 
-        OEO_00000212
-    
-    
-Class: OEO_00000010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
-        rdfs:label "electro motive generator"
-    
-    SubClassOf: 
-        OEO_00000188
-    
-    
-Class: OEO_00000011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting device is an artificial object that transforms or changes a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:comment "formerly called energy transformer",
-        rdfs:label "energy converting device"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage"
-    
-    SubClassOf: 
-        OEO_00000151,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: OEO_00000013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
-        rdfs:label "fluorinated greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000026 or OEO_00000038 or OEO_00000219 or OEO_00000322
-    
-    SubClassOf: 
-        OEO_00000020
-    
-    
-Class: OEO_00000014
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (has_origin some OEO_00030002)
-    
-    SubClassOf: 
-        has_origin some OEO_00030003
-    
-    
-Class: OEO_00000016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
-        rdfs:label "fuel cell"
-    
-    SubClassOf: 
-        OEO_00000188
-    
-    
-Class: OEO_00000017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
-        rdfs:label "gas fired power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some 
-            (OEO_00000173
-             and (has_normal_state_of_matter value OEO_00000182))
-    
-    
-Class: OEO_00000019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
-        rdfs:label "geothermal power unit"
-    
-    SubClassOf: 
-        OEO_00000334
-    
-    
-Class: OEO_00000020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
-        rdfs:label "hard coal power unit"
-    
-    SubClassOf: 
-        OEO_00000008,
-        uses some OEO_00000204
-    
-    
-Class: OEO_00000022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
-        rdfs:label "hydrogen power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000220
-    
-    
-Class: OEO_00000024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
-        rdfs:label "lignite power unit"
-    
-    EquivalentTo: 
-        uses some OEO_00000251
-    
-    SubClassOf: 
-        OEO_00000008
-    
-    
-Class: OEO_00000025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a portion of matter with the chemical formular CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
-        rdfs:label "methane"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
-        rdfs:label "nitrogen trifluoride"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030000,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
-        rdfs:label "nitrous oxide"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000028
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00000029
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
-        rdfs:label "nuclear power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000302
-    
-    
-Class: OEO_00000030
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
-        rdfs:label "oil power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000309
-    
-    
-Class: OEO_00000031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an aggregate of power generating units that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "powerplant"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV cell is a generator that converts light into electrical energy.",
-        rdfs:label "PV cell"
-    
-    SubClassOf: 
-        OEO_00000188
-    
-    
-Class: OEO_00000033
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an energy carrier disposition that is used as a fuel.",
-        rdfs:label "renewable fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (has_origin some OEO_00030004)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
-        rdfs:label "solar power unit"
-    
-    SubClassOf: 
-        OEO_00000334
-    
-    
-Class: OEO_00000035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
-        rdfs:label "solar thermal power unit"
-    
-    SubClassOf: 
-        OEO_00000034,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
-    
-    
-Class: OEO_00000036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
-        rdfs:label "solid biomass powerplant"
-    
-    SubClassOf: 
-        OEO_00000073
-    
-    
-Class: OEO_00000037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
-        rdfs:label "solid biomass power unit"
-    
-    SubClassOf: 
-        OEO_00000003,
-        uses some OEO_00000332
-    
-    
-Class: OEO_00000038
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
-        rdfs:label "sulphur hexafluoride"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030000,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
-        rdfs:label "thermal energy storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    
-Class: OEO_00000040
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030003,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000041
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
-        rdfs:label "waste power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        uses some OEO_00000439
-    
-    
-Class: OEO_00000042
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:label "waste role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00000043
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000044
-
-    Annotations: 
-        definition "A wind energy converting unit is a power generating unit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        rdfs:label "wind energy converting unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000425
-    
-    
-Class: OEO_00000047
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "undirected",
-        rdfs:label "AC-line"@en
-    
-    SubClassOf: 
-        OEO_00000253
-    
-    DisjointWith: 
-        OEO_00000126
-    
-    
-Class: OEO_00000054
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
-        rdfs:label "air"
-    
-    SubClassOf: 
-        OEO_00000331,
-        is_used_by some OEO_00000399,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000055
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution"
-    
-    SubClassOf: 
-        OEO_00000330,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010012
-    
-    
-Class: OEO_00000056
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
-        rdfs:label "ambient heat"
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00000058
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite"
-    
-    SubClassOf: 
-        OEO_00000204
-    
-    
-Class: OEO_00000061
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition),
- https://github.com/OpenEnergyPlatform/ontology/pull/128 (subclasses)",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    
-Class: OEO_00000062
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "associated gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000066
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "aviation gasoline"
-    
-    SubClassOf: 
-        OEO_00000183
-    
-    
-Class: OEO_00000068
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is a device using different chemical or physical reactions to store energy."@en,
-        rdfs:label "battery"
-    
-    SubClassOf: 
-        OEO_00000159,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
-    
-    
-Class: OEO_00000070
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
-        rdfs:label "battery storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    DisjointWith: 
-        OEO_00000269
-    
-    
-Class: OEO_00000071
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that includes bio-diesel (a methyl-ester produced from vegetable or animal oil, of diesel quality), biodimethylether (dimethylether produced from biomass), Fischer-Tropsch (Fischer-Tropsch produced from biomass), cold extracted bio-oil (oil produced from oil seed through mechanical processing only) and all other liquid biofuels which are added to, blended with or used straight as transport diesel.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "biodiesel"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000072
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a fuel that is produced through contemporary biological processes, such as agriculture and anaerobic digestion, rather than a fuel produced by geological processes such as those involved in the formation of fossil fuels, such as coal and petroleum, from prehistoric biological matter.
-
-Biofuels can be derived directly from plants (i.e. energy crops), or indirectly from agricultural, commercial, domestic, and/or industrial wastes.[1] Renewable biofuels generally involve contemporary carbon fixation, such as those that occur in plants or microalgae through the process of photosynthesis. Other renewable biofuels are made through the use or conversion of biomass (referring to recently living organisms, most often referring to plants or plant-derived materials). This biomass can be converted to convenient energy-containing substances in three different ways: thermal conversion, chemical conversion, and biochemical conversion. This biomass conversion can result in fuel in solid, liquid, or gas form. This new biomass can also be used directly for biofuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Biofuel&oldid=866432109",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
-        rdfs:label "biofuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (has_origin some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000173,
-        has_origin some OEO_00030001,
-        has_origin some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
-        rdfs:label "biofuel powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000003
-    
-    
-Class: OEO_00000074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
-        rdfs:label "biogas"
-    
-    SubClassOf: 
-        OEO_00000072,
-        has_origin some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000075
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that includes bioethanol (ethanol produced from biomass and/or the biodegradable fraction of waste), biomethanol (methanol produced from biomass and/or the biodegradable fraction of waste), bioETBE (ethyl-tertio-butyl-ether produced on the basis of bioethanol; the percentage by volume of bioETBE that is calculated as biofuel is 47 %) and bioMTBE (methyl-tertio-butyl-ether produced on the basis of biomethanol: the percentage by volume of bioMTBE that is calculated as biofuel is 36 %)",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Bioethanol"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "biogasoline",
-        rdfs:label "biogasoline"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000077
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "blast furnace gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000084
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "charcoal"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000088
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:label "coal"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000089
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
-        rdfs:label "coal powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000093
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coke oven gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000094
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coking coal"
-    
-    SubClassOf: 
-        OEO_00000204
-    
-    
-Class: OEO_00000096
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
-        rdfs:label "colliery gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000097
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00000099
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
-    
-    SubClassOf: 
-        OEO_00000173
-    
-    
-Class: OEO_00000102
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
-        rdfs:label "compressed air"
-    
-    SubClassOf: 
-        OEO_00000054
-    
-    
-Class: OEO_00000115
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        OEO_00000309,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000117
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is a barrier that stops or restricts the flow of water or underground streams. Reservoirs created by dams not only suppress floods but also provide water for activities such as irrigation, human consumption, industrial use, aquaculture, and navigability. Hydropower is often used in conjunction with dams to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Dam&oldid=906014627"@en,
-        rdfs:label "dammed water"
-    
-    SubClassOf: 
-        OEO_00000441,
-        is_used_by some OEO_00000399
-    
-    
-Class: OEO_00000126
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "directed",
-        rdfs:label "HVDC-line"@en
-    
-    SubClassOf: 
-        OEO_00000253
-    
-    DisjointWith: 
-        OEO_00000047
-    
-    
-Class: OEO_00000129
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Derived heat covers the total heat production in heating plants and in combined heat and power plants. It includes the heat used by the auxiliaries of the installation which use hot fluid (space heating, liquid fuel heating, etc.) And losses in the installation/network heat exchanges. For autoproducing entities (= entities generating electricity and/or heat wholly or partially for their own use as an activity which supports their primary activity) the heat used by the undertaking for its own processes is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=DSP_GLOSSARY_NOM_DTL_VIEW&StrNom=CODED2&StrLanguageCode=EN&IntKey=16452285&RdoSearch=&TxtSearch=&CboTheme=&IntCurrentPage=1"@en,
-        rdfs:label "derived heat"
-    
-    EquivalentTo: 
-        OEO_00000132
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00000131
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "diesel fuel",
-        rdfs:label "diesel fuel"@en
-    
-    SubClassOf: 
-        OEO_00000181
-    
-    
-Class: OEO_00000132
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
-        rdfs:label "district heat"
-    
-    EquivalentTo: 
-        OEO_00000129
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00000139
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is energy derived from electric potential energy or kinetic energy. [...] This energy is supplied by the combination of electric current and electric potential that is delivered by an electrical circuit"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        rdfs:label "electrical energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000143
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 OEO_00000253
-    
-    
-Class: OEO_00000144
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00000146
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "electric vehicle"
-    
-    SubClassOf: 
-        OEO_00010023
-    
-    
-Class: OEO_00000147
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000150
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of matter and radiation which is manifest as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: OEO_00000151
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: OEO_00000159
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage object"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000165
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
-        rdfs:label "field photovoltaic powerplant"
-    
-    SubClassOf: 
-        OEO_00000324
-    
-    DisjointWith: 
-        OEO_00000361
-    
-    
-Class: OEO_00000169
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery, or redox flow battery (after reduction–oxidation), is a type of electrochemical cell where chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
-        rdfs:label "flow battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000173
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and which has a fuel role that is realised in processes that release the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00000174
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled powerplant"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
-    
-    SubClassOf: 
-        OEO_00000031
-    
-    
-Class: OEO_00000175
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power unit"
-    
-    EquivalentTo: 
-        uses some OEO_00000173
-    
-    SubClassOf: 
-        OEO_00000334
-    
-    
-Class: OEO_00000181
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gas diesel oil"
-    
-    SubClassOf: 
-        OEO_00000309,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000183
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
-        rdfs:label "gasoline"
-    
-    SubClassOf: 
-        OEO_00000309,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000184
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
-        rdfs:label "gas powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000017
-    
-    
-Class: OEO_00000185
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Combustion turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "gas turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        has_physical_output some OEO_00000333,
-        has_physical_input only OEO_00000292
-    
-    
-Class: OEO_00000186
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
-
-The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gasworks gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000188
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting device that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        OEO_00000011,
-        has_physical_output some OEO_00000139
-    
-    
-Class: OEO_00000189
-
-    Annotations: 
-        rdfs:label "geographic coordinate"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-    
-    
-Class: OEO_00000191
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
-— for electricity generation using dry steam or high enthalpy brine after flashing,
-— directly as heat for district heating, agriculture etc"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "geothermal heat"
-    
-    SubClassOf: 
-        OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
-    
-    
-Class: OEO_00000192
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
-        rdfs:label "geothermal powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000198
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse effect disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: OEO_00000199
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas emission"
-    
-    SubClassOf: 
-        OEO_00000147,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020
-    
-    
-Class: OEO_00000200
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: OEO_00000204
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "hard coal"
-    
-    SubClassOf: 
-        OEO_00000088
-    
-    DisjointWith: 
-        OEO_00000251
-    
-    
-Class: OEO_00000205
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
-        rdfs:label "hard coal powerplant"
-    
-    SubClassOf: 
-        OEO_00000089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
-    
-    
-Class: OEO_00000206
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
-       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000207
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In thermodynamics, heat is energy in transfer to or from a thermodynamic system, by mechanisms other than thermodynamic work or transfer of matter.
-       The mechanisms include conduction, through direct contact of immobile bodies, or through a wall or barrier that is impermeable to matter; or radiation between separated bodies; or isochoric mechanical work done by the surroundings on the system of interest; or Joule heating by an electric current driven through the system of interest by an external system; or a combination of these."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Heat&oldid=90563031157"@en,
-        rdfs:label "heat"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000210
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "heater"
-    
-    SubClassOf: 
-        OEO_00000011,
-        has_physical_output some OEO_00000207
-    
-    
-Class: OEO_00000211
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil",
-        rdfs:label "heating oil"@en
-    
-    SubClassOf: 
-        OEO_00000181
-    
-    
-Class: OEO_00000212
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
-        rdfs:label "heat pump"
-    
-    SubClassOf: 
-        OEO_00000210
-    
-    
-Class: OEO_00000216
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Potential and kinetic energy of water converted into electricity in hydroelectric plants.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "hydroelectricity"
-    
-    SubClassOf: 
-        OEO_00000218
-    
-    
-Class: OEO_00000218
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydropower or water power [...] is power derived from the energy of falling water or fast running water, which may be harnessed for useful purposes."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydropower&oldid=906980683"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "hydro energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000219
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
-        rdfs:label "hydrofluorocarbon"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030000
-    
-    
-Class: OEO_00000220
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000221
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
-        rdfs:label "hydrogen powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
-    
-    
-Class: OEO_00000222
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "hydrogen turbine"
-    
-    SubClassOf: 
-        OEO_00000185,
-        has_physical_output some OEO_00000333,
-        has_physical_input only OEO_00000220
-    
-    
-Class: OEO_00000226
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste fuel is waste fuel of industrial non-renewable origin (solids or liquids) combusted directly for the production of electricity and/or heat. The quantity of fuel used should be reported on a net calorific value basis. Renewable industrial waste should be reported in the solid biomass, biogas and/or liquid biofuels categories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "industrial waste fuel"
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00000240
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by internal combustion engine.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "internal combustion vehicle"
-    
-    SubClassOf: 
-        OEO_00010023
-    
-    
-Class: OEO_00000245
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "KeroseneTypeJetFuel"@en,
-        rdfs:label "jet fuel"
-    
-    SubClassOf: 
-        OEO_00000246
-    
-    
-Class: OEO_00000246
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
-[...]
-
-Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        rdfs:label "kerosene"
-    
-    SubClassOf: 
-        OEO_00000309,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000248
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery or Li-ion battery (abbreviated as LIB) is a type of rechargeable battery [...] In the batteries lithium ions move from the negative electrode to the positive electrode during discharge and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material, compared to the metallic lithium used in a non-rechargeable lithium battery. "@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
-        rdfs:label "lithium-ion battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000251
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
-
-Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "lignite"
-    
-    SubClassOf: 
-        OEO_00000088,
-        has_origin some OEO_00030002,
-        has_normal_state_of_matter value OEO_00000390
-    
-    DisjointWith: 
-        OEO_00000204
-    
-    
-Class: OEO_00000252
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
-        rdfs:label "lignite powerplant"
-    
-    SubClassOf: 
-        OEO_00000089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000024
-    
-    
-Class: OEO_00000253
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerline is a grid component that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        OEO_00000255,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
-    
-Class: OEO_00000255
-
-    Annotations: 
-        definition "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    DisjointWith: 
-        OEO_00000296
-    
-    
-Class: OEO_00000257
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has been compressed and cooled to store energy until it condenses as a liquid. To discharge energy, the air is expanded."@en,
-        rdfs:label "liquid air"
-    
-    SubClassOf: 
-        OEO_00000054
-    
-    
-Class: OEO_00000258
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
-        rdfs:label "liquid biofuel"
-    
-    EquivalentTo: 
-        OEO_00000072
-         and (has_normal_state_of_matter value OEO_00000256)
-    
-    SubClassOf: 
-        has_origin some OEO_00030001,
-        has_origin some OEO_00030004,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000259
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rechargeable liquid-metal batteries are used for electric vehicles and potentially also for grid energy storage, to balance out intermittent renewable power sources such as solar panels and wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "liquid-metal battery"
-    
-    SubClassOf: 
-        OEO_00000283
-    
-    
-Class: OEO_00000263
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
-        rdfs:label "manufactured coal based gas"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000269
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
-        rdfs:label "methanation gas storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    DisjointWith: 
-        OEO_00000070
-    
-    
-Class: OEO_00000282
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-salt batteries are a class of battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "molten-salt battery"
-    
-    SubClassOf: 
-        OEO_00000283
-    
-    
-Class: OEO_00000283
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Molten-state batteries consist of two molten metal alloys separated by an electrolyte."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wastes produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "molten state battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000286
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
-
-Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "motor gasoline"
-    
-    SubClassOf: 
-        OEO_00000183
-    
-    
-Class: OEO_00000290
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Municipal waste fuel is waste fuel of waste produced by households, hospitals and the tertiary sector incinerated at specific installations, on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "municipal waste fuel"
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00000292
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
-
-It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "natural gas"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00000293
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "negative emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000296
-
-    Annotations: 
-        definition "A grid node is a grid component of a supply grid where two or more links meet."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid node"
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    DisjointWith: 
-        OEO_00000255
-    
-    
-Class: OEO_00000297
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "non associated gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000298
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "non-methane volatile organic compound"
-    
-    SubClassOf: 
-        OEO_00000437
-    
-    
-Class: OEO_00000299
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non renewable municipal waste fuel is municipal waste fuel of non-biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "non renewable municipal waste fuel"
-    
-    SubClassOf: 
-        OEO_00000290,
-        has_origin some OEO_00030002
-    
-    
-Class: OEO_00000300
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy is the use of nuclear reactions that release nuclear energy to generate heat, which most frequently is then used in steam turbines to produce electricity in a nuclear power plant. Nuclear power can be obtained from nuclear fission, nuclear decay and nuclear fusion. Presently, the vast majority of electricity from nuclear power is produced by nuclear fission of elements in the actinide series of the periodic table. Nuclear decay processes are used in niche applications such as radioisotope thermoelectric generators. The possibility of generating electricity from nuclear fusion is still at a research phase with no commercial applications. This article mostly deals with nuclear fission power for electricity generation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Nuclear_power&oldid=868476098"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "nuclear energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000302
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
-    
-    SubClassOf: 
-        OEO_00000173
-    
-    
-Class: OEO_00000303
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
-        rdfs:label "nuclear powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000308
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
-        rdfs:label "offshore wind farm"
-    
-    SubClassOf: 
-        OEO_00000447
-    
-    DisjointWith: 
-        OEO_00000311
-    
-    
-Class: OEO_00000309
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
-
-It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
-        rdfs:label "oil and petroleum products"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000310
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
-        rdfs:label "oil powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000311
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
-        rdfs:label "onshore wind farm"
-    
-    SubClassOf: 
-        OEO_00000447
-    
-    DisjointWith: 
-        OEO_00000308
-    
-    
-Class: OEO_00000316
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The origin is a quality that indicates where something comes from (its source).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: OEO_00000318
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter"
-    
-    SubClassOf: 
-        OEO_00000331,
-        (has_normal_state_of_matter value OEO_00000256) or (has_normal_state_of_matter value OEO_00000390),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
-    
-    
-Class: OEO_00000320
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
-
-This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "peat"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000322
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
-        rdfs:label "perfluorocarbon"
-    
-    SubClassOf: 
-        OEO_00000331,
-        has_origin some OEO_00030000
-    
-    
-Class: OEO_00000324
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
-        rdfs:label "photovoltaic powerplant"
-    
-    SubClassOf: 
-        OEO_00000386,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
-    
-    
-Class: OEO_00000330
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution"
-    
-    SubClassOf: 
-        OEO_00000147
-    
-    
-Class: OEO_00000331
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is a part of a material entity that has a state_of_matter property."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: OEO_00000332
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "solid biofuel"@en
-    
-    EquivalentTo: 
-        OEO_00000072
-         and (has_normal_state_of_matter value OEO_00000390)
-    
-    SubClassOf: 
-        has_origin some OEO_00030001,
-        has_origin some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000333
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        OEO_00030019,
-        process_attribute_of some OEO_00020003
-    
-    
-Class: OEO_00000334
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an artificial object that contains a generator, among other parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
-        rdfs:label "power generating unit"
-    
-    SubClassOf: 
-        OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188
-    
-    
-Class: OEO_00000335
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
-        rdfs:label "power-to-gas system"
-    
-    SubClassOf: 
-        OEO_00000159
-    
-    
-Class: OEO_00000343
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
-        rdfs:label "pumped storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    
-Class: OEO_00000345
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is water which was pumped into an upper reservoir and thus contains potential energy."@en,
-        rdfs:label "pumped water"
-    
-    SubClassOf: 
-        OEO_00000441,
-        is_used_by some OEO_00000399
-    
-    
-Class: OEO_00000348
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
-        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
-        rdfs:label "PV panel"
-    
-    SubClassOf: 
-        OEO_00000034,
-        has_physical_output some OEO_00000333,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032
-    
-    
-Class: OEO_00000350
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is a generically depenent continuant defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "quantity value"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00000356
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable municipal waste fuel is municipal waste fuel of biological origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "renewable municipal waste fuel"
-    
-    SubClassOf: 
-        OEO_00000290,
-        has_origin some OEO_00030001,
-        has_origin some OEO_00030004
-    
-    
-Class: OEO_00000361
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
-        rdfs:label "rooftop photovoltaic powerplant"
-    
-    SubClassOf: 
-        OEO_00000324
-    
-    DisjointWith: 
-        OEO_00000165
-    
-    
-Class: OEO_00000374
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
-        rdfs:label "SMES"
-    
-    SubClassOf: 
-        OEO_00000159
-    
-    
-Class: OEO_00000376
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sodium-ion batteries (SIB) are a type of rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
-        rdfs:label "sodium-ion battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000377
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        rdfs:label "sodium-sulfur battery"
-    
-    SubClassOf: 
-        OEO_00000283
-    
-    
-Class: OEO_00000384
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "solar energy"
-    
-    SubClassOf: 
-        OEO_00000150,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
-    
-    
-Class: OEO_00000386
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
-        rdfs:label "solar power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
-    
-    
-Class: OEO_00000387
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
-        rdfs:label "solar thermal collector"
-    
-    SubClassOf: 
-        OEO_00000210,
-        has_physical_input only OEO_00000388
-    
-    
-Class: OEO_00000388
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat from solar radiation; can consist of:
-(a) solar thermal-electric plants; or
-(b) equipment for the production of domestic hot water or for the seasonal heating of swimming pools (e.g. flat plate collectors, mainly of the thermosyphon type)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "solar thermal heat"
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00000389
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
-        rdfs:label "solar thermal powerplant"
-    
-    SubClassOf: 
-        OEO_00000386,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000035,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000391
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid fossil fuels are fuels of fossil origin and that have a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164",
-        rdfs:label "solid fossil fuel"
-    
-    EquivalentTo: 
-        (has_origin some OEO_00030002)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
-         and (has_normal_state_of_matter value OEO_00000390)
-    
-    SubClassOf: 
-        OEO_00000173,
-        has_origin some OEO_00030002,
-        has_normal_state_of_matter value OEO_00000390
-    
-    
-Class: OEO_00000395
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: OEO_00000396
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
-        rdfs:label "steam turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        has_physical_output some OEO_00000333
-    
-    
-Class: OEO_00000399
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
-        rdfs:label "storage unit"
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
-    
-Class: OEO_00000401
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal"
-    
-    SubClassOf: 
-        OEO_00000088
-    
-    
-Class: OEO_00000407
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
-        rdfs:label "technology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000420
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
-        rdfs:label "transformer"
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
-    
-Class: OEO_00000425
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
-        rdfs:label "turbine"
-    
-    SubClassOf: 
-        OEO_00000011
-    
-    
-Class: OEO_00000429
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Underground hydrogen storage is the practice of hydrogen storage in underground caverns,salt domes and depleted oil/gas fields."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
-        rdfs:label "underground hydrogen storage"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000437
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound"
-    
-    EquivalentTo: 
-        OEO_00000025 or OEO_00000298
-    
-    SubClassOf: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
-    
-    
-Class: OEO_00000439
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification.",
-        rdfs:label "waste fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000042)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000440
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
-        rdfs:label "waste powerplant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000441
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter that is transparent, tasteless, odorless, and nearly colorless, which is the main constituent of Earth's hydrosphere, and the fluids of most living organisms. It is vital for all known forms of life, even though it provides no calories or organic nutrients. Its chemical formula is H2O, meaning that each of its molecules contains one oxygen and two hydrogen atoms, connected by covalent bonds. Water is the name of the liquid state of H2O at standard ambient temperature and pressure.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Water",
-        rdfs:label "water"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
-        has_normal_state_of_matter value OEO_00000256
-    
-    
-Class: OEO_00000442
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "water turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        has_physical_output some OEO_00000333,
-        has_physical_input only OEO_00000218
-    
-    
-Class: OEO_00000446
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy of wind exploited for electricity generation in wind turbines."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind energy"
-    
-    SubClassOf: 
-        OEO_00000150,
-        uses some OEO_00000043,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
-    
-    
-Class: OEO_00000447
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
-        rdfs:label "wind farm"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000044
-    
-    
-Class: OEO_00000448
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "wind rotor"
-    
-    SubClassOf: 
-        OEO_00000425,
-        has_physical_output some OEO_00000333,
-        uses some OEO_00000446,
-        has_physical_input only OEO_00000446
-    
-    
-Class: OEO_00000449
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood and other is solid biomass of purpose-grown energy crops (poplar, willow etc.), a multitude of woody materials generated by an industrial process (wood/paper industry in particular) or provided directly by forestry and agriculture (firewood, wood chips, wood pellets, bark, sawdust, shavings, chips, black liquor etc.) as well as wastes such as straw, rice husks, nut shells, poultry litter, crushed grape dregs etc. Combustion is the preferred technology for these solid wastes. The quantity of fuel used should be reported on a net calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "wood and other"
-    
-    SubClassOf: 
-        OEO_00000332,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
-    
-    
-Class: OEO_00010000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. Synonyms are trihydridonitrogen and nitrogen trihydride.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "ammonia"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00010001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00010002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00010003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitric oxide"@en
-    
-    SubClassOf: 
-        OEO_00010002
-    
-    
-Class: OEO_00010004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen dioxide"@en
-    
-    SubClassOf: 
-        OEO_00010002
-    
-    
-Class: OEO_00010007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "sulphur dioxide"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        has_normal_state_of_matter value OEO_00000182
-    
-    
-Class: OEO_00010009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en
-    
-    SubClassOf: 
-        OEO_00000318
-    
-    
-Class: OEO_00010010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en
-    
-    SubClassOf: 
-        OEO_00000318
-    
-    
-Class: OEO_00010011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: OEO_00010012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that has the disposition to participates in air pollution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "air pollutant"@en
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055)
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00010015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "fossil hydrogen"@de
-    
-    SubClassOf: 
-        OEO_00000220,
-        has_origin some OEO_00030002
-    
-    
-Class: OEO_00010016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic hydrogen"@de
-    
-    SubClassOf: 
-        OEO_00000220,
-        has_origin some OEO_00030005
-    
-    
-Class: OEO_00010017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic fuel"@de
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (has_origin some OEO_00030005)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00010018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is synthetic fuel produced in a power-to-gas system from water and carbon dioxide using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic methane"@de
-    
-    SubClassOf: 
-        OEO_00000025,
-        has_origin some OEO_00030005
-    
-    
-Class: OEO_00010019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic liquid fuel is synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electric energy applying.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic liquid fuel"@de
-    
-    EquivalentTo: 
-        OEO_00010017
-         and (has_normal_state_of_matter value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00010017
-    
-    
-Class: OEO_00010020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "power-to-liquid system"@de
-    
-    SubClassOf: 
-        OEO_00000159
-    
-    
-Class: OEO_00010021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "water electrolyser"@de
-    
-    SubClassOf: 
-        OEO_00000011
-    
-    
-Class: OEO_00010022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting device that produces syngas from hydrocarbons such as natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "steam reformer"@de
-    
-    SubClassOf: 
-        OEO_00000011
-    
-    
-Class: OEO_00010023
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle"@de
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00020003
-
-    Annotations: 
-        definition "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
-        rdfs:label "energy transformation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00020004
-
-    Annotations: 
-        definition "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "gas grid"@en
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
-    
-    
-Class: OEO_00020005
-
-    Annotations: 
-        definition "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "heating grid"@en
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
-    
-    
-Class: OEO_00020006
-
-    Annotations: 
-        definition "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
-    
-Class: OEO_00020007
-
-    Annotations: 
-        definition "A gas grid component is a grid component that is part of a gas grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "gas grid component"@en
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020008
-
-    Annotations: 
-        definition "A heating grid component is a grid component that is part of a heating grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "heating grid component"@en
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020009
-
-    Annotations: 
-        definition "A switchyard is an electricity grid component that connects different levels of voltage"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@en
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
-    
-    
-Class: OEO_00030000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "anthropogenic"
-    
-    SubClassOf: 
-        OEO_00000316
-    
-    
-Class: OEO_00030001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "biogenic is an origin of portions of matter made by or produced from life forms.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "biogenic"
-    
-    SubClassOf: 
-        OEO_00000316
-    
-    
-Class: OEO_00030002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "fossil is an origin of portions of matter created from organic material by geolocial processes lasting thousands or millions of years.
-
-In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        OEO_00030003
-    
-    
-Class: OEO_00030003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "geogenic is an origin of portions of matter that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        OEO_00000316
-    
-    
-Class: OEO_00030004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "renewable"
-    
-    SubClassOf: 
-        OEO_00000316
-    
-    
-Class: OEO_00030005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "synthetic is an origin of portions of matter created artifically by a chemical process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
-        rdfs:label "synthetic"
-    
-    SubClassOf: 
-        OEO_00000316
-    
-    
-Class: OEO_00030019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"@de
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    
-Class: OEO_00230000
-
-    Annotations: 
-        definition "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "storage capacity"
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00230001
-
-    Annotations: 
-        definition "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "power rating"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00230002
-
-    Annotations: 
-        definition "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "declared net capacity"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00230003
-
-    Annotations: 
-        definition "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "nameplate capacity"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Individual: OEO_00000182
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
         rdfs:label "gaseous"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000256
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
         rdfs:label "liquid"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000326
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000326>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000390
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
 DisjointClasses: 
-    OEO_00000188,OEO_00000210,OEO_00000425
+    <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3002,7 +3002,7 @@ Class: OEO_00010023
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that is used for transporting people or goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle"@de
+        rdfs:label "vehicle"@en
     
     SubClassOf: 
         OEO_00000061

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3001,6 +3001,22 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
         <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "A plug-in hybrid electric vehicle is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        rdfs:label "plug-in hybrid electric vehicle"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
+    
+    
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1238,7 +1238,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
         rdfs:label "electric vehicle"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
@@ -2961,6 +2962,29 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "An electric motor is an energy converting device that converts electrical energy into kinetic energy.",
+        rdfs:label "electric motor"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "A traction motor is an electric motor used for propulsion.",
+        rdfs:label "traction motor"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3029,7 +3029,7 @@ Class: OEO_00010025
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A fuel cell electric vehicle (FCEV) is a vehicle that uses electrical energy from a fuel cell.",
-        rdfs:label "fuel cell electric vehicle"@de
+        rdfs:label "fuel cell electric vehicle"@en
     
     SubClassOf: 
         OEO_00000146,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2935,7 +2935,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
@@ -2949,6 +2950,17 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
         <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
         <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "A traction battery is a battery used in vehicles for propulsion.",
+        rdfs:label "traction battery"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1702,7 +1702,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
         rdfs:label "internal combustion vehicle"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000245>
@@ -2985,6 +2987,18 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        dc:description "An internal combustion engine is an energy converting device that converts chemical energy into into rotational energy using a cyclic combustion process.",
+        rdfs:label "internal combustion engine"@de
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1696,7 +1696,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000240>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
         rdfs:label "internal combustion vehicle"
@@ -2946,7 +2946,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
-        dc:description "A fuel cell electric vehicle is a vehicle that uses electrical energy from an fuel cell.",
+        dc:description "A fuel cell electric vehicle is a vehicle that uses electrical energy from a fuel cell.",
         rdfs:label "fuel cell vehicle"@de
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3026,8 +3026,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
+        <http://openenergy-platform.org/ontology/oeo/uses> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2934,7 +2934,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A battery electric vehicle (BEV) is a vehicle that stores energy in an on-board battery.",
         rdfs:label "battery electric vehicle"@de
     
@@ -2947,7 +2948,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A fuel cell electric vehicle (FCEV) is a vehicle that uses electrical energy from a fuel cell.",
         rdfs:label "fuel cell electric vehicle"@de
     
@@ -2960,7 +2962,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A traction battery is a battery used in vehicles for propulsion.",
         rdfs:label "traction battery"@de
     
@@ -2971,7 +2974,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "An electric motor is an energy converting device that converts electrical energy into kinetic energy.",
         rdfs:label "electric motor"@de
     
@@ -2983,7 +2987,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A traction motor is an electric motor used for propulsion.",
         rdfs:label "traction motor"@de
     
@@ -3007,7 +3012,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
         rdfs:label "plug-in hybrid electric vehicle"@de
     
@@ -3023,8 +3029,9 @@ Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
 Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied vehicle is an electric vehicle that uses electrical energy via a conductor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         rdfs:label "grid supplied electric vehicle"@de
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3015,7 +3015,7 @@ Class: OEO_00010024
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A battery electric vehicle (BEV) is a vehicle that stores energy in an on-board battery.",
-        rdfs:label "battery electric vehicle"@de
+        rdfs:label "battery electric vehicle"@en
     
     SubClassOf: 
         OEO_00000146,
@@ -3408,4 +3408,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3042,8 +3042,8 @@ Class: OEO_00010026
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A traction battery is a battery used in vehicles for propulsion.",
-        rdfs:label "traction battery"@de
+        dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
+        rdfs:label "traction battery"@en
     
     SubClassOf: 
         OEO_00000068
@@ -3068,7 +3068,7 @@ Class: OEO_00010028
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A traction motor is an electric motor used for propulsion.",
-        rdfs:label "traction motor"@de
+        rdfs:label "traction motor"@en
     
     SubClassOf: 
         OEO_00010027
@@ -3093,7 +3093,7 @@ Class: OEO_00010030
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
-        rdfs:label "plug-in hybrid electric vehicle"@de
+        rdfs:label "plug-in hybrid electric vehicle"@en
     
     SubClassOf: 
         OEO_00010023,
@@ -3110,7 +3110,7 @@ Class: OEO_00010031
         <http://purl.obolibrary.org/obo/IAO_0000233> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "grid supplied electric vehicle"@de
+        rdfs:label "grid supplied electric vehicle"@en
     
     SubClassOf: 
         OEO_00000146

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2973,6 +2973,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         OEO_00000011
     
     
+Class: OEO_00010023
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425",
+        rdfs:label "vehicle"@de
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
 Class: OEO_00020003
 
     Annotations: 


### PR DESCRIPTION
closes #425 

Adds the following vehicles classes:
* battery electric vehicle
* fuel cell electric vehicle
* grid supplied electric vehicle
* plug-in hybrid electric vehicle

Adds the following energy converting devices and energy storage objects:
* traction battery
* motor
* electric motor
* traction motor 
* internal combustion engine