### PR TITLE
Feature/consumption subclasses #576

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - flow / stock potential and subclasses (#607)
 - kinetic energy (#609)
 - aggregation types (#610)
+- subclasses of consumption and energy amount value (#613)
 
 ### Changed
 - powerplant (#594)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3594,6 +3594,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/UO_0000111>
     
     
+Class: OEO_00050016
+
+    SubClassOf: 
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00050017
+
+    SubClassOf: 
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00050018
+
+    SubClassOf: 
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00050019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
+        rdfs:label "energy amount value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
 Class: OEO_00140000
 
     Annotations: 
@@ -3993,3 +4022,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3615,7 +3615,7 @@ Class: OEO_00050018
 Class: OEO_00050019
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
         rdfs:label "energy amount value"@en
@@ -4024,4 +4024,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3616,6 +3616,8 @@ Class: OEO_00050019
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
         rdfs:label "energy amount value"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -281,6 +281,8 @@ Class: OEO_00050016
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
         rdfs:label "final energy consumption"@en
     
     SubClassOf: 
@@ -292,7 +294,9 @@ Class: OEO_00050017
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland consumption is the total consumption of energy in a geographical region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
-        rdfs:label "Gross inland energy consumption"@en
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+        rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
         OEO_00140039
@@ -302,7 +306,9 @@ Class: OEO_00050018
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a geographical region excluding the non-energetic use of fuels."@en,
-        rdfs:label "Primary energy consumption"@en
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+        rdfs:label "primary energy consumption"@en
     
     SubClassOf: 
         OEO_00140039

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -292,7 +292,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
 Class: OEO_00050017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland consumption is the total consumption of energy in a geographical region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -305,7 +305,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
 Class: OEO_00050018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a geographical region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
         rdfs:label "primary energy consumption"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -24,6 +24,9 @@ Annotations:
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
@@ -274,6 +277,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
+Class: OEO_00050016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
+        rdfs:label "final energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    
+Class: OEO_00050017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland consumption is the total consumption of energy in a geographical region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
+        rdfs:label "Gross inland energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    
+Class: OEO_00050018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a geographical region excluding the non-energetic use of fuels."@en,
+        rdfs:label "Primary energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    
 Class: OEO_00140003
 
     Annotations: 
@@ -332,5 +366,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
     
     SubClassOf: 
         OEO_00140003
+    
+    
+Class: OEO_00140039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+        rdfs:label "consumption"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -686,18 +686,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563",
         OEO_00140012
     
     
-Class: OEO_00140039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "consumption"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
 Class: OEO_00140040
 
     Annotations: 


### PR DESCRIPTION
I moved `consumption` from oeo-social to oeo-shared and added the following terms:

- Final energy consumption is the consumption of energy delivered to and consumed by end users.

- Gross inland consumption is the total consumption of energy in a geographical region (e.g. a country).

- Primary energy consumption is the total consumption of energy in a geographical region excluding the non-energetic use of fuels.

- An energy value is a quantity value that has an energy unit as unit.

and the relations:
final/gross inland/primary energy consumption `has quantity value` `energy amount value`
energy amount value `has unit` `energy unit`

closes #576 
