### PR TITLE
add time step, time series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - annotation property unique individual identifier (#523)
 - sector individuals (#523)
 - output and input data (#536)
+- time step, time series, etc (#538)
 
 ### Changed
 - harmonise 'definition' annotation property (#529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 - has contributor (#530)
 - sponsor (#557)
 - economic value and gross domestic product (#559)
+- time step, time series, etc (#538)
 
 ### Changed
 - move subclasses of has participant (#530)
@@ -50,7 +51,6 @@ Here is a template for new release sections
 - annotation property unique individual identifier (#523)
 - sector individuals (#523)
 - output and input data (#536)
-- time step, time series, etc (#538)
 
 ### Changed
 - harmonise 'definition' annotation property (#529)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1051,6 +1051,8 @@ Class: OEO_00030031
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "start time"
     
     SubClassOf: 
@@ -1061,6 +1063,8 @@ Class: OEO_00030032
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "end time"
     
     SubClassOf: 
@@ -1071,6 +1075,8 @@ Class: OEO_00030033
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "a time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "time step"
     
     SubClassOf: 
@@ -1084,6 +1090,8 @@ Class: OEO_00030034
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "time series"
     
     SubClassOf: 
@@ -1099,6 +1107,8 @@ Class: OEO_00030035
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "duration is a quantity value indicating the time span of a one-dimensional temporal region, measured in a time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "duration"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1065,7 +1065,7 @@ Class: OEO_00030032
         <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "end time"
+        rdfs:label "ending time"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000148>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1071,7 +1071,7 @@ Class: OEO_00030032
 Class: OEO_00030033
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "a time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "time step"
@@ -1086,7 +1086,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030034
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "time series"
@@ -1103,7 +1103,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030035
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "duration is a quantity value indicating the time span of a one-dimensional temporal region, measured in a time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A duration is a quantity value indicating the time span of a one-dimensional temporal region, measured in a time unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "duration"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1090,7 +1090,9 @@ Class: OEO_00030034
         <http://purl.obolibrary.org/obo/IAO_0000100>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
     
     
 Class: OEO_00030035

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1048,10 +1048,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500",
     
     
 Class: OEO_00030031
-   
+
     
 Class: OEO_00030032
-    
+
     
 Class: OEO_00030033
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -244,6 +244,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000148>
+
+    
 Class: <http://purl.obolibrary.org/obo/IAO_0000010>
 
     
@@ -1015,6 +1018,46 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: OEO_00030031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        rdfs:label "start time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00030032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        rdfs:label "end time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00030033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "a time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
+        rdfs:label "time step"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>
+    
+    
+Class: OEO_00030034
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        rdfs:label "time series"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 Individual: OEO_00000049

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -71,6 +71,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
@@ -190,6 +193,9 @@ ObjectProperty: OEO_00000519
 ObjectProperty: OEO_00000522
 
     
+ObjectProperty: OEO_00040010
+
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -267,6 +273,15 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000300>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000003>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000046>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    
     
 Class: OEO_00000048
 
@@ -725,6 +740,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00000350
+
+    
 Class: OEO_00000353
 
     Annotations: 
@@ -1056,7 +1074,10 @@ Class: OEO_00030033
         rdfs:label "time step"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>
+        <http://purl.obolibrary.org/obo/BFO_0000038>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035
     
     
 Class: OEO_00030034
@@ -1066,7 +1087,22 @@ Class: OEO_00030034
         rdfs:label "time series"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
+        <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035
+    
+    
+Class: OEO_00030035
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "duration is a quantity value indicating the time span of a one-dimensional temporal region, measured in a time unit.",
+        rdfs:label "duration"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000038>
     
     
 Individual: OEO_00000049

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1048,27 +1048,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500",
     
     
 Class: OEO_00030031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "start time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
+   
     
 Class: OEO_00030032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "ending time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
 Class: OEO_00030033

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11,9 +11,9 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
-<http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl>
+<http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/oeo-physical.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/oeo-shared.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-minimal-module.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production.",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14,7 +14,6 @@ Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-physical/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-physical.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-minimal-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The 'Physical' module covers all those aspects of the world that are relevant for the energy systems domain, including physical entities such as generators, power lines, technologies, hardware, portions of matter; attributes of those, such as the energy they carry or release, whether they can be a pollutant, or their origins; representational transformations into maps and measures, such as coordinates, units, quantities; and the processes that modify the physical entities, such as energy production.",
@@ -3447,16 +3446,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
     
 Class: OEO_00140001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "length value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
     
 Class: OEO_00230000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -93,7 +93,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
-    
+
     
 ObjectProperty: OEO_00000501
 
@@ -288,7 +288,7 @@ ObjectProperty: OEO_00000533
     
     
 ObjectProperty: OEO_00040010
-    
+
     
 ObjectProperty: OEO_00140002
 
@@ -360,10 +360,13 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
-    
+
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000000>
+
     
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
 
@@ -3419,7 +3422,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
     
 Class: OEO_00140001
-    
+
     
 Class: OEO_00230000
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3420,6 +3420,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/BFO_0000019>,
         OEO_00140002 some OEO_00140001
     
+    
 Class: OEO_00140001
 
     Annotations: 
@@ -3431,9 +3432,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     SubClassOf: 
         OEO_00000350,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
-
-Class: OEO_00140001
-
+    
     
 Class: OEO_00230000
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3420,7 +3420,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/BFO_0000019>,
         OEO_00140002 some OEO_00140001
     
+Class: OEO_00140001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "length value"@en
     
+    SubClassOf: 
+        OEO_00000350,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+
 Class: OEO_00140001
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -93,14 +93,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
-        rdfs:comment "This relation has been imported from UO.",
-        rdfs:label "is unit of"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 ObjectProperty: OEO_00000501
@@ -296,16 +288,6 @@ ObjectProperty: OEO_00000533
     
     
 ObjectProperty: OEO_00040010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 ObjectProperty: OEO_00140002
@@ -378,14 +360,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
-        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -135,6 +135,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000031>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000148>
+
+    
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
     Annotations: 
@@ -166,7 +169,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00000419
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
+        rdfs:label "transformation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
 Class: OEO_00030031
 
     Annotations: 
@@ -182,24 +198,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030032
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "ending time"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>    
-    
-Class: OEO_00000419
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
-        rdfs:label "transformation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
 Class: OEO_00140003

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -13,6 +13,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-annotation-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-minimal-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/ro-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/uo-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -180,19 +180,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: OEO_00140001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "length value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
-    
-    
 Class: OEO_00140003
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -151,9 +151,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000001>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
     
 Class: OEO_00000350
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -14,6 +14,7 @@ Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/iao-annotation-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/ro-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.0.0/imports/uo-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
@@ -35,6 +36,9 @@ AnnotationProperty: rdfs:label
 
     
 Datatype: rdf:PlainLiteral
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
 ObjectProperty: OEO_00000500
@@ -103,6 +107,39 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete u
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000031>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000000>
+
+Class: OEO_00140001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "length value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+    
+Class: OEO_00000350
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is a generically dependent continuant defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496",
+        rdfs:label "quantity value"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 Class: OEO_00000419
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -166,7 +166,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000000>
+
+Class: OEO_00030031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "start time"
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00030032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "end time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "ending time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>    
     
 Class: OEO_00000419
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -41,6 +41,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: dc:identifier
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -156,10 +159,10 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000031>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000148>
+Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000141>
+Class: <http://purl.obolibrary.org/obo/BFO_0000148>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
@@ -182,9 +185,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
 
     
-Class: <http://purl.obolibrary.org/obo/UO_0000046>
-
-
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
 
     SubClassOf: 
@@ -226,7 +226,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
 Class: OEO_00030031
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "start time"
@@ -238,7 +238,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030032
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "ending time"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -41,6 +41,17 @@ Datatype: rdf:PlainLiteral
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
+        rdfs:comment "This relation has been imported from UO.",
+        rdfs:label "is unit of"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 ObjectProperty: OEO_00000500
 
     Annotations: 
@@ -105,6 +116,19 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete u
         rdfs:label "covers"
     
     
+ObjectProperty: OEO_00040010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
     
@@ -113,17 +137,23 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000031>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
-Class: OEO_00140001
-
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "length value"@en
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
+        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
     
     SubClassOf: 
-        OEO_00000350,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000001>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000046>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
     
 Class: OEO_00000350
 
@@ -151,6 +181,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "length value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
     
 Class: OEO_00140003


### PR DESCRIPTION
part of #267 

- moves quantity value class over to oeo-shared bc it's needed in oeo-model too and was in oeo-physical
- moved lenght value with it bc I think it's also needed in more than oeo-physical

add classes with definitions:
-  start time and end time: start time is a zero-dim temporal region that indicates the beginning of a 1-dim temporal region. End time indicating the end, accordingly.
-    duration is a quantity value that can be related to both time step and time series. duration is a quantity value indicating the time span of a 1-dim temporal region, measured in a time unit. 
-    time step: a time step is a 1-dim temporal region that has a start time and an endtime and thus a finite duration. 
-    time series: time series is a data set that references a set of time steps or zero-dim temporal regions. 

add relations:

- duration: `is about some 1-dim temporal region` and `has unit some time unit`
- time step: `has part some start time` and `has part some end time` and `has part some duration`
- time series: `has part some start time` and `has part some end time` and `has part some duration`
- time series: `is about some (time step or zero-dim temporal region)`
