### PR TITLE
add ambient thermal energy and related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - heat exchanger (#734)
 - geothermal heat transfer, rock (#739)
 - emission certificate (#740)
+- natural / artificial ambient thermal energy, ambient thermal energy transfer (#742)
 
 ### Changed
 - has physical output, has constraint (#716)
@@ -38,6 +39,8 @@ Here is a template for new release sections
 - covers energy carrier (#722)
 - photon, wind energy, solar energy (#732)
 - geothermal energy (#739)
+- ambient thermal energy (#742)
+- has origin, renewable, anthropogenic (#742)
 
 ### Removed
 - has numerical input / output (#716)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -953,9 +953,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
 Class: OEO_00000056
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient heat, understood as heat that is naturally around us in its diffuse and extended form, emanates from a diversity of heat sources, including earth, water, or air, and is increasingly attracting the attention of those concerned with energy and sustainability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Urchueguia, J. F. (2016). Shallow geothermal and ambient heat technologies for renewable heating. In Renewable Heating and Cooling (pp. 89-118). Woodhead Publishing."@en,
-        rdfs:label "ambient heat"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
+        rdfs:label "ambient thermal energy"
     
     SubClassOf: 
         OEO_00000207
@@ -3680,7 +3679,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
 Class: OEO_00030000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter or energies created by human activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "anthropogenic"
@@ -3730,7 +3729,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00030004
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter or energies that replenish on a human time scale.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
@@ -4679,6 +4678,40 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734",
     SubClassOf: 
         OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101
+    
+    
+Class: OEO_00140104
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
+        rdfs:label "natural ambient thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000056,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00140105
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
+        rdfs:label "artificial ambient thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000056,
+        OEO_00000530 some OEO_00030000
+    
+    
+Class: OEO_00140106
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
+        rdfs:label "ambient thermal energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00140101,
+        OEO_00000532 some OEO_00000056,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00230000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -954,6 +954,8 @@ Class: OEO_00000056
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         rdfs:label "ambient thermal energy"
     
     SubClassOf: 
@@ -3680,6 +3682,9 @@ Class: OEO_00030000
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter or energies created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "anthropogenic"
@@ -3730,6 +3735,9 @@ Class: OEO_00030004
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of portions of matter or energies that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
@@ -4684,6 +4692,8 @@ Class: OEO_00140104
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         rdfs:label "natural ambient thermal energy"@en
     
     SubClassOf: 
@@ -4695,6 +4705,8 @@ Class: OEO_00140105
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         rdfs:label "artificial ambient thermal energy"@en
     
     SubClassOf: 
@@ -4706,6 +4718,8 @@ Class: OEO_00140106
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         rdfs:label "ambient thermal energy transfer"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -261,7 +261,11 @@ ObjectProperty: OEO_00000530
         <http://purl.obolibrary.org/obo/RO_0000086>
     
     Domain: 
-        OEO_00000331
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
+        OEO_00000150 or OEO_00000331
     
     Range: 
         OEO_00000316


### PR DESCRIPTION
- `ambient thermal energy`: _Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps._
- `natural ambient thermal energy`: Natural ambient thermal energy is ambient thermal energy that has a renewable origin._
  - `has origin some renewable`
- `artificial ambient thermal energy`: _Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin._
  - `has origin some anthropogenic`
- `ambient thermal energy transfer`: _Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity._
  - `has participant some material entity`
  - `has physical input some ambient thermal energy`
- I added "or energies" to the definitions of `anthropocentric` and `renewable`. This is needed for the axioms above, but should be discussed further (see https://github.com/OpenEnergyPlatform/ontology/issues/741)

closes #728 