### PR TITLE
add gross value added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Here is a template for new release sections
 - economic value and gross domestic product (#559)
 - time step, time series, etc (#538)
 - has member and member of (#562)
+- gross value added (#563)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -658,6 +658,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559",
         OEO_00140012
     
     
+Class: OEO_00140023
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to GDP. It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
+        rdfs:label "gross value added"@en
+    
+    SubClassOf: 
+        OEO_00140012
+    
+    
 Class: OEO_00230013
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -662,6 +662,8 @@ Class: OEO_00140023
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to GDP. It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563",
         rdfs:label "gross value added"@en
     
     SubClassOf: 


### PR DESCRIPTION
Add `gross value added` to the ontology.
Definition: _Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to GDP. It is calculated as the monetary value of products and services produced, less the value of intermediate consumption._
closes #455 