### PR TITLE
Changed relation from turbine to wind rotor #75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Here is a template for new release sections
 - geothermal energy (#739)
 - ambient thermal energy (#742)
 - has origin, renewable, anthropogenic (#742)
+- wind energy converting unit uses wind rotor (#754)
 
 ### Removed
 - has numerical input / output (#716)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -919,6 +919,8 @@ Class: OEO_00000044
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754",
         rdfs:label "wind energy converting unit"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -923,7 +923,7 @@ Class: OEO_00000044
     
     SubClassOf: 
         OEO_00000334,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000425,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
     
     
@@ -999,10 +999,10 @@ Class: OEO_00000058
     SubClassOf: 
         OEO_00000204
     
-
+    
 Class: OEO_00000061
 
-
+    
 Class: OEO_00000062
 
     Annotations: 


### PR DESCRIPTION
Wind energy converting unit had turbine as part, but there is a wind turbine/wind rotor that should be used instead. Use wind rotor as has part entity.

closes #753