### PR TITLE
add model descriptor and subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Here is a template for new release sections
 - demand (#569)
 - consumption (#569)
 - time stamp and time stamp alignment (#570)
+- content descriptor and subclasses (#577)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Here is a template for new release sections
 - demand (#569)
 - consumption (#569)
 - time stamp and time stamp alignment (#570)
-- content descriptor and subclasses (#577)
+- model descriptor and subclasses (#577)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1104,7 +1104,7 @@ Class: OEO_00030015
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@de
+        rdfs:label "energy system model"@en
     
     SubClassOf: 
         OEO_00000274
@@ -1544,7 +1544,7 @@ Individual: OEO_00000451
 Individual: OEO_00020023
 
     Annotations: 
-        rdfs:label "top down"@de
+        rdfs:label "top down"@en
     
     Types: 
         OEO_00020017
@@ -1553,7 +1553,7 @@ Individual: OEO_00020023
 Individual: OEO_00020024
 
     Annotations: 
-        rdfs:label "bottom up"@de
+        rdfs:label "bottom up"@en
     
     Types: 
         OEO_00020017
@@ -1562,7 +1562,7 @@ Individual: OEO_00020024
 Individual: OEO_00020026
 
     Annotations: 
-        rdfs:label "hybrid"@de
+        rdfs:label "hybrid"@en
     
     Types: 
         OEO_00020017
@@ -1571,7 +1571,7 @@ Individual: OEO_00020026
 Individual: OEO_00020027
 
     Annotations: 
-        rdfs:label "spreadsheet"@de
+        rdfs:label "spreadsheet"@en
     
     Types: 
         OEO_00020018
@@ -1580,7 +1580,7 @@ Individual: OEO_00020027
 Individual: OEO_00020028
 
     Annotations: 
-        rdfs:label "monte carlo"@de
+        rdfs:label "monte carlo"@en
     
     Types: 
         OEO_00020018
@@ -1589,7 +1589,7 @@ Individual: OEO_00020028
 Individual: OEO_00020029
 
     Annotations: 
-        rdfs:label "econometric"@de
+        rdfs:label "econometric"@en
     
     Types: 
         OEO_00020018

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1519,6 +1519,60 @@ Individual: OEO_00000451
         OEO_00000120
     
     
+Individual: OEO_00020023
+
+    Annotations: 
+        rdfs:label "top down"@de
+    
+    Types: 
+        OEO_00020017
+    
+    
+Individual: OEO_00020024
+
+    Annotations: 
+        rdfs:label "bottom up"@de
+    
+    Types: 
+        OEO_00020017
+    
+    
+Individual: OEO_00020026
+
+    Annotations: 
+        rdfs:label "hybrid"@de
+    
+    Types: 
+        OEO_00020017
+    
+    
+Individual: OEO_00020027
+
+    Annotations: 
+        rdfs:label "spreadsheet"@de
+    
+    Types: 
+        OEO_00020018
+    
+    
+Individual: OEO_00020028
+
+    Annotations: 
+        rdfs:label "monte carlo"@de
+    
+    Types: 
+        OEO_00020018
+    
+    
+Individual: OEO_00020029
+
+    Annotations: 
+        rdfs:label "econometric"@de
+    
+    Types: 
+        OEO_00020018
+    
+    
 Individual: OEO_00140045
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1001,13 +1001,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "methodical focus"@de
     
     SubClassOf: 
-        OEO_00020016
+        OEO_00020016,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
     
     
 Class: OEO_00020019

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1008,6 +1008,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020019
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "primary modelling purpose"@de

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -609,10 +609,15 @@ Class: OEO_00000276
 Class: OEO_00000277
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a factsheet that contains information about a model."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Since a model facsheet is a model descriptor as well as a factsheet, this class is implemented as equivalent class to OEO_00000277.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model factsheet"
+    
+    EquivalentTo: 
+        OEO_00020031
     
     SubClassOf: 
         OEO_00000162,
@@ -1024,6 +1029,21 @@ Class: OEO_00020022
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model documentation"@de
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model factsheet"@de
+    
+    EquivalentTo: 
+        OEO_00000277
     
     SubClassOf: 
         OEO_00020016

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -971,12 +971,61 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/561",
 Class: OEO_00020016
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model descriptor"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
+    
+    
+Class: OEO_00020017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "analytical appoach"@de
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "methodical focus"@de
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "primary modelling purpose"@de
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model documentation"@de
+    
+    SubClassOf: 
+        OEO_00020016
     
     
 Class: OEO_00030007

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -968,6 +968,17 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/561",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00020016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that contains information about some model."@en,
+        rdfs:label "model descriptor"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
+    
+    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -992,7 +992,7 @@ Class: OEO_00020017
         <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "analytical appoach"@de
+        rdfs:label "analytical appoach"@en
     
     SubClassOf: 
         OEO_00020016
@@ -1004,7 +1004,7 @@ Class: OEO_00020018
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "methodical focus"@de
+        rdfs:label "methodical focus"@en
     
     SubClassOf: 
         OEO_00020016,
@@ -1017,7 +1017,7 @@ Class: OEO_00020019
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "primary modelling purpose"@de
+        rdfs:label "primary modelling purpose"@en
     
     SubClassOf: 
         OEO_00020016
@@ -1029,7 +1029,7 @@ Class: OEO_00020022
         <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model documentation"@de
+        rdfs:label "model documentation"@en
     
     SubClassOf: 
         OEO_00020016
@@ -1041,7 +1041,7 @@ Class: OEO_00020031
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model factsheet"@de
+        rdfs:label "model factsheet"@en
     
     EquivalentTo: 
         OEO_00000277


### PR DESCRIPTION
closes #82 


-  `model descriptor`
    - definition: _An information content entity that contains information about some model._
    - object property restriction: `is about` some `model`
- `analytical approach` 
    - has individuals: `top down`, `bottom up`, `hybrid` and `other`.
    - definition: _A model descriptor that contains additional information about the analysis strategy of a model._
- `methodical focus`
    - has individuals: `spreadsheet`, `monte carlo`, `econometric` and others.
    - definition: _A model descriptor that specifies the primary method used in a model._
    - **also added**: relation _is about_ `model calculation`
- `primary modelling purpose`
    - definition: _A model descriptor stating the main purpose of a model._
    - changed the name from `primary purpose` to `primary modelling purpose`
- `model factsheet`
    - definition: _A model factsheet is a model descriptor that contains a brief description of all relevant model information._ 
    - **implemented as equivalent class to OEO_00000277**
- `model documentation`
    - definition: _A model documentation is a model descriptor that contains a detailed description of a model._