### PR TITLE
automate issue management

### DIFF
--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -2,7 +2,7 @@
 name: "[A] New ontology term"
 about: For including new terms into the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: "[A] new term", "To do"
+labels: ["[A] new term" "To do"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -2,7 +2,7 @@
 name: "[A] New ontology term"
 about: For including new terms into the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: "[A] new term"
+labels: ["[A] new term", "To do"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -2,7 +2,7 @@
 name: "[A] New ontology term"
 about: For including new terms into the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: ["[A] new term" "To do"]
+labels: "[A] new term, To do"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -2,7 +2,7 @@
 name: "[A] New ontology term"
 about: For including new terms into the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: ["[A] new term", "To do"]
+labels: "[A] new term"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -2,7 +2,7 @@
 name: "[A] New ontology term"
 about: For including new terms into the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: "[A] new term"
+labels: "[A] new term", "To do"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
+++ b/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
@@ -2,7 +2,7 @@
 name: "[B] Restructure ontology"
 about: For restructuring existing parts of the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: "[B] restructure"
+labels: ["[B] restructure", "To do"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
+++ b/.github/ISSUE_TEMPLATE/-b--restructure-ontology.md
@@ -2,7 +2,7 @@
 name: "[B] Restructure ontology"
 about: For restructuring existing parts of the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: ["[B] restructure", "To do"]
+labels: "[B] restructure, To do"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -2,7 +2,7 @@
 name: "[C] Ontology definition update"
 about: For restructuring existing partsof the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: "[C] definition update"
+labels: ["[C] definition update", "To do"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -2,7 +2,7 @@
 name: "[C] Ontology definition update"
 about: For restructuring existing partsof the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: ["[C] definition update", "To do"]
+labels: "[C] definition update, To do"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/-d--normal-issue.md
+++ b/.github/ISSUE_TEMPLATE/-d--normal-issue.md
@@ -2,7 +2,7 @@
 name: Normal issue
 about: For issues not directly related to the ontology oeo.omn file
 title: Your title should make sense if said after "The issue is <your issue title>"
-labels: ''
+labels: "To do"
 assignees: ''
 
 ---

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 1
+daysUntilStale: 14
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 100000
 # Issues with these labels will never be considered stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 1
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 100000
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - To do
+  - oeo dev meeting
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: false
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/workflows/InDiscussionProject.yml
+++ b/.github/workflows/InDiscussionProject.yml
@@ -10,7 +10,7 @@ jobs:
       id: count
       uses: akleinau/githubJSActions/DiscussedToColumn@master
       with:
-        repo: https://api.github.com/repos/akleinau/ontology
+        repo: https://api.github.com/repos/OpenEnergyPlatform/ontology
     - name: printit
       run: echo ${{ steps.count.outputs.continue }} 
     - name: addToColumn

--- a/.github/workflows/InDiscussionProject.yml
+++ b/.github/workflows/InDiscussionProject.yml
@@ -10,7 +10,7 @@ jobs:
       id: count
       uses: akleinau/githubJSActions/DiscussedToColumn@master
       with:
-        repo: https://api.github.com/repos/OpenEnergyPlatform/ontology
+        repo: https://api.github.com/repos/akleinau/ontology
     - name: printit
       run: echo ${{ steps.count.outputs.continue }} 
     - name: addToColumn

--- a/.github/workflows/RemoveToDo.yml
+++ b/.github/workflows/RemoveToDo.yml
@@ -1,0 +1,14 @@
+name: RemoveToDoLabel
+
+on:
+  project_card:
+    types: [moved]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: remove to do label
+        uses: andymckay/labeler@master
+        with:
+          remove-labels: "To do"


### PR DESCRIPTION
this automates some things to make issue and project management as easy as possible.

## Automate "Issue"-Project 
- issues now get automatically moved to the "In discussion" tab when there are three or more comments, indicating it gets discussed. This will especially help new contributors to find active issues.
- not started, "to do"-issues now get the label "to do" (which is helpful and a support step for the "stale issues" solution). It get's removed as soon as they get discussed

## Mark stale issues
- issues that don't have the "to do" label anymore and therefore already got discussed get labeled "stale" when they don't have activity for more than 14 days. The label is removed when activity occurs again. This step gets completed after the pull request by a bot that I will activate
- this prevents issues that got discussed but for some reason stopped (got stale) to get forgotten and not further worked on