### PR TITLE
Remove own 'definition' annotation property and instead use IAO's 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
 - sector individuals (#523)
 
 ### Changed
+- harmonise 'definition' annotation property (#529)
 - move object properties to oeo-shared (#472)
 - definition of sector and sector subclasses (#477, #484)
 - definition of sector (#477)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -50,12 +50,6 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:license
 
     
-AnnotationProperty: definition
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: rdfs:comment
 
     
@@ -580,7 +574,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287",
 Class: OEO_00000275
 
     Annotations: 
-        definition "A model calculation is a process of solving mathematical equations of a model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504"@en,
         rdfs:label "model calculation"
@@ -913,7 +907,7 @@ Class: OEO_00000435
 Class: OEO_00020011
 
     Annotations: 
-        definition "A study is a project with the goal to investigate something."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497"@en,
         rdfs:label "study"@en
@@ -925,7 +919,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497"@en,
 Class: OEO_00020012
 
     Annotations: 
-        definition "A study report is a report that is the output from some study."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497"@en,
         rdfs:label "study report"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -51,12 +51,6 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:license
 
     
-AnnotationProperty: definition
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: rdfs:comment
 
     
@@ -873,7 +867,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
 Class: OEO_00000044
 
     Annotations: 
-        definition "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
         rdfs:label "wind energy converting unit"
     
@@ -1901,7 +1895,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000255
 
     Annotations: 
-        definition "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "grid component link"
@@ -2061,7 +2055,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: OEO_00000296
 
     Annotations: 
-        definition "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "grid node"
@@ -3174,7 +3168,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00020001
 
     Annotations: 
-        definition "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445"@en,
         rdfs:label "ethanol"@en
@@ -3187,7 +3181,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445"@en,
 Class: OEO_00020003
 
     Annotations: 
-        definition "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a process in which one ore more certain types of energy as input result in certain types of energy as output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
@@ -3201,7 +3195,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371",
 Class: OEO_00020004
 
     Annotations: 
-        definition "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "gas grid"@en
@@ -3214,7 +3208,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020005
 
     Annotations: 
-        definition "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
         rdfs:label "heating grid"@en
@@ -3227,7 +3221,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020006
 
     Annotations: 
-        definition "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an artificial object that is a discrete part of a supply grid serving a specific purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         rdfs:label "grid component"@en
@@ -3240,7 +3234,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00020007
 
     Annotations: 
-        definition "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -3257,7 +3251,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020008
 
     Annotations: 
-        definition "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -3274,7 +3268,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020009
 
     Annotations: 
-        definition "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "switchyard"@en
@@ -3376,7 +3370,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
 Class: OEO_00030024
 
     Annotations: 
-        definition "An energy system is a system of spatially extended linked energy sources and sinks.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a system of spatially extended linked energy sources and sinks.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
         rdfs:label "energy system"
@@ -3388,7 +3382,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
 Class: OEO_00030025
 
     Annotations: 
-        definition "A supply system is a system that connects producers and consumers.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
         rdfs:label "supply system"
@@ -3462,7 +3456,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
 Class: OEO_00230000
 
     Annotations: 
-        definition "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
         rdfs:label "storage capacity"
@@ -3474,7 +3468,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
 Class: OEO_00230001
 
     Annotations: 
-        definition "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is the quantity value stating the maximum power an energy converting device can convert.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
         rdfs:label "power rating"@en
@@ -3486,7 +3480,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
 Class: OEO_00230002
 
     Annotations: 
-        definition "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is the quantity value stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
         rdfs:label "declared net capacity"@en
@@ -3498,7 +3492,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
 Class: OEO_00230003
 
     Annotations: 
-        definition "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the quantity value stating the maximum power a power generating unit or a power plant can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
         rdfs:label "nameplate capacity"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -55,12 +55,6 @@ AnnotationProperty: dc:identifier
 AnnotationProperty: dc:license
 
     
-AnnotationProperty: definition
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: rdfs:comment
 
     
@@ -571,7 +565,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030022
 
     Annotations: 
-        definition "An organization is an immaterial entity that has the organization role and there exists some sort of legal framework that recognises the entity and its continued existence.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is an immaterial entity that has the organization role and there exists some sort of legal framework that recognises the entity and its continued existence.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
         rdfs:label "organization"
@@ -584,7 +578,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
 Class: OEO_00230013
 
     Annotations: 
-        definition "A population is an aggregate of people in a spatial region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
@@ -597,7 +591,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230014
 
     Annotations: 
-        definition "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -614,7 +608,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230015
 
     Annotations: 
-        definition "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
 https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -631,7 +625,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230016
 
     Annotations: 
-        definition "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -645,7 +639,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230017
 
     Annotations: 
-        definition "The working age population is the population of people aged 15 to 65."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
 https://github.com/OpenEnergyPlatform/ontology/issues/479
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -73,12 +73,6 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:license
 
     
-AnnotationProperty: definition
-
-    SubPropertyOf: 
-        rdfs:comment
-    
-    
 AnnotationProperty: rdfs:comment
 
     


### PR DESCRIPTION
Replace use of a custom OEO 'definition' annotation property with use of IAO's 'definition' annotation property in all edits modules. 

Closes #529 