### PR TITLE
update gross inland energy consumption and primary energy consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 
 ### Changed
 - has physical output, has constraint (#716)
+- gross inland energy consumption, primary energy consumption
 
 ### Removed
 - has numerical input / output (#716)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Here is a template for new release sections
 
 ### Changed
 - has physical output, has constraint (#716)
-- gross inland energy consumption, primary energy consumption
+- gross inland energy consumption, primary energy consumption (#719)
 
 ### Removed
 - has numerical input / output (#716)

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -8,6 +8,6 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-module.owl" uri="../imports/ro-module.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1614088530430" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1616500288567" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3954,6 +3954,7 @@ Class: OEO_00050016
 Class: OEO_00050017
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
 Gross inland energy consumption covers:
@@ -3963,23 +3964,39 @@ Gross inland energy consumption covers:
   - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
 
 Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption including non-energy use of energy carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en
+https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
+        OEO_00140039,
         OEO_00140002 some OEO_00050019
     
     
 Class: OEO_00050018
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "primary energy consumption"@en
     
     SubClassOf: 
+        OEO_00140039,
         OEO_00140002 some OEO_00050019
     
     
@@ -4229,6 +4246,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
     SubClassOf: 
         OEO_00140034
     
+    
+Class: OEO_00140039
+
     
 Class: OEO_00140049
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3953,12 +3953,32 @@ Class: OEO_00050016
     
 Class: OEO_00050017
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
+
+Gross inland energy consumption covers:
+  - consumption by the energy sector itself;
+  - distribution and transformation losses;
+  - final energy consumption by end users;
+  - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
+
+Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption including non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en
+    
     SubClassOf: 
         OEO_00140002 some OEO_00050019
     
     
 Class: OEO_00050018
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en
+    
     SubClassOf: 
         OEO_00140002 some OEO_00050019
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -294,7 +294,8 @@ Class: OEO_00050017
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709"@en,
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719"@en,
         rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
@@ -308,7 +309,8 @@ Class: OEO_00050018
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709"@en,
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719"@en,
         rdfs:label "primary energy consumption"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -289,10 +289,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
 Class: OEO_00050017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709"@en,
         rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
@@ -304,7 +306,9 @@ Class: OEO_00050018
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709"@en,
         rdfs:label "primary energy consumption"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -286,37 +286,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
         OEO_00140039
     
     
-Class: OEO_00050017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "gross inland energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00140039
-    
-    
-Class: OEO_00050018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "primary energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00140039
-    
-    
 Class: OEO_00140003
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -291,11 +291,11 @@ Class: OEO_00050017
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gross inland consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719"@en,
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
         rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
@@ -306,11 +306,11 @@ Class: OEO_00050018
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719"@en,
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
         rdfs:label "primary energy consumption"@en
     
     SubClassOf: 


### PR DESCRIPTION
- modify definition of gross inland energy consumption to include the
  "energy" part
- add alternative terms primary energy consumptuion excluding non-energy
  use of energy carriers and primary energy consumption including
  non-energy use of energy carriers to primary energy consumption and
  gross inland energy consumption, respectively
- link to Eurostat definitions in primary energy consumption and gross
  inland energy consumption
- included extended explanations for primary energy consumption and
  gross inland energy consumption from Eurostat as editor notes

closes #709