### PR TITLE
Add Market exchange subclasses #677

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Here is a template for new release sections
 - goal description (#729)
 - heat transfer (#733)
 - heat exchanger (#734)
+- emission certificate (#740)
 
 ### Changed
 - has physical output, has constraint (#716)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1005,17 +1005,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/536",
         OEO_00030030
     
     
-Class: OEO_00020015
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561",
-        rdfs:label "licence"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020016

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+﻿Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -3312,20 +3312,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
     SubClassOf: 
         OEO_00000350,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00010079
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
-        rdfs:label "emission quantity value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
-    
     
 Class: OEO_00010080
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-﻿Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: obda: <https://w3id.org/obda/vocabulary#>
@@ -3312,6 +3312,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
     SubClassOf: 
         OEO_00000350,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00010079
+
     
 Class: OEO_00010080
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -249,17 +249,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
 
+Class: OEO_00010079
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
+        rdfs:label "emission quantity value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>    
+    
 Class: OEO_00020015
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
+move to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "licence"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>    
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 Class: OEO_00030031
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -248,7 +248,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+
+Class: OEO_00020015
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/561",
+        rdfs:label "licence"
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>    
     
 Class: OEO_00030031
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -172,6 +172,9 @@ ObjectProperty: OEO_00000510
 ObjectProperty: OEO_00000522
 
     
+ObjectProperty: OEO_00020056
+
+    
 ObjectProperty: OEO_00040010
 
     
@@ -595,6 +598,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
     
     SubClassOf: 
         OEO_00000368
+    
+    
+Class: OEO_00010079
+
+    SubClassOf: 
+        OEO_00020056 some OEO_00020063
     
     
 Class: OEO_00020015

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -597,6 +597,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         OEO_00000368
     
     
+Class: OEO_00020060
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is a market exchange where fuels like oil, coal, nuclear, renewable energy, and natural gas are traded.",
+        rdfs:label "fuel market exchange"
+    
+    SubClassOf: 
+        OEO_00040002
+    
+    
 Class: OEO_00030016
 
     Annotations: 
@@ -661,6 +671,8 @@ Class: OEO_00040002
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
 https://github.com/OpenEnergyPlatform/ontology/pull/639",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/677
+https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "market exchange"@en,
         rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -637,6 +637,7 @@ Class: OEO_00020064
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 ton.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "EU allowance"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -604,6 +604,8 @@ Class: OEO_00020060
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is a market exchange where fuels like oil, coal, nuclear, renewable energy, and natural gas are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "fuel market exchange"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -597,6 +597,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         OEO_00000368
     
     
+Class: OEO_00020015
+
+    
 Class: OEO_00020060
 
     Annotations: 
@@ -605,6 +608,30 @@ Class: OEO_00020060
     
     SubClassOf: 
         OEO_00040002
+    
+    
+Class: OEO_00020063
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a license that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "emission certificate"
+    
+    SubClassOf: 
+        OEO_00020015
+    
+    
+Class: OEO_00020064
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 ton.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "EU allowance"
+    
+    SubClassOf: 
+        OEO_00020063
     
     
 Class: OEO_00030016


### PR DESCRIPTION
closes #677 

I'd like to move `licence` from oeo-model to oeo-shared, thus `emission certificate` (subclass of licence) can be part of oeo-social. Is it possible to move the class without deleting and recreating it @sfluegel05 ?