### PR TITLE
add flag / quality control flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ Here is a template for new release sections
 - thorium and plutonium (#708)
 - has information input / output (#716)
 - has typical computation time / hardware (#723)
+- quality control flag (#724)
 
 ### Changed
 - has physical output, has constraint (#716)
 - gross inland energy consumption, primary energy consumption (#719)
 - covers energy carrier (#722)
+- data descriptor (#724)
 
 ### Removed
 - has numerical input / output (#716)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -407,6 +407,9 @@ Class: OEO_00000119
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
         <http://purl.obolibrary.org/obo/IAO_0000118> "flag",
         rdfs:label "data descriptor"
     
@@ -1371,6 +1374,8 @@ Class: OEO_00140098
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a time series.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
         rdfs:label "quality control flag"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1411,7 +1411,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
     
     SubClassOf: 
         OEO_00000119,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030034
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 Individual: OEO_00000049

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1405,7 +1405,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Class: OEO_00140098
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a time series.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
         rdfs:label "quality control flag"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -442,7 +442,6 @@ Class: OEO_00000119
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "flag",
         rdfs:label "data descriptor"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -407,6 +407,7 @@ Class: OEO_00000119
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "flag",
         rdfs:label "data descriptor"
     
     SubClassOf: 
@@ -1364,6 +1365,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
     
     SubClassOf: 
         OEO_00000119
+    
+    
+Class: OEO_00140098
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a time series.",
+        rdfs:label "quality control flag"@en
+    
+    SubClassOf: 
+        OEO_00000119,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030034
     
     
 Individual: OEO_00000049


### PR DESCRIPTION
closes #612 

- add `flag` as `alternative term` to `data descriptor`
- add `quality control flag`: _A quality control flag is a data descriptor that describes the measurement quality of a time series._