### PR TITLE
restructure solar energy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ Here is a template for new release sections
 - emission value, greenhouse gas emission value, carbon dioxide equivalent quantity (#651)
 - disjointness axiom for (has origin some natural gas) and (has origin some anthropogenic) (#658)
 - radiative energy (#665)
+- solar energy transformation and subclasses (#672)
 
 ### Changed
 - relations to energy transformation (#646)
 - has global warming potential (#651)
 - definition of battery electric vehicle and fuel cell electric vehicle (#655)
 - energy (#656 and #665)
+- solar energy (#672)
 
 ### Removed
 -

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2492,14 +2492,16 @@ Class: OEO_00000377
 Class: OEO_00000384
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation exploited for hot water production and electricity generation. This energy production is the heat available to the heat transfer medium, i.e. the incident solar energy less the optical and collectors' losses. Passive solar energy for the direct heating, cooling and lighting of dwellings or other buildings is not included."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+restructure solar energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
         rdfs:label "solar energy"
     
     SubClassOf: 
-        OEO_00000150,
+        OEO_00020040,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000033
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3455,6 +3455,44 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666",
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00000139
     
     
+Class: OEO_00020046
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
+        rdfs:label "solar energy transformation"
+    
+    SubClassOf: 
+        OEO_00020003
+    
+    
+Class: OEO_00020047
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
+        rdfs:label "solar thermal energy transformation"
+    
+    SubClassOf: 
+        OEO_00020046,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
+    
+    
+Class: OEO_00020048
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
+        rdfs:label "photovoltaic energy transformation"
+    
+    SubClassOf: 
+        OEO_00020046,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3452,7 +3452,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666",
     SubClassOf: 
         OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
-        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00020042,
+        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00000446 ,
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00000139
     
     
@@ -4385,4 +4385,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-


### PR DESCRIPTION
closes #663 

- reclassify `solar energy` as subclass of `radiative energy`
- add `solar energy transformation` and subclasses `thermal energy transformation` and `photovoltaic energy transformation`