### PR TITLE
add gross domestic product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Here is a template for new release sections
 ### Added
 - sensitivity analysis (#550)
 - has contributor (#530)
+- economic value and gross domestic product (#559)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -295,19 +295,7 @@ ObjectProperty: OEO_00000533
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
     
-    
-ObjectProperty: OEO_00040010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
+            
     
 ObjectProperty: OEO_00140002
 
@@ -370,35 +358,10 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000144>
-
-    
-Class: <http://purl.obolibrary.org/obo/IAO_0000030>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
-        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000001>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000046>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
 Class: OEO_00000001
@@ -2398,21 +2361,6 @@ Class: OEO_00000348
     
 Class: OEO_00000350
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 Class: OEO_00000356
@@ -3548,4 +3496,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -295,15 +295,6 @@ ObjectProperty: OEO_00000533
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
     
-            
-    
-ObjectProperty: OEO_00140002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en
     
     
 ObjectProperty: owl:topObjectProperty
@@ -3496,3 +3487,6 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+
+
+ObjectProperty: OEO_00140002

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -296,6 +296,8 @@ ObjectProperty: OEO_00000533
         <http://purl.obolibrary.org/obo/RO_0002234>
     
     
+ObjectProperty: OEO_00140002
+
     
 ObjectProperty: owl:topObjectProperty
 
@@ -349,11 +351,19 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000144>
+
     
+Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
+Class: <http://purl.obolibrary.org/obo/UO_0000000>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000001>
+
     
 Class: OEO_00000001
 
@@ -2353,7 +2363,6 @@ Class: OEO_00000348
 Class: OEO_00000350
 
     
-    
 Class: OEO_00000356
 
     Annotations: 
@@ -3488,5 +3497,3 @@ Individual: OEO_00000390
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
 
-
-ObjectProperty: OEO_00140002

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -359,9 +359,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
-Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
 
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -13,14 +13,20 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
 <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/oeo-shared.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-annotation-module.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/ro-module.owl>
-Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/uo-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-minimal-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/ro-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/uo-module.owl>
+Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The\"Shared\" module covers all entities that are relevant for all our other modules. This includes shared imports like the BFO, IAO-annotation and RO- module."
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
+
+    
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: OEO_00010037
 
     Annotations: 
@@ -32,12 +38,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
     SubPropertyOf: 
         dc:identifier
     
-    
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
-
-    
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
-
     
 AnnotationProperty: dc:description
 
@@ -118,6 +118,79 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete u
         rdfs:label "covers"
     
     
+ObjectProperty: OEO_00040010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+ObjectProperty: OEO_00140002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "has quantity value"@en
+    
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000015>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000031>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000141>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000000>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
+        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000046>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    
+Class: OEO_00000350
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
+        rdfs:label "quantity value"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
 Class: OEO_00000419
 
     Annotations: 
@@ -130,8 +203,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000015>
-
 Class: OEO_00140003
 
     Annotations: 
@@ -192,65 +263,3 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
         OEO_00140003
     
     
-Class: OEO_00000350
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
-
-
-Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
-        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-
-
-ObjectProperty: OEO_00040010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-
-    
-Class: <http://purl.obolibrary.org/obo/IAO_0000030>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-
-
-Class: <http://purl.obolibrary.org/obo/UO_0000046>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-        
-
-ObjectProperty: OEO_00140002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -15,6 +15,8 @@ Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-annotation-module.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/ro-module.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/uo-module.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/releases/v1.1.0/imports/iao-minimal-module.owl>
 
 Annotations: 
     dc:description "The Open Energy Ontology is an ontology for all aspects of the energy modelling domain. The\"Shared\" module covers all entities that are relevant for all our other modules. This includes shared imports like the BFO, IAO-annotation and RO- module."
@@ -189,5 +191,57 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
     SubClassOf: 
         OEO_00140003
     
+    
+Class: OEO_00000350
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
+        rdfs:label "quantity value"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
+
+
+Class: <http://purl.obolibrary.org/obo/UO_0000000>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
+        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+
+
+ObjectProperty: OEO_00040010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
 
     
+Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+
+
+Class: <http://purl.obolibrary.org/obo/UO_0000046>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -245,3 +245,12 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
+        
+
+ObjectProperty: OEO_00140002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "has quantity value"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -592,7 +592,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
 Class: OEO_00140012
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value that is economically relevant.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
         rdfs:label "economic value"@en
     
     SubClassOf: 
@@ -602,7 +602,7 @@ Class: OEO_00140012
 Class: OEO_00140013
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         rdfs:label "gross domestic product"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -423,6 +423,9 @@ Class: OEO_00000341
         OEO_00000051
     
     
+Class: OEO_00000350
+
+    
 Class: OEO_00000367
 
     Annotations: 
@@ -584,6 +587,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
+    
+Class: OEO_00140012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value that is economically relevant.",
+        rdfs:label "economic value"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00140013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        rdfs:label "gross domestic product"@en
+    
+    SubClassOf: 
+        OEO_00140012
     
     
 Class: OEO_00230013

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -593,6 +593,8 @@ Class: OEO_00140012
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559",
         rdfs:label "economic value"@en
     
     SubClassOf: 
@@ -603,6 +605,8 @@ Class: OEO_00140013
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559",
         rdfs:label "gross domestic product"@en
     
     SubClassOf: 


### PR DESCRIPTION
To resolve #454:
- add class `economic value`, definition: _An economic value is a quantity value that is economically relevant._
- add class `gross domestic product`, definition: _A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period._

In order to make this possible:
- move `quantity value`, `unit`, `has unit` and `has quantity value` from oeo-physical to oeo-shared 
- import uo-module and iao-minimal-module in oeo-shared instead of oeo-physical
- move the subclass-relationships of `information content entity` and `prefix` from oeo-physical to oeo-shared

For `quantity value` and `has quantity value` I had to duplicate the class IRIs, so that they appear in oeo-shared and oeo-physical. I am not sure why this is necessary or if it should be this way, but as soon as I remove the IRIs from oeo-physical, everything stops working.