### PR TITLE
change factsheet relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Here is a template for new release sections
 ### Changed
 - move subclasses of has participant (#530)
 - licence (#561)
+- factsheet subclasses (#584)
 
 ### Removed
 - software maintenance (#566)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -518,7 +518,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440",
     
     SubClassOf: 
         OEO_00000162,
-        OEO_00000522 some OEO_00000382
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000382
     
     
 Class: OEO_00000202
@@ -621,7 +621,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
     
     SubClassOf: 
         OEO_00000162,
-        OEO_00000522 some OEO_00000274
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
     
     
 Class: OEO_00000279
@@ -770,7 +770,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440",
     
     SubClassOf: 
         OEO_00000162,
-        OEO_00000522 some OEO_00000364
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000364
     
     
 Class: OEO_00000370

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -513,7 +513,8 @@ Class: OEO_00000172
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "framework factsheet"
     
     SubClassOf: 
@@ -613,7 +614,8 @@ Class: OEO_00000277
         <http://purl.obolibrary.org/obo/IAO_0000116> "Since a model facsheet is a model descriptor as well as a factsheet, this class is implemented as equivalent class to OEO_00000277.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "model factsheet"
     
     EquivalentTo: 
@@ -765,7 +767,8 @@ Class: OEO_00000365
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "scenario factsheet"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -126,9 +126,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)",
 ObjectProperty: OEO_00000522
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the thing it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a model calculation/model and the thing it covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)",
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "covers"
     
     


### PR DESCRIPTION
closes #579

- change relation of factsheet subclasses to `is about` some `model` / `scenario` / `framework`
- change def of `covers`: delete "publication"