### PR TITLE
update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Here is a template for new release sections
 - model calculation (#504)
 - electrical energy definition (#524)
 - assumption (#525)
+- update original release date and teams in `README` (#535)
 
 ### Removed
 - unused object properties (#452)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ We combine domain knowledge with knowledge about how an ontology should be desig
 If you have a specific question about ontology design, energy system modelling or economy (in context of this ontology), you can [tag](https://github.com/OmahaGirlsWhoCode/OmahaGirlsWhoCode/wiki/How-to-tag-someone-in-a-pull-request) one of these teams (or persons) to notify its members that you need their feedback or help.
 
 The OEO is organised in an general team: 
-- [@oeo-dev](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev/)
+- [@oeo-dev](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev)
 
 and several [subteams](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev/teams):
-- [@oeo-general-expert-formal-ontology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-expert-formal-ontology)
-- [@oeo-domain-expert-energy-modelling ](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-energy-modelling)
+- [@oeo-concept-owner](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-concept-owner)
+- [@oeo-domain-expert-economy](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-economy)
+- [@oeo-domain-expert-energy-modelling](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-energy-modelling)
 - [@oeo-domain-expert-linked-open-data](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-linked-open-data)
+- [@oeo-domain-expert-meteorology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-meteorology)
+- [@oeo-general-expert-formal-ontology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-expert-formal-ontology)
+- [@oeo-general-steering-committee](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-steering-committee)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Developing a common ontology for energy system analysis and scenarios.
 
 ## Introduction
 
-The Open Energy Ontology (OEO) is a domain ontology of the energy-system modelling context. It is developed as part of the [Open Energy Family](https://github.com/OpenEnergyPlatform). The OEO is published on github as open source software. The language used is the Manchester OWL Syntax, which was chosen because it is user-friendly for editing and viewing diffs of edited files. The OEO is still under development and not released yet. A steering committee was created to accompany the development, increase awareness of the ontology and include it in current projects.
+The Open Energy Ontology (OEO) is a domain ontology of the energy-system modelling context. It is developed as part of the [Open Energy Family](https://github.com/OpenEnergyPlatform). The OEO is published on github as open source software. The language used is the Manchester OWL Syntax, which was chosen because it is user-friendly for editing and viewing diffs of edited files. The first version of the Open Energy Ontology (OEO) has been released on June 11th 2020. A steering committee was created to accompany the development, increase awareness of the ontology and include it in current projects.
 
 ## Scope of this ontology
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Developing a common ontology for energy system analysis and scenarios.
 
 ## Introduction
 
-The Open Energy Ontology (OEO) is a domain ontology of the energy-system modelling context. It is developed as part of the [Open Energy Family](https://github.com/OpenEnergyPlatform). The OEO is published on github as open source software. The language used is the Manchester OWL Syntax, which was chosen because it is user-friendly for editing and viewing diffs of edited files. The first version of the Open Energy Ontology (OEO) has been released on June 11th 2020. A steering committee was created to accompany the development, increase awareness of the ontology and include it in current projects.
+The Open Energy Ontology (OEO) is a domain ontology of the energy-system modelling context. It is developed as part of the [Open Energy Family](https://github.com/OpenEnergyPlatform). The OEO is published on github as open source software. The language used is the Manchester OWL Syntax, which was chosen because it is user-friendly for editing and viewing diffs of edited files. The OEO is constantly being extended. The first version of the Open Energy Ontology (OEO) has been released on June 11th 2020. A steering committee was created to accompany the development, increase awareness of the ontology and include it in current projects.
 
 ## Scope of this ontology
 


### PR DESCRIPTION
- replace "The OEO is still under development and not released yet." by "The first version of the Open Energy Ontology (OEO) has been released on June 11th 2020." (closes #532 )
- update list of teams to include all actual teams (closes #511 )