### PR TITLE
Add class river and annotation property owl:equivalentClass #760

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Here is a template for new release sections
 - trade, market participant (#745)
 - reservoir (#755)
 - contract (#756)
+- river (#760)
 
 ### Changed
 - trader (#745)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3402,6 +3402,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
     
     
+Class: OEO_00010093
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is liquid water that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        rdfs:label "river"@en
+    
+    SubClassOf: 
+        OEO_00110000
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -4920,3 +4930,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -52,6 +52,9 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: owl:equivalentClass
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -3406,7 +3409,8 @@ Class: OEO_00010093
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A river is liquid water that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
-        rdfs:label "river"@en
+        rdfs:label "river"@en,
+        owl:equivalentClass "ENVO:00000022"
     
     SubClassOf: 
         OEO_00110000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3412,7 +3412,7 @@ Class: OEO_00010093
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765",
         rdfs:label "river"@en,
-        owl:equivalentClass "ENVO:00000022"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
     
     SubClassOf: 
         OEO_00110000,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3409,11 +3409,14 @@ Class: OEO_00010093
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A river is liquid water that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765",
         rdfs:label "river"@en,
         owl:equivalentClass "ENVO:00000022"
     
     SubClassOf: 
-        OEO_00110000
+        OEO_00110000,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110002
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -59,6 +59,9 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:identifier
 
     
+AnnotationProperty: owl:equivalentClass
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -228,6 +231,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000030>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000031>
 
     
@@ -277,8 +283,8 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artifici
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
-
-
+    
+    
 Class: OEO_00000206
 
     Annotations: 
@@ -289,8 +295,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
     
     SubClassOf: 
         OEO_00000061
-
-
+    
+    
 Class: OEO_00000350
 
     Annotations: 


### PR DESCRIPTION
closes #760 

* Add class `river`: _A river is liquid water that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply._
* Add annotation property `owl:equivalentClass`