### PR TITLE
rework geothermal energy #727

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,14 @@ Here is a template for new release sections
 - goal description (#729)
 - heat transfer (#733)
 - heat exchanger (#734)
+- geothermal heat transfer, rock (#739)
 
 ### Changed
 - has physical output, has constraint (#716)
 - gross inland energy consumption, primary energy consumption (#719)
 - covers energy carrier (#722)
 - photon, wind energy, solar energy (#732)
+- geothermal energy (#739)
 
 ### Removed
 - has numerical input / output (#716)

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl" uri="oeo.omn"/>
     <uri id="User Entered Import Resolution" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical-axioms.omn" uri="edits/oeo-physical-axioms.owl"/>
     <uri id="User Edited Redirect" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical-axioms.owl" uri="edits/oeo-physical-axioms.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/iao-module.owl" uri="imports/iao-module.owl"/>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3666,6 +3666,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
     SubClassOf: 
         OEO_00000331,
         OEO_00000530 some OEO_00030003,
+        OEO_00000530 some OEO_00030004,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
         OEO_00000529 value OEO_00000390
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1611,11 +1611,10 @@ Class: OEO_00000189
 Class: OEO_00000191
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy available as heat emitted from within the earth's crust, usually in the form of hot water or steam. This energy production is the difference between the enthalpy of the fluid produced in the production borehole and that of the fluid eventually disposed of. It is exploited at suitable sites:
-— for electricity generation using dry steam or high enthalpy brine after flashing,
-— directly as heat for district heating, agriculture etc"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "geothermal heat"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
+        rdfs:label "geothermal energy"
     
     SubClassOf: 
         OEO_00000207,
@@ -3660,6 +3659,8 @@ Class: OEO_00020058
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
         rdfs:label "rock"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1613,7 +1613,7 @@ Class: OEO_00000191
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         rdfs:label "geothermal energy"
     
     SubClassOf: 
@@ -3660,7 +3660,7 @@ Class: OEO_00020058
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         rdfs:label "rock"
     
     SubClassOf: 
@@ -3675,7 +3675,7 @@ Class: OEO_00020059
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         rdfs:label "geothermal heat transfer"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3674,7 +3674,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
     
     SubClassOf: 
         OEO_00140101,
-        OEO_00000530 some OEO_00030003,
         OEO_00000532 only OEO_00000191
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3656,6 +3656,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00000207
     
     
+Class: OEO_00020058
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
+        rdfs:label "rock"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030003,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        OEO_00000529 value OEO_00000390
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3670,6 +3670,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
         OEO_00000529 value OEO_00000390
     
     
+Class: OEO_00020059
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxx",
+        rdfs:label "geothermal heat transfer"
+    
+    SubClassOf: 
+        OEO_00140101,
+        OEO_00000530 some OEO_00030003,
+        OEO_00000532 only OEO_00000191
+    
+    
 Class: OEO_00030000
 
     Annotations: 


### PR DESCRIPTION
closes #727

I implemented as discussed in #727. Including the relation `geothermal heat transfer has origin some geogenic`. Apparently, `origin` is a quality and `geothermal heat transfer` is a process, which doesn't match, I guess? @sfluegel05 
Since `geothermal energy has origin some geogenic` exists, too, and `geothermal energy` is physical input to `geothermal energy`, we could drop the relation in my opinion.
--> keep in mind for #728 !




