### PR TITLE
add primary energy carrier classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Here is a template for new release sections
 - oeo-shared module (#450)
 - object property definitions (#478)
 - energy and supply system (#493)
-- primary energy production (#498)
+- primary energy production and subclasses (#498)
 
 ### Changed
 - move object properties to oeo-shared (#472)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - oeo-shared module (#450)
 - object property definitions (#478)
 - energy and supply system (#493)
+- primary energy production (#498)
 
 ### Changed
 - move object properties to oeo-shared (#472)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3355,6 +3355,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
         <http://purl.obolibrary.org/obo/RO_0002577>
     
     
+Class: OEO_00030026
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a process that prepares raw material for its use as primary energy carrier.",
+        rdfs:label "primary energy production"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00030027
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production process that recovers non-renewable energy carriers from its natural site.",
+        rdfs:label "primary energy carrier mining"
+    
+    SubClassOf: 
+        OEO_00030026
+    
+    
+Class: OEO_00030028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production process that collects solid biomass from its natural site.",
+        rdfs:label "primary energy carrier harvest"
+    
+    SubClassOf: 
+        OEO_00030026
+    
+    
 Class: OEO_00230000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3359,6 +3359,8 @@ Class: OEO_00030026
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a process that prepares raw material for its use as primary energy carrier.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
         rdfs:label "primary energy production"
     
     SubClassOf: 
@@ -3369,6 +3371,8 @@ Class: OEO_00030027
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production process that recovers non-renewable energy carriers from its natural site.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
         rdfs:label "primary energy carrier mining"
     
     SubClassOf: 
@@ -3379,6 +3383,8 @@ Class: OEO_00030028
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production process that collects solid biomass from its natural site.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
         rdfs:label "primary energy carrier harvest"
     
     SubClassOf: 


### PR DESCRIPTION
closes #77

adds classes:
* `primary energy production` as subclass of `process`: *Primary energy production is a process that prepares raw material for its use as primary energy carrier.*
* `primary energy carrier mining` as subclass of `primary energy production`:  *primary energy carrier mining is a primary energy production process that recovers non-renewable energy carriers from its natural site.* 
* `primary energy carrier harvest` as subclass of `primary energy production`:  *primary energy carrier harvest is a primary energy production process that collects solid biomass from its natural site.* 
