### PR TITLE
Implement sector concept of Bundes-Klimaschutzgesetz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Here is a template for new release sections
 - industrial process (#589)
 - energy conversion efficiency and energy conversion performance (#591)
 - fuel-powered electricity generation (#592)
+- further IPCC sector individuals (#595)
+- sector division and sector individuals of Bundes-Klimaschutzgesetz (#595)
 
 ### Changed
 - powerplant (#594)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1169,7 +1169,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
 Individual: OEO_00010056
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 2 of the Bundes-Klimaschutzgesetz (KSG).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector division"
@@ -1337,6 +1337,7 @@ Individual: OEO_00010065
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
 - CRF sector (IPCC 2006): fugitive emissions from fuels (CRF 1.B)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector energy industry"
@@ -1358,6 +1359,7 @@ Individual: OEO_00010066
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
 - CRF sector (IPCC 2006): industrial processes and product use (CRF 2)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector industry"
@@ -1378,6 +1380,7 @@ Individual: OEO_00010067
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector buildings"
@@ -1399,6 +1402,7 @@ Individual: OEO_00010068
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
 - CRF sector (IPCC 2006): railways (CRF 1.A.3.c)
 - CRF sector (IPCC 2006): domestic navigation (CRF 1.A.3.d)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector transport"
@@ -1420,6 +1424,7 @@ Individual: OEO_00010069
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector agriculture"
@@ -1439,6 +1444,7 @@ Individual: OEO_00010070
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector waste management and other"
@@ -1457,6 +1463,7 @@ Individual: OEO_00010071
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector land use, land-use change and forestry"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1167,11 +1167,164 @@ Individual: OEO_00010056
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 2 of the Bundes-Klimaschutzgesetz (KSG).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector division"
     
     Types: 
         OEO_00000368
+    
+    
+Individual: OEO_00010057
+
+    Annotations: 
+        OEO_00010037 "CRF 1.B",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) fugitive emissions from fuels is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): fugitive emissions from fuels"
+    
+    Types: 
+        OEO_00000367
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
+    
+    
+Individual: OEO_00010058
+
+    Annotations: 
+        OEO_00010037 "CRF 1.C",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) CO2 transport and storage is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): CO2 transport and storage"
+    
+    Types: 
+        OEO_00000367
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
+    
+    
+Individual: OEO_00010059
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.a",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) domestic aviation is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): domestic aviation"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+    
+    
+Individual: OEO_00010060
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.b",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) road transport is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): road transportation"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+    
+    
+Individual: OEO_00010061
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.c",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) railways is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Emissions from railway transport for both freight and passenger traffic routes.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): railways"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+    
+    
+Individual: OEO_00010062
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.d",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) domestic navigation is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): domestic navigation"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+    
+    
+Individual: OEO_00010063
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.e",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) other transportation is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): other transportation"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+    
+    
+Individual: OEO_00010064
+
+    Annotations: 
+        OEO_00010037 "CRF 1.A.3.e",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) pipeline transport is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
+Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 1.8.2.4, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "CRF sector (IPCC 2006): pipeline transport"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010063
     
     
 DisjointClasses: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1333,7 +1333,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010065
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
+- CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
+- CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
+- CRF sector (IPCC 2006): fugitive emissions from fuels (CRF 1.B)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector energy industry"
@@ -1351,7 +1354,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010066
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
+- CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
+- CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
+- CRF sector (IPCC 2006): industrial processes and product use (CRF 2)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector industry"
@@ -1369,7 +1375,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010067
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
+- CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
+- CRF sector (IPCC 2006): residential (CRF 1.A.4.b)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector buildings"
@@ -1386,7 +1394,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010068
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
+- CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
+- CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
+- CRF sector (IPCC 2006): railways (CRF 1.A.3.c)
+- CRF sector (IPCC 2006): domestic navigation (CRF 1.A.3.d)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector transport"
@@ -1405,7 +1417,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010069
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
+- CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
+- CRF sector (IPCC 2006): agriculture (CRF 3)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector agriculture"
@@ -1422,7 +1436,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010070
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
+- CRF sector (IPCC 2006): waste (CRF 5)
+- CRF sector (IPCC 2006): other (CRF 6)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector waste management and other"
@@ -1439,7 +1455,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010071
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
+It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector land use, land-use change and forestry"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1163,6 +1163,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
     
     
+Individual: OEO_00010056
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 2 of the Bundes-Klimaschutzgesetz (KSG).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580",
+        rdfs:label "KSG sector division"
+    
+    Types: 
+        OEO_00000368
+    
+    
 DisjointClasses: 
     OEO_00000145,OEO_00000213,OEO_00000422
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1073,6 +1073,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
     Facts:  
      OEO_00000504  OEO_00000242
     
+    SameAs: 
+        OEO_00010071
+    
     
 Individual: OEO_00010049
 
@@ -1325,6 +1328,130 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
     Facts:  
      OEO_00000504  OEO_00000242,
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010063
+    
+    
+Individual: OEO_00010065
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector energy industry"
+    
+    Types: 
+        OEO_00000158
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010057,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010064
+    
+    
+Individual: OEO_00010066
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector industry"
+    
+    Types: 
+        OEO_00000227
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010041,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010058
+    
+    
+Individual: OEO_00010067
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector buildings"
+    
+    Types: 
+        OEO_00010034
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010052,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010053
+    
+    
+Individual: OEO_00010068
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector transport"
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010059,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010060,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010061,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010062
+    
+    
+Individual: OEO_00010069
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector agriculture"
+    
+    Types: 
+        OEO_00010035
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010054
+    
+    
+Individual: OEO_00010070
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector waste management and other"
+    
+    Types: 
+        OEO_00010036
+    
+    Facts:  
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
+    
+    
+Individual: OEO_00010071
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
+        rdfs:label "KSG sector land use, land-use change and forestry"
+    
+    Types: 
+        OEO_00010035
+    
+    Facts:  
+     OEO_00000504  OEO_00010056
+    
+    SameAs: 
+        OEO_00010048
     
     
 DisjointClasses: 


### PR DESCRIPTION
Closes #580

Sector division individuals added:
* `KSG sector division`

CRF sector individuals added:
* `CRF sector (IPCC 2006): fugitive emissions from fuels`
* `CRF sector (IPCC 2006): CO2 transport and storage`
* `CRF sector (IPCC 2006): domestic aviation`
* `CRF sector (IPCC 2006): road transportation`
* `CRF sector (IPCC 2006): railways`
* `CRF sector (IPCC 2006): domestic navigation`
* `CRF sector (IPCC 2006): other transportation`
* `CRF sector (IPCC 2006): pipeline transport`

KSG sector individuals added:
* `KSG sector energy industry`
* `KSG sector industry` 
* `KSG sector buildings`
* `KSG sector transport`
* `KSG sector agriculture`
* `KSG sector waste management and other`
* `KSG sector land use, land-use change and forestry`