### PR TITLE
add contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 
 ### Added
 - trade, market participant (#745)
+- contract (#756)
 
 ### Changed
 - trader (#745)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -809,7 +809,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "request"@en
     
     SubClassOf: 
-        OEO_00040006
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00040007

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -940,6 +940,8 @@ Class: OEO_00140109
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
         rdfs:label "contract"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -244,9 +244,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000009>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
-    EquivalentTo: 
-        OEO_00040006
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
@@ -811,8 +808,8 @@ Class: OEO_00040006
 https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "request"@en
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+    SubClassOf: 
+        OEO_00040006
     
     
 Class: OEO_00040007

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -244,6 +244,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000009>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
+    EquivalentTo: 
+        OEO_00040006
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
@@ -276,6 +279,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
@@ -805,7 +811,7 @@ Class: OEO_00040006
 https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "request"@en
     
-    SubClassOf: 
+    EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
@@ -927,6 +933,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000017>
+    
+    
+Class: OEO_00140109
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
+        rdfs:label "contract"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
 Class: OEO_00230013


### PR DESCRIPTION
solves part of #376 

- i added `contract` (_A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound._)
- the other classes had already been added in #642 (`contract` was left out because it was missing an iao-import to oeo-social, which has been fixed in the meantime)