### PR TITLE
replace underscores with spaces in labels of object properties

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -96,7 +96,7 @@ ObjectProperty: OEO_00000511
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimization and its objective function or objective variable."@en,
-        rdfs:label "has_objective"
+        rdfs:label "has objective"
     
     Domain: 
         OEO_00000313
@@ -106,7 +106,7 @@ ObjectProperty: OEO_00000512
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimization and its objective function."@en,
-        rdfs:label "has_objectivefunction"
+        rdfs:label "has objective function"
     
     SubPropertyOf: 
         OEO_00000511
@@ -116,7 +116,7 @@ ObjectProperty: OEO_00000513
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimization and its objective variable."@en,
-        rdfs:label "has_objectivevariable"
+        rdfs:label "has objective variable"
     
     SubPropertyOf: 
         OEO_00000511
@@ -126,14 +126,14 @@ ObjectProperty: OEO_00000514
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model/model calculation and the resolution it uses."@en,
-        rdfs:label "has_resolution"
+        rdfs:label "has resolution"
     
     
 ObjectProperty: OEO_00000515
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation thst holds between a publication/model/model calculation and the spacial resolution it uses."@en,
-        rdfs:label "has_spatial_resolution"
+        rdfs:label "has spatial resolution"
     
     SubPropertyOf: 
         OEO_00000514
@@ -143,7 +143,7 @@ ObjectProperty: OEO_00000516
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation thst holds between a publication/model/model calculation and the time resolution it uses."@en,
-        rdfs:label "has_temporal_resolution"
+        rdfs:label "has temporal resolution"
     
     SubPropertyOf: 
         OEO_00000514

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -112,7 +112,7 @@ ObjectProperty: OEO_00000521
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology.",
-        rdfs:label "applies_technology"
+        rdfs:label "applies technology"
     
     Domain: 
         OEO_00000061
@@ -131,7 +131,7 @@ ObjectProperty: OEO_00000523
 
     Annotations: 
         rdfs:comment "A relation that holds between a publication/model calculation/model and the energycarrier it covers.",
-        rdfs:label "covers_energycarrier"
+        rdfs:label "covers energycarrier"
     
     SubPropertyOf: 
         OEO_00000522
@@ -146,7 +146,7 @@ ObjectProperty: OEO_00000524
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has_globalwarmingpotential"
+        rdfs:label "has global warming potential"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -159,7 +159,7 @@ ObjectProperty: OEO_00000525
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object.",
-        rdfs:label "is_applied_to_object"
+        rdfs:label "is applied to object"
     
     Domain: 
         OEO_00000407
@@ -177,7 +177,7 @@ ObjectProperty: OEO_00000526
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "is_connected_to"
+        rdfs:label "is connected to"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -192,7 +192,7 @@ ObjectProperty: OEO_00000527
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has_sink"
+        rdfs:label "has sink"
     
     SubPropertyOf: 
         OEO_00000526
@@ -207,7 +207,7 @@ ObjectProperty: OEO_00000528
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has_source"
+        rdfs:label "has source"
     
     SubPropertyOf: 
         OEO_00000526
@@ -219,8 +219,8 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
 ObjectProperty: OEO_00000529
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has_normal_state_of_matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        rdfs:label "has_normal_state_of_matter"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        rdfs:label "has normal state of matter"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -236,7 +236,7 @@ ObjectProperty: OEO_00000530
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        rdfs:label "has_origin"
+        rdfs:label "has origin"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -251,7 +251,7 @@ ObjectProperty: OEO_00000530
 ObjectProperty: OEO_00000531
 
     Annotations: 
-        rdfs:label "has_state_of_matter"
+        rdfs:label "has state of matter"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -267,7 +267,7 @@ ObjectProperty: OEO_00000532
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en,
-        rdfs:label "has_physical_input"
+        rdfs:label "has physical input"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002233>
@@ -285,7 +285,7 @@ ObjectProperty: OEO_00000533
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en,
-        rdfs:label "has_physical_output"
+        rdfs:label "has physical output"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -37,6 +37,15 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002086>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002093>
+
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002086>
+    
+    
 ObjectProperty: OEO_00000500
 
     Annotations: 
@@ -46,7 +55,7 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "has_process_attribute"
+        rdfs:label "has process attribute"
     
     InverseOf: 
         OEO_00000502
@@ -57,7 +66,7 @@ ObjectProperty: OEO_00000501
     Annotations: 
         rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472",
-        rdfs:label "is_used_by"
+        rdfs:label "is used by"
     
     InverseOf: 
         OEO_00000503
@@ -72,7 +81,7 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process_attribute_of"
+        rdfs:label "process attribute of"
     
     InverseOf: 
         OEO_00000500

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -37,15 +37,6 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
-ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002086>
-
-    
-ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002093>
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002086>
-    
-    
 ObjectProperty: OEO_00000500
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -76,20 +76,29 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
+
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0004007>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0004007>
+
+    
 ObjectProperty: OEO_00000504
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurant (B) in which (A) determines the semantic of (B)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/",
-        rdfs:label "is_defined_by"
+        rdfs:label "is defined by"
     
     
 ObjectProperty: OEO_00000505
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the sector it models."@en,
-        rdfs:label "covers_sector"
+        rdfs:label "covers sector"
     
     SubPropertyOf: 
         OEO_00000522
@@ -102,7 +111,7 @@ ObjectProperty: OEO_00000506
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and its author."@en,
-        rdfs:label "has_author"
+        rdfs:label "has author"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
@@ -115,7 +124,7 @@ ObjectProperty: OEO_00000507
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and the client that requested its creation."@en,
-        rdfs:label "has_client"
+        rdfs:label "has client"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
@@ -128,7 +137,7 @@ ObjectProperty: OEO_00000508
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and the person to contact with issues about it."@en,
-        rdfs:label "has_contact"
+        rdfs:label "has contact"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
@@ -138,7 +147,7 @@ ObjectProperty: OEO_00000509
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and its source of funding."@en,
-        rdfs:label "has_funding_source"
+        rdfs:label "has funding source"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
@@ -151,7 +160,7 @@ ObjectProperty: OEO_00000510
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication and the institution in which it was created."@en,
-        rdfs:label "has_institution"
+        rdfs:label "has institution"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -76,15 +76,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
-ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
-
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0004007>
-    
-    
-ObjectProperty: <http://purl.obolibrary.org/obo/RO_0004007>
-
-    
 ObjectProperty: OEO_00000504
 
     Annotations: 


### PR DESCRIPTION
Some of the object properties still used labels with underscores which I replaced with spaces.

closes #506 