### PR TITLE
Add cost

### DIFF
--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -719,6 +719,8 @@ Class: OEO_00040009
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/268
+https://github.com/OpenEnergyPlatform/ontology/pull/643",
         rdfs:label "cost"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -646,6 +646,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     
+Class: OEO_00040002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organization, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
+https://github.com/OpenEnergyPlatform/ontology/pull/639",
+        rdfs:label "market exchange"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
 Class: OEO_00040005
 
     Annotations: 
@@ -658,7 +674,8 @@ https://github.com/OpenEnergyPlatform/ontology/pull/641",
     
     SubClassOf: 
         OEO_00000051
-
+    
+    
 Class: OEO_00040006
 
     Annotations: 
@@ -695,21 +712,17 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
     
     SubClassOf: 
         OEO_00140012
-
-Class: OEO_00040002
+    
+    
+Class: OEO_00040009
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organization, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639",
-        rdfs:label "market exchange"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
+        rdfs:label "cost"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        OEO_00140012
     
     
 Class: OEO_00140009


### PR DESCRIPTION
Add cost, defined as 'Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.'

Closes #268 