### PR TITLE
add chemical reaction and subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Here is a template for new release sections
 - has member and member of (#562)
 - gross value added (#563)
 - validation and subclasses (#565)
+- chemical reaction and subclasses (#568)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3404,6 +3404,8 @@ Class: OEO_00140033
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "chemical reaction"@en
     
     SubClassOf: 
@@ -3415,6 +3417,8 @@ Class: OEO_00140034
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "redox reaction"@en
     
     SubClassOf: 
@@ -3425,6 +3429,8 @@ Class: OEO_00140035
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "oxidation"@en
     
     SubClassOf: 
@@ -3435,6 +3441,8 @@ Class: OEO_00140036
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "reduction"@en
     
     SubClassOf: 
@@ -3445,6 +3453,8 @@ Class: OEO_00140037
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "electrochemical reaction"@en
     
     SubClassOf: 
@@ -3455,6 +3465,8 @@ Class: OEO_00140038
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         rdfs:label "combustion"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -289,7 +289,7 @@ ObjectProperty: OEO_00000533
     
 ObjectProperty: OEO_00040010
 
-
+    
 ObjectProperty: OEO_00140002
 
     
@@ -351,7 +351,7 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
-    
+
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
@@ -3398,6 +3398,67 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     SubClassOf: 
         OEO_00000350,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+    
+    
+Class: OEO_00140033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        rdfs:label "chemical reaction"@en
+    
+    SubClassOf: 
+        OEO_00000419
+    
+    
+Class: OEO_00140034
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
+        rdfs:label "redox reaction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140035
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        rdfs:label "oxidation"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140036
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        rdfs:label "reduction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
+        rdfs:label "electrochemical reaction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140038
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
+        rdfs:label "combustion"@en
+    
+    SubClassOf: 
+        OEO_00140034
     
     
 Class: OEO_00230000


### PR DESCRIPTION
I implemented the following class structure:

* `chemical reaction`: _A `chemical reaction` is a transformation that involves the interconversion of chemical species._
  
   * `redox reaction`: _A `redox reaction` is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant._ (alternative term: `oxidation`)     
     * `combustion`: _`Combustion` is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source._
   * `oxidation`: _`Oxidation` is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction._
   * `reduction`: _`Reduction` is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction._
   * `electrochemical reaction`: _An `electrochemical reaction` is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte._

closes #449 