### PR TITLE
add industrial process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Here is a template for new release sections
 - emission factor (#581)
 - spatial regions (#585)
 
-
 ### Changed
 - move subclasses of has participant (#530)
 - licence (#561)
@@ -169,5 +168,4 @@ Here is a template for new release sections
 - unused object properties (#351)
 - remove energy production and subclasses (#77)
 - quantity subclasses (#368)
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ Here is a template for new release sections
 -
 ```
 
+
+## unreleased
+
+### Added
+- industrial process (#589)
+-
+### Changed
+-
+
+### Removed
+
+
+
+
 ## [1.2.0] - 2020-10-30
 
 ### Added
@@ -36,7 +50,6 @@ Here is a template for new release sections
 - further sector individuals (#578)
 - emission factor (#581)
 - spatial regions (#585)
-- industrial process (#589)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Here is a template for new release sections
 - demand (#569)
 - consumption (#569)
 - time stamp and time stamp alignment (#570)
+- industrial process (589)
 
 ### Changed
 - move subclasses of has participant (#530)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3387,6 +3387,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
         OEO_00030026
     
     
+Class: OEO_00050000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
+        rdfs:label "industrial process"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some 
+            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
+    
+    
 Class: OEO_00140000
 
     Annotations: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -194,6 +194,8 @@ Class: OEO_000500000000000000000000
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
         rdfs:label "industrial process"@en
     
     SubClassOf: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -190,6 +190,18 @@ Class: OEO_00020012
         OEO_00000506 some OEO_00000064
     
     
+Class: OEO_000500000000000000000000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
+        rdfs:label "industrial process"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some 
+            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
+    
+    
 Class: OEO_00140009
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -190,20 +190,4 @@ Class: OEO_00020012
         OEO_00000506 some OEO_00000064
     
     
-Class: OEO_000500000000000000000000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
-        rdfs:label "industrial process"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some 
-            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
-    
-    
 Class: OEO_00140009
-
-    


### PR DESCRIPTION
Add class `industrial process`
def.:
An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.
Relation:
'has output' some (object or 'object aggregate')

closes #534 