### PR TITLE
add time stamp and time stamp alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - chemical reaction and subclasses (#568)
 - demand (#569)
 - consumption (#569)
+- time stamp and time stamp alignment (#570)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1069,9 +1069,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000038>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035
+        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
     
     
 Class: OEO_00030034
@@ -1151,6 +1152,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
     
     SubClassOf: 
         OEO_00140024
+    
+    
+Class: OEO_00140043
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        rdfs:label "time stamp"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00140044
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
+        rdfs:label "time stamp alignment"@en
+    
+    SubClassOf: 
+        OEO_00000119
     
     
 Individual: OEO_00000049
@@ -1430,5 +1451,38 @@ Individual: OEO_00000451
     
     Types: 
         OEO_00000120
+    
+    
+Individual: OEO_00140045
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
+        rdfs:label "start alignment"@en
+    
+    Types: 
+        OEO_00140044
+    
+    
+Individual: OEO_00140046
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
+        rdfs:label "middle alignment"@en
+    
+    Types: 
+        OEO_00140044
+    
+    
+Individual: OEO_00140047
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
+        rdfs:label "end alignment"@en
+    
+    Types: 
+        OEO_00140044
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1065,6 +1065,8 @@ Class: OEO_00030033
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "time step"
     
     SubClassOf: 
@@ -1158,6 +1160,8 @@ Class: OEO_00140043
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "time stamp"@en
     
     SubClassOf: 
@@ -1168,6 +1172,8 @@ Class: OEO_00140044
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "time stamp alignment"@en
     
     SubClassOf: 
@@ -1458,6 +1464,8 @@ Individual: OEO_00140045
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "start alignment"@en
     
     Types: 
@@ -1469,6 +1477,8 @@ Individual: OEO_00140046
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "middle alignment"@en
     
     Types: 
@@ -1480,6 +1490,8 @@ Individual: OEO_00140047
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "end alignment"@en
     
     Types: 


### PR DESCRIPTION
closes #267 

I added the following classes and individuals: 
- class `time stamp`: _A time stamp is a zero-dimensional temporal region that is used to describe a time step._
- class `time stamp alignment`: _A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step._
- individuals `start / middle / end alignment`: _A start / middle / end alignment is a time stamp alignment indicating that the time stamp marks the start / middle / end of the time step._ (alternative terms: left / centre / right alignment)
The individuals are instances of `time stamp alignment`.

I replaced the relations for `time step`, which where `has part some start time`, `has part some end time` and `has part some duration` with `(has part some start time and has part some ending time) or (has part some time stamp and has part some time stamp alignment and has part some duration)`