### PR TITLE
Add oeo-release-team in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ and several [subteams](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev/
 - [@oeo-domain-expert-meteorology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-meteorology)
 - [@oeo-general-expert-formal-ontology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-expert-formal-ontology)
 - [@oeo-general-steering-committee](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-steering-committee)
+- [@oeo-release-team](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-release-team)


### PR DESCRIPTION
The oeo-release-team is not yet mentioned in README.md. This quick pull request (without accompanying issue) includes this.