### PR TITLE
Move unit class, and add has unit property

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -99,6 +99,17 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
+        rdfs:comment "This relation has been imported from UO.",
+        rdfs:label "is unit of"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 ObjectProperty: OEO_00000501
 
     
@@ -291,6 +302,19 @@ ObjectProperty: OEO_00000533
         <http://purl.obolibrary.org/obo/RO_0002234>
     
     
+ObjectProperty: OEO_00040010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 ObjectProperty: OEO_00140002
 
     Annotations: 
@@ -366,7 +390,7 @@ Class: <http://purl.obolibrary.org/obo/RO_0002577>
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
+        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: <http://purl.obolibrary.org/obo/UO_0000001>


### PR DESCRIPTION
Change the parent of the (imported from UO) unit class to generically dependent continuant (was immaterial entity). 

Add _has unit_ property that can be used to connect a quantity value to a unit. 

Closes #508

