### PR TITLE
add demand and consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Here is a template for new release sections
 - gross value added (#563)
 - validation and subclasses (#565)
 - chemical reaction and subclasses (#568)
+- demand (#569)
+- consumption (#569)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -677,6 +677,8 @@ Class: OEO_00140039
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
         rdfs:label "consumption"@en
     
     SubClassOf: 
@@ -687,6 +689,8 @@ Class: OEO_00140040
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterized by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
         rdfs:label "demand"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -231,6 +231,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000017>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
     
@@ -668,6 +671,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563",
     
     SubClassOf: 
         OEO_00140012
+    
+    
+Class: OEO_00140039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        rdfs:label "consumption"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140040
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterized by a person, organisation or object needing it for a specific purpose.",
+        rdfs:label "demand"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000017>
     
     
 Class: OEO_00230013


### PR DESCRIPTION
In [oeo-dev-meeting 10](https://github.com/OpenEnergyPlatform/ontology/wiki/OEO-developer-meetings) we decided to implement the concepts of `consumption` and `demand` from #140 and leave out `load` (which could be added in a later issue if needed).

`consumption`: _The process of using something and thereby reducing its amount._
`demand`: _A realizable entity that is characterized by a person, organisation or object needing it for a specific purpose._

closes #140 