### PR TITLE
add energy conversion efficiency and related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Here is a template for new release sections
 
 ### Added
 - industrial process (#589)
--
+- energy conversion efficiency and energy conversion performance (#591)
+
 ### Changed
 -
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -359,6 +359,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
 
     
+Class: <http://purl.obolibrary.org/obo/UO_0010006>
+
+    
 Class: OEO_00000001
 
     Annotations: 
@@ -3321,7 +3324,7 @@ Class: OEO_00030019
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"@de
+        rdfs:label "process attribute"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000003>
@@ -3498,6 +3501,52 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
     
     SubClassOf: 
         OEO_00140034
+    
+    
+Class: OEO_00140049
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        rdfs:label "energy conversion efficiency"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003,
+        OEO_00140002 some OEO_00140050
+    
+    
+Class: OEO_00140050
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        rdfs:label "efficiency value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00140051
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
+        rdfs:label "coefficient of performance value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00140052
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
+        rdfs:label "energy conversion performance"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003,
+        OEO_00140002 some OEO_00140051
     
     
 Class: OEO_00230000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3507,6 +3507,8 @@ Class: OEO_00140049
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         rdfs:label "energy conversion efficiency"@en
     
     SubClassOf: 
@@ -3519,6 +3521,8 @@ Class: OEO_00140050
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         rdfs:label "efficiency value"@en
     
     SubClassOf: 
@@ -3530,6 +3534,8 @@ Class: OEO_00140051
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         rdfs:label "coefficient of performance value"@en
     
     SubClassOf: 
@@ -3541,6 +3547,8 @@ Class: OEO_00140052
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         rdfs:label "energy conversion performance"@en
     
     SubClassOf: 


### PR DESCRIPTION
closes #434 

I implemented the following classes and relations:

- `energy conversion efficiency`: _Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used._
  - `process attribute of some energy transformation` 
  - `has quantity value some efficiency value`
- `efficiency value`: _An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used._ 
  - `has unit some ratio`
- `coefficient of performance value`: _A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process._
  - `has unit some ratio`
- `energy conversion performance`: _Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used._
  - `process attribute of some energy transformation`
  - `has quantity value some coefficient of performance value`

