### PR TITLE
add emission value and others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Here is a template for new release sections
 - price request and marginal cost (#376)
 - cost (#268)
 - commodity (#339)
+- emission value, greenhouse gas emission value, carbon dioxide equivalent quantity (#651)
 
 ### Changed
 - relations to energy transformation (#646)
+- has global warming potential (#651)
 
 ### Removed
 -

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -149,7 +149,9 @@ ObjectProperty: OEO_00000524
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has. The global warming potential is a ratio that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of CO2.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
         rdfs:label "has global warming potential"
     
     SubPropertyOf: 
@@ -4139,6 +4141,8 @@ Class: OEO_00140081
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
         rdfs:label "emission value"@en
     
     SubClassOf: 
@@ -4150,6 +4154,8 @@ Class: OEO_00140082
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
         rdfs:label "greenhouse gas emission value"@en
     
     SubClassOf: 
@@ -4162,6 +4168,8 @@ Class: OEO_00140083
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
         rdfs:label "carbon dioxide equivalent quantity"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -147,7 +147,7 @@ ObjectProperty: OEO_00000523
 ObjectProperty: OEO_00000524
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has. The global warming potential is a ratio that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of CO2.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
         rdfs:label "has global warming potential"
@@ -157,6 +157,10 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
     
     Domain: 
         OEO_00000198
+    
+    Range: 
+        OEO_00000350
+         and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>)
     
     
 ObjectProperty: OEO_00000525
@@ -4129,6 +4133,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
     
     SubClassOf: 
         OEO_00020039
+    
+    
+Class: OEO_00140081
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        rdfs:label "emission value"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147
+    
+    
+Class: OEO_00140082
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
+        rdfs:label "greenhouse gas emission value"@en
+    
+    SubClassOf: 
+        OEO_00140081,
+        OEO_00000502 some OEO_00000199
+    
+    
+Class: OEO_00140083
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
+        rdfs:label "carbon dioxide equivalent quantity"@en
+    
+    SubClassOf: 
+        OEO_00140082
     
     
 Class: OEO_00230000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -147,7 +147,7 @@ ObjectProperty: OEO_00000523
 ObjectProperty: OEO_00000524
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has. The global warming potential is a ratio that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of CO2.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter and the global warming potential it has. The global warming potential is a ratio that measures the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of CO2.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -4278,4 +4278,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-


### PR DESCRIPTION
The following classes were added:
- `emission value`: _An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process._
- `greenhouse gas emission value`: _A greenhouse gas emission  value is an emission value that quantifies the output of a greenhouse gas emission process._
- `carbon dioxide equivalent quantity` (alternative term: CO2 equivalent quantity): _A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate._

Also, the definition of `has global warming potential` was changed to _A relation between a portion of matter and the global warming potential it has. The global warming potential is a ratio that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of CO2._

closes #420 