### PR TITLE
restructure energy carrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Here is a template for new release sections
 - heat, renamed to thermal energy (#609)
 - replace iao-annotation-module and iao-minimal-module with OBO metadata ontology, restructure iao-module (#616)
 - defs of relations has contributer, has resolution and covers (#626)
+- energy carrier disposition (#627)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -70,6 +70,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -344,6 +347,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000034>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000038>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000040>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
@@ -1377,7 +1383,7 @@ Class: OEO_00000151
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627",
         rdfs:label "energy carrier disposition"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3377,7 +3377,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
 Class: OEO_00020039
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An enery carrier is a material entity that has the disposition energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has the disposition energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627",
         rdfs:label "energy carrier"
@@ -4129,4 +4129,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3374,6 +3374,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
         OEO_00020037
     
     
+Class: OEO_00020039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An enery carrier is a material entity that has the disposition energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627",
+        rdfs:label "energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1373,9 +1373,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364",
 Class: OEO_00000151
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an object or object aggregate that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626",
         rdfs:label "energy carrier disposition"
     
     SubClassOf: 


### PR DESCRIPTION
- Adjust def of energy carrier disposition
- add equivalent class `energy carrier`
closes #407

Still to do:
- add general class axioms with `kinetic energy`, `chemical energy`, `eletrical energy`, `thermal energy` #630
- we don't have a class `potential energy` yet: #628 . The general axiom class needs to be added later.

