### PR TITLE
restructure has participant subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ Here is a template for new release sections
 
 ### Added
 - sensitivity analysis (#550)
+- has contributor (#530)
 
 ### Changed
--
+- move subclasses of has participant (#530)
+
 ### Removed
 -
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -131,7 +131,7 @@ ObjectProperty: OEO_00000508
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and the person to contact with issues about it."@en,
-        rdfs:label "has contact"
+        rdfs:label "has contact person"
     
     SubPropertyOf: 
         OEO_00140008

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -108,7 +108,7 @@ ObjectProperty: OEO_00000506
         rdfs:label "has author"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
+        OEO_00140008
     
     Range: 
         OEO_00000051
@@ -121,7 +121,7 @@ ObjectProperty: OEO_00000507
         rdfs:label "has client"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
+        OEO_00140008
     
     Range: 
         OEO_00000051
@@ -134,17 +134,17 @@ ObjectProperty: OEO_00000508
         rdfs:label "has contact"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
+        OEO_00140008
     
     
 ObjectProperty: OEO_00000509
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model and its source of funding."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
         rdfs:label "has funding source"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
+        owl:topObjectProperty
     
     Range: 
         OEO_00000051
@@ -157,11 +157,18 @@ ObjectProperty: OEO_00000510
         rdfs:label "has institution"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000057>
+        OEO_00140008
     
     
 ObjectProperty: OEO_00000522
 
+    
+ObjectProperty: OEO_00140008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a publication/model and a continuant, in which the continuant is somehow involved in the creation of the publication/model.",
+        rdfs:label "has contributor"@en
+    
     
 ObjectProperty: owl:topObjectProperty
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -141,6 +141,8 @@ ObjectProperty: OEO_00000509
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
         rdfs:label "has funding source"
     
     SubPropertyOf: 
@@ -167,6 +169,8 @@ ObjectProperty: OEO_00140008
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a publication/model and a continuant, in which the continuant is somehow involved in the creation of the publication/model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
         rdfs:label "has contributor"@en
     
     


### PR DESCRIPTION
- make `has funding` independent of `has participant`, adjust definition: _A relation that holds between an ~publication/model~ entity and its source of funding._
- create a new object property `has contributor`, defined as _A relation between a publication/model and a continuant, in which the continuant is somehow involved in the creation of the publication/model._
- move `has author`, `has client`, `has contact` and `has institution` from `has participant` to `has contributor`

closes #530 