### PR TITLE
Update powerplants #750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 
 ### Changed
 - trader (#745)
+- powerplant and power generating unit subclasses (#752)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -490,7 +490,8 @@ Class: OEO_00000008
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000088
+        OEO_00000503 some OEO_00000088,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000009
@@ -602,7 +603,8 @@ Class: OEO_00000019
         rdfs:label "geothermal power unit"
     
     SubClassOf: 
-        OEO_00000334
+        OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000020
@@ -641,7 +643,8 @@ Class: OEO_00000022
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000220
+        OEO_00000503 some OEO_00000220,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
     
     
 Class: OEO_00000024
@@ -719,7 +722,8 @@ Class: OEO_00000029
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000302
+        OEO_00000503 some OEO_00000302,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000030
@@ -730,7 +734,8 @@ Class: OEO_00000030
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000309
+        OEO_00000503 some OEO_00000309,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000031
@@ -870,7 +875,8 @@ Class: OEO_00000041
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000439
+        OEO_00000503 some OEO_00000439,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000042
@@ -1175,8 +1181,7 @@ Class: OEO_00000089
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008
     
     
 Class: OEO_00000093
@@ -1649,8 +1654,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019
     
     
 Class: OEO_00000198
@@ -1834,8 +1838,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022
     
     
 Class: OEO_00000222
@@ -2216,8 +2219,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029
     
     
 Class: OEO_00000308
@@ -2259,8 +2261,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030
     
     
 Class: OEO_00000311
@@ -2776,8 +2777,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041
     
     
 Class: OEO_00000441

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -436,11 +436,12 @@ Class: OEO_00000003
 Class: OEO_00000004
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant having an aggregate of biogas powerunits as its power generating units.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a powerplant that has biogas power units as parts.",
         rdfs:label "biogas powerplant"
     
     SubClassOf: 
-        OEO_00000073
+        OEO_00000073,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000005
     
     
 Class: OEO_00000005
@@ -799,11 +800,12 @@ Class: OEO_00000035
 Class: OEO_00000036
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biomass powerplant having an aggregate of solid biomass power units as its power generating units.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a powerplant that has solid biomass power units as parts.",
         rdfs:label "solid biomass powerplant"
     
     SubClassOf: 
-        OEO_00000073
+        OEO_00000073,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000037
     
     
 Class: OEO_00000037
@@ -1077,7 +1079,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
 Class: OEO_00000073
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant having an aggregate of biofuel power units as its power generating units.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant that has biofuel power units as parts.",
         rdfs:label "biofuel powerplant"
     
     SubClassOf: 
@@ -1162,7 +1164,7 @@ Class: OEO_00000088
 Class: OEO_00000089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant having an aggregate of coal power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant that has coal power units as parts."@en,
         rdfs:label "coal powerplant"
     
     SubClassOf: 
@@ -1558,7 +1560,7 @@ Class: OEO_00000183
 Class: OEO_00000184
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant having an aggregate of gas fired power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant that has gas power units as parts."@en,
         rdfs:label "gas powerplant"
     
     SubClassOf: 
@@ -1632,7 +1634,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
 Class: OEO_00000192
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant having an aggregate of geothermal power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant that has geothermal power units as parts."@en,
         rdfs:label "geothermal powerplant"
     
     SubClassOf: 
@@ -1702,7 +1704,7 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant having an aggregate of hard coal power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a powerplant that has hard coal power units as parts."@en,
         rdfs:label "hard coal powerplant"
     
     SubClassOf: 
@@ -1813,7 +1815,7 @@ Class: OEO_00000220
 Class: OEO_00000221
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant having an aggregate of hydrogen power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant that has hydrogen power units as parts."@en,
         rdfs:label "hydrogen powerplant"
     
     SubClassOf: 
@@ -1922,7 +1924,7 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
 Class: OEO_00000252
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant having an aggregate of lignite power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a powerplant that has lignite power units as parts."@en,
         rdfs:label "lignite powerplant"
     
     SubClassOf: 
@@ -2191,7 +2193,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000303
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant having an aggregate of nuclear power units as its power generating units.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant that has nuclear power units as parts.",
         rdfs:label "nuclear powerplant"
     
     SubClassOf: 
@@ -2232,7 +2234,7 @@ It consists of hydrocarbons of various molecular weights and other organic compo
 Class: OEO_00000310
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil powerplant is a powerplant having an aggregate of oil power units as its power generating units.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil powerplant is a powerplant that has oil power units as parts.",
         rdfs:label "oil powerplant"
     
     SubClassOf: 
@@ -2313,7 +2315,7 @@ Class: OEO_00000322
 Class: OEO_00000324
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant having an aggregate of PV panels as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant that has PV panels as parts."@en,
         rdfs:label "photovoltaic powerplant"
     
     SubClassOf: 
@@ -2534,12 +2536,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
 Class: OEO_00000386
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant having an aggregate of solar power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant that has solar power units as parts."@en,
         rdfs:label "solar power plant"
     
     SubClassOf: 
         OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000034
     
     
 Class: OEO_00000387
@@ -2570,7 +2572,7 @@ Class: OEO_00000388
 Class: OEO_00000389
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant consisting of solar thermal power units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant that has solar thermal power units as parts."@en,
         rdfs:label "solar thermal powerplant"
     
     SubClassOf: 
@@ -2741,7 +2743,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
 Class: OEO_00000440
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant having an aggregate of waste power units as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant that has waste power units as parts."@en,
         rdfs:label "waste powerplant"
     
     SubClassOf: 
@@ -2805,7 +2807,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
 Class: OEO_00000447
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant having an aggregate of wind energy converters as its power generating units."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant that has wind energy converting units as parts."@en,
         rdfs:label "wind farm"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -486,6 +486,8 @@ Class: OEO_00000008
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "coal power unit"
     
     SubClassOf: 
@@ -600,6 +602,8 @@ Class: OEO_00000019
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "geothermal power unit"
     
     SubClassOf: 
@@ -639,6 +643,8 @@ Class: OEO_00000022
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "hydrogen power unit"
     
     SubClassOf: 
@@ -718,6 +724,8 @@ Class: OEO_00000029
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "nuclear power unit"
     
     SubClassOf: 
@@ -871,6 +879,8 @@ Class: OEO_00000041
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "waste power unit"
     
     SubClassOf: 
@@ -1177,6 +1187,8 @@ Class: OEO_00000089
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant that has coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "coal powerplant"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -436,7 +436,9 @@ Class: OEO_00000003
 Class: OEO_00000004
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a powerplant that has biogas power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant that has biogas power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "biogas powerplant"
     
     SubClassOf: 
@@ -800,7 +802,9 @@ Class: OEO_00000035
 Class: OEO_00000036
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a powerplant that has solid biomass power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biofuel powerplant that has solid biomass power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "solid biomass powerplant"
     
     SubClassOf: 
@@ -1080,6 +1084,8 @@ Class: OEO_00000073
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant that has biofuel power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "biofuel powerplant"
     
     SubClassOf: 
@@ -1560,7 +1566,9 @@ Class: OEO_00000183
 Class: OEO_00000184
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant that has gas power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant that has gas fired power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "gas powerplant"
     
     SubClassOf: 
@@ -1635,6 +1643,8 @@ Class: OEO_00000192
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant that has geothermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "geothermal powerplant"
     
     SubClassOf: 
@@ -1704,7 +1714,9 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a powerplant that has hard coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant that has hard coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "hard coal powerplant"
     
     SubClassOf: 
@@ -1816,6 +1828,8 @@ Class: OEO_00000221
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant that has hydrogen power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "hydrogen powerplant"
     
     SubClassOf: 
@@ -1924,7 +1938,9 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
 Class: OEO_00000252
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a powerplant that has lignite power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant that has lignite power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "lignite powerplant"
     
     SubClassOf: 
@@ -2194,6 +2210,8 @@ Class: OEO_00000303
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant that has nuclear power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "nuclear powerplant"
     
     SubClassOf: 
@@ -2235,6 +2253,8 @@ Class: OEO_00000310
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A oil powerplant is a powerplant that has oil power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "oil powerplant"
     
     SubClassOf: 
@@ -2315,7 +2335,9 @@ Class: OEO_00000322
 Class: OEO_00000324
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a powerplant that has PV panels as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a solar powerplant that has PV panels as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "photovoltaic powerplant"
     
     SubClassOf: 
@@ -2537,6 +2559,8 @@ Class: OEO_00000386
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant that has solar power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "solar power plant"
     
     SubClassOf: 
@@ -2572,7 +2596,9 @@ Class: OEO_00000388
 Class: OEO_00000389
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a powerplant that has solar thermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a solar powerplant that has solar thermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "solar thermal powerplant"
     
     SubClassOf: 
@@ -2744,6 +2770,8 @@ Class: OEO_00000440
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant that has waste power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "waste powerplant"
     
     SubClassOf: 
@@ -2808,6 +2836,8 @@ Class: OEO_00000447
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant that has wind energy converting units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "wind farm"
     
     SubClassOf: 


### PR DESCRIPTION
Closes #750:

* New definition pattern for powerplants: _A XYZ powerplant is a powerplant having an aggregate of XYZ power units as its power generating units._
* Add missing `'has part'` relations.
* In some cases the `'has part' some 'xyz turbine'` was wrongly attributed wrongly to the `powerplant` classes instead of the `'power generating unit'` classes.