### PR TITLE
adding more subclasses of energy unit #606

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - further IPCC sector individuals (#595)
 - sector division and sector individuals of Bundes-Klimaschutzgesetz (#595)
 - radiation (#600)
+- subclasses of energy unit (#608)
 
 ### Changed
 - powerplant (#594)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3468,6 +3468,8 @@ Class: OEO_00050002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
         rdfs:label "kilo-joule"@en
     
@@ -3479,6 +3481,8 @@ Class: OEO_00050003
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
         rdfs:label "Mega-joule"@en
     
@@ -3490,6 +3494,8 @@ Class: OEO_00050004
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
         rdfs:label "Giga-joule"@en
     
@@ -3501,6 +3507,8 @@ Class: OEO_00050005
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
         rdfs:label "Tera-joule"@en
     
@@ -3512,6 +3520,8 @@ Class: OEO_00050006
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
         rdfs:label "Peta-joule"@en
     
@@ -3523,6 +3533,8 @@ Class: OEO_00050007
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
         rdfs:label "Exa-joule"@en
     
@@ -3534,6 +3546,8 @@ Class: OEO_00050008
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
         rdfs:label "Megawatt-hour"@en
     
@@ -3545,6 +3559,8 @@ Class: OEO_00050009
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
         rdfs:label "Terawatt-hour"@en
     
@@ -3556,6 +3572,8 @@ Class: OEO_00050010
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
         rdfs:label "Petawatt-hour"@en
     
@@ -3567,6 +3585,8 @@ Class: OEO_00050011
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
         rdfs:label "Gigawatt-hour"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -41,6 +41,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
+AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
+
+    
 AnnotationProperty: dc:contributor
 
     
@@ -360,6 +363,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000111>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
@@ -3458,6 +3464,116 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592",
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175
     
     
+Class: OEO_00050002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
+        rdfs:label "kilo-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
+        rdfs:label "Mega-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
+        rdfs:label "Giga-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
+        rdfs:label "Tera-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050006
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
+        rdfs:label "Peta-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
+        rdfs:label "Exa-joule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
+        rdfs:label "Megawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050009
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
+        rdfs:label "Terawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
+        rdfs:label "Petawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
+        rdfs:label "Gigawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
 Class: OEO_00140000
 
     Annotations: 
@@ -3701,3 +3817,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3471,7 +3471,7 @@ Class: OEO_00050002
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
-        rdfs:label "kilo-joule"@en
+        rdfs:label "kilojoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3484,7 +3484,7 @@ Class: OEO_00050003
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
-        rdfs:label "Mega-joule"@en
+        rdfs:label "megajoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3497,7 +3497,7 @@ Class: OEO_00050004
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
-        rdfs:label "Giga-joule"@en
+        rdfs:label "gigajoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3510,7 +3510,7 @@ Class: OEO_00050005
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
-        rdfs:label "Tera-joule"@en
+        rdfs:label "terajoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3523,7 +3523,7 @@ Class: OEO_00050006
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
-        rdfs:label "Peta-joule"@en
+        rdfs:label "petajoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3536,7 +3536,7 @@ Class: OEO_00050007
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
-        rdfs:label "Exa-joule"@en
+        rdfs:label "exajoule"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3549,7 +3549,7 @@ Class: OEO_00050008
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
-        rdfs:label "Megawatt-hour"@en
+        rdfs:label "megawatt-hour"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3562,7 +3562,7 @@ Class: OEO_00050009
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
-        rdfs:label "Terawatt-hour"@en
+        rdfs:label "terawatt-hour"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3575,7 +3575,7 @@ Class: OEO_00050010
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
-        rdfs:label "Petawatt-hour"@en
+        rdfs:label "petawatt-hour"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -3588,7 +3588,7 @@ Class: OEO_00050011
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
-        rdfs:label "Gigawatt-hour"@en
+        rdfs:label "gigawatt-hour"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>


### PR DESCRIPTION
closes #606 

I added the following subclasses to the energy unit:

- kJ, MJ, GJ, TJ, PJ, EJ
- MWh, GWh, TWh, PWh

I labeled them with the ful name and used the abbreviations from above as exact synonyms.
The definitions are structured liked that:

_An energy unit which is equal to XX watt-hours/joules._
