### PR TITLE
remove software maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Here is a template for new release sections
 - licence (#561)
 
 ### Removed
-- software maintenance (#558)
+- software maintenance (#566)
 
 ## [1.1.0] - 2020-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Here is a template for new release sections
 - licence (#561)
 
 ### Removed
--
+- software maintenance (#558)
 
 ## [1.1.0] - 2020-09-01
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -837,15 +837,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: OEO_00000383
-
-    Annotations: 
-        rdfs:label "software maintenance"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
 Class: OEO_00000392
 
     Annotations: 


### PR DESCRIPTION
delete the class `software maintenance` because it does not appear in the factsheets and doesn't have a definition or usage.
closes #558 