### PR TITLE
add primary, secondary and final energy carrier (disposition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Here is a template for new release sections
 - aggregation types (#610)
 - subclasses of consumption and energy amount value (#613)
 - areal energy / power density classes, solar-related subclasses and corresponding unit classes (#615)
-- add primary, secondary and final energy carrier (disposition) (#633)
+- primary, secondary and final energy carrier (disposition) (#633)
 
 ### Changed
 - powerplant (#594)
@@ -186,4 +186,3 @@ Here is a template for new release sections
 - unused object properties (#351)
 - remove energy production and subclasses (#77)
 - quantity subclasses (#368)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Here is a template for new release sections
 - aggregation types (#610)
 - subclasses of consumption and energy amount value (#613)
 - areal energy / power density classes, solar-related subclasses and corresponding unit classes (#615)
+- add primary, secondary and final energy carrier (disposition) (#633)
 
 ### Changed
 - powerplant (#594)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4031,7 +4031,7 @@ Class: OEO_00140075
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "crude oil",
+ 
         <http://purl.obolibrary.org/obo/IAO_0000112> "natural gas",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4047,7 +4047,6 @@ Class: OEO_00140076
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
   
-        <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4045,7 +4045,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140076
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000112> "coke oven gas",
         <http://purl.obolibrary.org/obo/IAO_0000112> "cokes",
         <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4034,6 +4034,8 @@ Class: OEO_00140075
         <http://purl.obolibrary.org/obo/IAO_0000112> "crude oil",
         <http://purl.obolibrary.org/obo/IAO_0000112> "natural gas",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "primary energy carrier disposition"@en
     
     SubClassOf: 
@@ -4048,6 +4050,8 @@ Class: OEO_00140076
         <http://purl.obolibrary.org/obo/IAO_0000112> "cokes",
         <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "secondary energy carrier disposition"@en
     
     SubClassOf: 
@@ -4060,6 +4064,8 @@ Class: OEO_00140077
         <http://purl.obolibrary.org/obo/IAO_0000112> "district heat",
         <http://purl.obolibrary.org/obo/IAO_0000112> "electricity",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "final energy carrier disposition"@en
     
     SubClassOf: 
@@ -4070,6 +4076,8 @@ Class: OEO_00140078
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "primary energy carrier"@en
     
     EquivalentTo: 
@@ -4084,6 +4092,8 @@ Class: OEO_00140079
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "secondary energy carrier"@en
     
     EquivalentTo: 
@@ -4098,6 +4108,8 @@ Class: OEO_00140080
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         rdfs:label "final energy carrier"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4060,7 +4060,6 @@ Class: OEO_00140077
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "electricity",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4047,7 +4047,6 @@ Class: OEO_00140076
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
   
-        <http://purl.obolibrary.org/obo/IAO_0000112> "cokes",
         <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4032,7 +4032,7 @@ Class: OEO_00140075
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
  
-        <http://purl.obolibrary.org/obo/IAO_0000112> "natural gas",
+   
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4059,7 +4059,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140077
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000112> "electricity",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4030,7 +4030,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140075
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
         <http://purl.obolibrary.org/obo/IAO_0000112> "crude oil",
         <http://purl.obolibrary.org/obo/IAO_0000112> "natural gas",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
@@ -4222,4 +4222,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4027,6 +4027,87 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         OEO_00140062
     
     
+Class: OEO_00140075
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "crude oil",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "natural gas",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        rdfs:label "primary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140076
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coke oven gas",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "cokes",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        rdfs:label "secondary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140077
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
+        rdfs:label "final energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140078
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        rdfs:label "primary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00140079
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        rdfs:label "secondary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00140080
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
+        rdfs:label "final energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140077)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
 Class: OEO_00230000
 
     Annotations: 
@@ -4129,3 +4210,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4046,7 +4046,7 @@ Class: OEO_00140076
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coke oven gas",
+  
         <http://purl.obolibrary.org/obo/IAO_0000112> "cokes",
         <http://purl.obolibrary.org/obo/IAO_0000112> "motor gasoline",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",


### PR DESCRIPTION
I added the classes `primary`, `secondary` and `final energy carrier disposition` and the corresponding `... energy carrier`-equivalent classes:
- _Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows. Examples are: crude oil, natural gas, coals, etc._
- _Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers. Examples are: cokes, motor gasoline and coke oven gas, blast furnace gas, etc._
- _Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use. Examples are: electricity, district heat, etc._
I added the examples as `example of usage`

closes #575