### PR TITLE
update subclasses of has input / has output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ Here is a template for new release sections
 
 ### Added
 - thorium and plutonium (#708)
+- has information input / output (#716)
 
 ### Changed
--
+- has physical output, has constraint (#716)
+
 ### Removed
--
+- has numerical input / output (#716)
 
 ## [1.4.0] - 2021-03-02
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -168,23 +168,6 @@ ObjectProperty: OEO_00000517
         OEO_00000104
     
     
-ObjectProperty: OEO_00000519
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en,
-        rdfs:label "has_numerical_output"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Characteristics: 
-        Irreflexive,
-        Asymmetric
-    
-    Domain: 
-        OEO_00000419
-    
-    
 ObjectProperty: OEO_00000522
 
     
@@ -199,6 +182,22 @@ ObjectProperty: OEO_00140093
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: OEO_00140094
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
+        rdfs:label "has information output"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
     
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -156,27 +156,16 @@ ObjectProperty: OEO_00000517
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
-        rdfs:label "has_constraint"
+        rdfs:label "has constraint"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    
-ObjectProperty: OEO_00000518
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its input."@en,
-        rdfs:label "has_numerical_input"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Characteristics: 
-        Irreflexive,
-        Asymmetric
+        OEO_00140093
     
     Domain: 
         OEO_00000419
+    
+    Range: 
+        OEO_00000104
     
     
 ObjectProperty: OEO_00000519
@@ -201,6 +190,22 @@ ObjectProperty: OEO_00000522
     
 ObjectProperty: OEO_00040010
 
+    
+ObjectProperty: OEO_00140093
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
+        rdfs:label "has information input"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 ObjectProperty: owl:topObjectProperty
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -156,6 +156,8 @@ ObjectProperty: OEO_00000517
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
         rdfs:label "has constraint"
     
     SubPropertyOf: 
@@ -178,6 +180,8 @@ ObjectProperty: OEO_00140093
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
         rdfs:label "has information input"@en
     
     SubPropertyOf: 
@@ -194,6 +198,8 @@ ObjectProperty: OEO_00140094
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
         rdfs:label "has information output"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -312,12 +312,6 @@ pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
     
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: OEO_00040010
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -304,11 +304,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
 ObjectProperty: OEO_00000533
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and its output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity or energy"@en,
         rdfs:label "has physical output"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 ObjectProperty: OEO_00040010

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -305,6 +305,8 @@ ObjectProperty: OEO_00000533
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity or energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
         rdfs:label "has physical output"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -294,6 +294,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
         Irreflexive,
         Asymmetric
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     Range: 
         OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
     


### PR DESCRIPTION
closes #618 

> * replace `has numerical input` by `has information input`, defined as _p has information input c iff: p has input c, and c is an information content entity_ (analogous to the definition of `has physical input`).
> * add missing domains and ranges to the children of `has input` to further distinguish them
> * make `has constraint` a subproperty of `has information input`
> * do the same for `has ... output`

