### PR TITLE
Restructure hydro power plant and related classes #78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Here is a template for new release sections
 - trade, market participant (#745)
 - reservoir (#755)
 - contract (#756)
-- hydro power unit, hydro powerplant and subclasses (#758)
+- hydro power unit, hydro powerplant and subclasses, pump (#758)
 
 ### Changed
 - trader (#745)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - powerplant and power generating unit subclasses (#752)
 - dammed water -> dam; pumped water (#755)
 - objective function (#757)
+- water turbine (#758)
 - portion of matter (#759)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Here is a template for new release sections
 ### Added
 - trade, market participant (#745)
 - contract (#756)
+- hydro power unit, hydro powerplant and subclasses (#758)
 
 ### Changed
 - trader (#745)
@@ -30,7 +31,7 @@ Here is a template for new release sections
 - objective function (#757)
 
 ### Removed
-
+- hydroelectric dam energy transformation and run-off-river energy transformation (#758)
 
 ## [1.5.0] - 2021-05-03
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3471,6 +3471,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         OEO_00010088
     
     
+Class: OEO_00010090
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting device that converts rotational energy into energy of a moving fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "pump"@en
+    
+    SubClassOf: 
+        OEO_00000011
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3396,7 +3396,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010086
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a power plant having an aggregate of hydro power generating units as its power generating units parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a powerplant having an aggregate of hydro power generating units as its power generating units parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "hydro powerplant"@en
@@ -3411,7 +3411,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro power plant that uses the momentarily available hydro energy of a river.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "run of river powerplant"@en
@@ -3423,7 +3423,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage powerplant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage powerplant is a hydro powerplant that uses the available hydro energy of a stationary water storage.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storage powerplant",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4211,30 +4211,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00000139
     
     
-Class: OEO_00110006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Run-off-river energy transformation is an hydroelectric energy transformation that converts hydro energy of a river to electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "run-off-river energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110005
-    
-    
-Class: OEO_00110007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric dam energy transformation is an hydroelectric energy transformation that converts potential hydro energy of dammed water to electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "hydroelectric dam energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110005
-    
-    
 Class: OEO_00140000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3382,6 +3382,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735",
         OEO_00000533 some OEO_00000007
     
     
+Class: OEO_00010084
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+        rdfs:label "reservoir"@en
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00000503 some OEO_00110000,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
+    
+    
 Class: OEO_00010085
 
     Annotations: 
@@ -3420,7 +3435,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "run of river powerplant"@en
     
     SubClassOf: 
-        OEO_00010086
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
     
     
 Class: OEO_00010088
@@ -3433,7 +3449,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "hydro storage powerplant"@en
     
     SubClassOf: 
-        OEO_00010086
+        OEO_00010086,
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010084)
     
     
 Class: OEO_00010089
@@ -3446,21 +3464,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
     
     SubClassOf: 
         OEO_00010088
-
-
-Class: OEO_00010084
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
-        rdfs:label "reservoir"@en
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00000503 some OEO_00110000,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
     
     
 Class: OEO_00020001
@@ -4957,3 +4960,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3389,19 +3389,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
     
     SubClassOf: 
         OEO_00000334,
+        OEO_00000503 some OEO_00000441,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442
     
     
 Class: OEO_00010086
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating units parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a power plant having an aggregate of hydro power generating units as its power generating units parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro power plant"@en
+        rdfs:label "hydro powerplant"@en
     
     SubClassOf: 
         OEO_00000031,
+        OEO_00000503 some OEO_00000441,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010085,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
     
@@ -3409,10 +3411,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro power plant that uses the momentarily available hydro energy of a river.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "run of river power plant"@en
+        rdfs:label "run of river powerplant"@en
     
     SubClassOf: 
         OEO_00010086
@@ -3421,11 +3423,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage powerplant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storage powerplant",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro storage power plant"@en
+        rdfs:label "hydro storage powerplant"@en
     
     SubClassOf: 
         OEO_00010086

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3460,7 +3460,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010086
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a powerplant having an aggregate of hydro power generating units as its power generating units parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a powerplant having an aggregate of hydro power generating units as its power generating unit parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "hydro powerplant"@en
@@ -3507,7 +3507,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage powerplant is a hydro storage powerplant which has some pumps.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage powerplant is a hydro storage powerplant which has some pumps as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "pumped hydro storage powerplant"@en
@@ -5084,4 +5084,3 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
-

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3485,6 +3485,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         OEO_00000011
     
     
+Class: OEO_00010091
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "open-loop pumped hydro storage powerplant"@en
+    
+    SubClassOf: 
+        OEO_00010089
+    
+    
+Class: OEO_00010092
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "closed-loop pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010089
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2804,9 +2804,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684",
 Class: OEO_00000442
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting kinetic energy and potential energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "water turbine"
     
     SubClassOf: 
@@ -3434,7 +3436,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "run of river powerplant"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3483,6 +3483,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
     
     SubClassOf: 
         OEO_00010086,
+        OEO_00000503 some OEO_00010093,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
     
     
@@ -3499,7 +3500,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
     SubClassOf: 
         OEO_00010086,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010084)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010084),
+        OEO_00000503 some OEO_00110000
     
     
 Class: OEO_00010089
@@ -3535,7 +3537,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "open-loop pumped hydro storage powerplant"@en
     
     SubClassOf: 
-        OEO_00010089
+        OEO_00010089,
+        OEO_00000503 some OEO_00000345
     
     
 Class: OEO_00010092
@@ -3547,9 +3550,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "closed-loop pumped hydro storage powerplant"@en
     
     SubClassOf: 
-        OEO_00010089
-
-
+        OEO_00010089,
+        OEO_00000503 only OEO_00000345
+    
+    
 Class: OEO_00010093
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3513,7 +3513,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "pumped hydro storage powerplant"@en
     
     SubClassOf: 
-        OEO_00010088
+        OEO_00010088,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090
     
     
 Class: OEO_00010090

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3379,6 +3379,70 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735",
         OEO_00000533 some OEO_00000007
     
     
+Class: OEO_00010085
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power unit"@en
+    
+    SubClassOf: 
+        OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442
+    
+    
+Class: OEO_00010086
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating units parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power plant"@en
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
+    
+    
+Class: OEO_00010087
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "run of river power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086
+    
+    
+Class: OEO_00010088
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086
+    
+    
+Class: OEO_00010089
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010088
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3478,7 +3478,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010090
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting device that converts rotational energy into energy of a moving fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting device that converts energy into kinetic or potential energy of a fluid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "pump"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3437,6 +3437,7 @@ Class: OEO_00010087
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river powerplant and an hydro storage powerplant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "run of river powerplant"@en
@@ -3450,6 +3451,7 @@ Class: OEO_00010088
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage powerplant is a hydro powerplant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river powerplant and an hydro storage powerplant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storage powerplant",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -3464,10 +3466,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage powerplant is a hydro storage powerplant which has some pumps.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "pumped hydro storage power plant"@en
+        rdfs:label "pumped hydro storage powerplant"@en
     
     SubClassOf: 
         OEO_00010088
@@ -3488,7 +3490,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010091
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "open-loop pumped hydro storage powerplant"@en
@@ -3500,10 +3502,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010092
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has no natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "closed-loop pumped hydro storage power plant"@en
+        rdfs:label "closed-loop pumped hydro storage powerplant"@en
     
     SubClassOf: 
         OEO_00010089


### PR DESCRIPTION
Partially resolves #78 

New classes:
*  `hydro power unit`: _A hydro power unit is a power generating unit that uses hydro energy._ (analogous to wind)
relation: `has_part some water turbine`
* `hydro powerplant`: _A hydro powerplant is a powerplant having an aggregate of hydro power generating units as its power generating units parts._
`'participates in' some 'hydroelectric energy transformation'`
  * `run of river powerplant`: _A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage._ (turbine + dam + river) plus editor note
  * `hydro storage powerplant`: _A hydro storage powerplant is a hydro powerplant that uses the available hydro energy of a stationary water storage._ (turbine + dam + reservoir) plus editor note
alternative term: `storage powerplant` (turbine + dam + river)
    * `pumped hydro storage powerplant`: _A pumped hydro storage powerplant is a hydro storage powerplant which has some pumps._
      * `open-loop pumped hydro storage powerplant`: _An open-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has natural inflows._
      * `closed-loop pumped hydro storage`: _A closed-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has no natural inflows._
* `pump`: _A pump is an energy converting device that converts energy into kinetic or potential energy of a fluid._

Redefinitions:
* `water turbine`: _A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy._

Delete classes as it is basically the same process, only the power plants differ:
* `hydroelectric dam energy transformation`
* `run-off-river energy transformation`