### PR TITLE
add fluid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Here is a template for new release sections
 - hydro power unit, hydro powerplant and subclasses, pump (#758, #768)
 - river (#760)
 - analysis scope (#764)
+- fluid (#769)
 
 ### Changed
 - trader (#745)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4978,7 +4978,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140116
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid or gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
         rdfs:label "fluid"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2741,7 +2741,8 @@ Class: OEO_00000425
         rdfs:label "turbine"
     
     SubClassOf: 
-        OEO_00000011
+        OEO_00000011,
+        OEO_00000503 some OEO_00140116
     
     
 Class: OEO_00000429
@@ -3526,7 +3527,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "pump"@en
     
     SubClassOf: 
-        OEO_00000011
+        OEO_00000011,
+        OEO_00000503 some OEO_00140116
     
     
 Class: OEO_00010091
@@ -4965,6 +4967,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         OEO_00140101,
         OEO_00000532 some OEO_00000056,
         <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00140116
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid or gas.",
+        rdfs:label "fluid"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and ((OEO_00000531 value OEO_00000182) or (OEO_00000531 value OEO_00000256) or (OEO_00000531 value OEO_00000326))
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00230000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2742,6 +2742,9 @@ Class: OEO_00000425
     
     SubClassOf: 
         OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
         OEO_00000503 some OEO_00140116
     
     
@@ -3528,6 +3531,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
     
     SubClassOf: 
         OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
         OEO_00000503 some OEO_00140116
     
     
@@ -4973,6 +4979,8 @@ Class: OEO_00140116
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid or gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
         rdfs:label "fluid"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2850,11 +2850,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000139,
+        OEO_00000503 some OEO_00000218,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000503 only OEO_00000218
+        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000139
     
     
 Class: OEO_00000446

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -165,7 +165,7 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 
-   
+    
 Class: OEO_00000064
 
     
@@ -177,7 +177,7 @@ Class: OEO_00000335
     
 Class: OEO_00000340
 
-     
+    
 Class: OEO_00010021
 
     
@@ -191,7 +191,8 @@ Class: OEO_00020012
 
     SubClassOf: 
         OEO_00000506 some OEO_00000064
- 
-   
+    
+    
 Class: OEO_00140009
 
+    


### PR DESCRIPTION
closes #763

- add class `fluid`: _A fluid is a material entity which is a liquid or a gas._
- `turbine uses some fluid`
- `pump uses some fluid`
- `fluid EquivalentTo 'material entity' and ('has state of matter' value gaseous or 'has state of matter' value liquid or 'has state of matter' value plasmatic)`

I also had to change `water turbine uses only hydro energy` to `water turbine uses **some** hydro energy` because it lead to unsatisfiable classes. However, this is part of bigger problem discussed in #761.