### PR TITLE
add typical computation time and hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 ### Added
 - thorium and plutonium (#708)
 - has information input / output (#716)
+- has typical computation time / hardware (#723)
 
 ### Changed
 - has physical output, has constraint (#716)
@@ -32,6 +33,7 @@ Here is a template for new release sections
 
 ### Removed
 - has numerical input / output (#716)
+- computation time (#723)
 
 ## [1.4.0] - 2021-03-02
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -219,6 +219,8 @@ ObjectProperty: OEO_00140095
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
         rdfs:label "has typical computation time"@en
     
     SubPropertyOf: 
@@ -235,6 +237,8 @@ ObjectProperty: OEO_00140096
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
         rdfs:label "has typical computation hardware"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -176,6 +176,9 @@ ObjectProperty: OEO_00000522
 ObjectProperty: OEO_00040010
 
     
+ObjectProperty: OEO_00140002
+
+    
 ObjectProperty: OEO_00140093
 
     Annotations: 
@@ -210,6 +213,38 @@ pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
     
     Range: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: OEO_00140095
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
+        rdfs:label "has typical computation time"@en
+    
+    SubPropertyOf: 
+        OEO_00140002
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        OEO_00030035
+    
+    
+ObjectProperty: OEO_00140096
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
+        rdfs:label "has typical computation hardware"@en
+    
+    SubPropertyOf: 
+        OEO_00000503
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        OEO_00030035
     
     
 ObjectProperty: owl:topObjectProperty
@@ -273,6 +308,9 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000028>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000064>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
@@ -367,16 +405,6 @@ Class: OEO_00000091
     
     SubClassOf: 
         OEO_00000119
-    
-    
-Class: OEO_00000103
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "computation time is a software descriptor describing how long a Software or an Algorithm needs to compute."^^xsd:string,
-        rdfs:label "computation time"
-    
-    SubClassOf: 
-        OEO_00000378
     
     
 Class: OEO_00000104

--- a/src/ontology/imports/iao-module.owl
+++ b/src/ontology/imports/iao-module.owl
@@ -209,6 +209,22 @@ Request that IAO either clarify these or change definitions not to use them</rdf
         <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document</rdfs:label>
     </owl:Class>
+
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000064 -->
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000064">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <obo:IAO_0000111 xml:lang="en">algorithm</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">PMID: 18378114.Genomics. 2008 Mar 28. LINKGEN: A new algorithm to process data in genetic linkage studies.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">A plan specification which describes the inputs and output of mathematical functions as well as workflow of execution for achieving an predefined objective. Algorithms are realized usually by means of implementation as computer programs for execution by automata.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PlanAndPlannedProcess Branch</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000270</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">adapted from discussion on OBI list (Matthew Pocock, Christian Cocos, Alan Ruttenberg)</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">algorithm</rdfs:label>
+    </owl:Class>
     
 </rdf:RDF>
 


### PR DESCRIPTION
closes #527 

- add `has typical computation time`: _a relation between an algorithm or a software and the typical duration of its execution._
  - subproperty of `quantity value` with domain `algorithm or software` and range `duration`
- add `has typical computation hardware`: _a relation between an algorithm or a software and the typical hardware used for its execution._
  - subproperty of `uses` with domain `algorithm or software` and range `hardware`
- delete `computation time`
- re-add `algorithm` to iao-module