### PR TITLE
update branch naming convention in contribution.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,9 @@ by [Vincent Driessen](https://nvie.com/posts/a-successful-git-branching-model/).
     ```bash
     git pull
     ```
-    Branch from `dev`
+    Branch from `dev` (see also section "naming conventions" below)
     ```bash
-    git checkout -b feature/myfeature-#issueNumber
+    git checkout -b feature-issueNumber-myfeature
     ```
     It is best to merge one's changes *as fast as possible* (i.e. do not wait for 2 weeks) to avoid merging conflicts
 3. 📙 or 📗 Open [Protégé](https://protege.stanford.edu/) or a text editor and work on the ontology. If you haven't already, make sure you change your protégé settings to use [numeric identifiers](https://github.com/OpenEnergyPlatform/ontology/wiki/Numerical-Identifiers). Please choose the right module of the oeo to do your changes, oeo.omn is in most cases not the right file to change. Refer to [this article](https://github.com/OpenEnergyPlatform/ontology/wiki/how-to-use-prot%C3%A9g%C3%A9-to-change-the-ontology) for detailed explanations on working with protégé.


### PR DESCRIPTION
closes #711

@Ludee already updated the contributing.md to include the new branch naming convention, I just spotted a line where the old convention was still used.