### PR TITLE
change spelling, fix minor mistakes

### DIFF
--- a/.github/ISSUE_TEMPLATE/-c--definition-update.md
+++ b/.github/ISSUE_TEMPLATE/-c--definition-update.md
@@ -1,6 +1,6 @@
 ---
 name: "[C] Ontology definition update"
-about: For restructuring existing partsof the ontology
+about: For restructuring existing parts of the ontology
 title: Your title should make sense if said after "The issue is <your issue title>"
 labels: "[C] definition update, To do"
 assignees: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Here is a template for new release sections
 - water turbine (#758)
 - portion of matter (#759)
 - energy-related input and output relations (#766)
+- spelling convention: British labels with American synonyms (#772)
 
 ### Removed
 - hydroelectric dam energy transformation and run-off-river energy transformation (#758)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -538,8 +538,9 @@ Class: OEO_00000149
 Class: OEO_00000161
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimizer is a software external to a model that computes an optimization."^^xsd:string,
-        rdfs:label "external optimizer"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
+        rdfs:label "external optimiser"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
@@ -621,7 +622,7 @@ Class: OEO_00000264
 Class: OEO_00000274
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealized reproduction of a system and its behaviours."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
 
@@ -682,10 +683,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000279
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A modeling software is a software used to create and maintain a (mathematical) model.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
         pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
-        rdfs:label "modeling software"
+        rdfs:label "modelling software"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
@@ -716,7 +718,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
 Class: OEO_00000312
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labeling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
         rdfs:label "open source"
     
     SubClassOf: 
@@ -729,8 +731,9 @@ Class: OEO_00000312
 Class: OEO_00000313
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
-        rdfs:label "optimization"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
+        rdfs:label "optimisation"
     
     SubClassOf: 
         OEO_00000275
@@ -742,8 +745,9 @@ Class: OEO_00000313
 Class: OEO_00000314
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimization model is a model that optimizes a target function."@en,
-        rdfs:label "optimization model"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
+        rdfs:label "optimisation model"
     
     SubClassOf: 
         OEO_00000274
@@ -840,7 +844,7 @@ Class: OEO_00000367
 Class: OEO_00000370
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behavior from the real world."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
         rdfs:label "simulation"
     
     SubClassOf: 
@@ -853,7 +857,7 @@ Class: OEO_00000370
 Class: OEO_00000371
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simultaion model is a model that simulates the behaviour of a system without a target function."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
         rdfs:label "simulation model"
     
     SubClassOf: 
@@ -919,7 +923,7 @@ Class: OEO_00000392
 Class: OEO_00000403
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealized model year."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
         rdfs:label "synthetic dataset"
     
@@ -1069,6 +1073,7 @@ Class: OEO_00020019
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "primary modelling purpose"@en
@@ -1796,6 +1801,7 @@ Individual: OEO_00140046
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "center alignment",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -846,6 +846,7 @@ Class: OEO_00000038
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
         rdfs:label "sulphur hexafluoride"
     
@@ -1169,7 +1170,7 @@ Class: OEO_00000084
 Class: OEO_00000088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulfur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
         rdfs:label "coal"
     
@@ -1239,7 +1240,7 @@ Class: OEO_00000097
 Class: OEO_00000099
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         rdfs:label "combustion fuel"
@@ -1333,7 +1334,7 @@ Class: OEO_00000131
 Class: OEO_00000132
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralized location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating (also known as heat networks or teleheating) is a system for distributing heat generated in a centralised location through a system of insulated pipes for residential and commercial heating requirements such as space heating and water heating. The heat is often obtained from a cogeneration plant burning fossil fuels or biomass, but heat-only boiler stations, geothermal heating, heat pumps and central solar heating are also used, as well as heat waste from nuclear power electricity generation. "@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=District_heating&oldid=906646999"@en,
         rdfs:label "district heat"
     
@@ -1784,7 +1785,6 @@ Class: OEO_00000211
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil",
         rdfs:label "heating oil"@en
     
     SubClassOf: 
@@ -2214,7 +2214,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
 Class: OEO_00000302
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realizes its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         rdfs:label "nuclear fuel"
@@ -2559,9 +2559,10 @@ Class: OEO_00000376
 Class: OEO_00000377
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulfur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulfur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulfides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        rdfs:label "sodium-sulfur battery"
+        rdfs:label "sodium-sulphur battery"
     
     SubClassOf: 
         OEO_00000283
@@ -2672,7 +2673,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
 Class: OEO_00000396
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurized steam into rotational energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
         rdfs:label "steam turbine"
     
     SubClassOf: 
@@ -2996,6 +2997,7 @@ Class: OEO_00010007
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "sulphur dioxide"@en
@@ -4440,7 +4442,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and center-line of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         rdfs:label "hub height"@en
@@ -4633,7 +4635,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140059
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilized economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         rdfs:label "economic flow potential"@en
@@ -4705,7 +4707,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140065
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilized economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         rdfs:label "economic stock potential"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -254,7 +254,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537",
-        rdfs:comment "The original defnition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
+        rdfs:comment "The original definition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -228,7 +228,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend de
 ObjectProperty: OEO_00140017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organization where the person is a member of the organization.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
         rdfs:label "member of"@en
@@ -243,7 +243,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
 ObjectProperty: OEO_00140018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organization and a person where the person is a member of the organization.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
         rdfs:label "has member"@en
@@ -333,7 +333,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00000051
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organization that directs its activity towards achieving goals."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
         rdfs:label "agent"
@@ -461,7 +461,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000238
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organization that serves a social purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
         rdfs:label "institution"
     
     SubClassOf: 
@@ -471,10 +471,11 @@ Class: OEO_00000238
 Class: OEO_00000315
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization role is a role of an aggregate of people that has a collective goal and a set of organization rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organization role"
+        rdfs:label "organisation role"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -499,7 +500,7 @@ Class: OEO_00000323
 Class: OEO_00000329
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organization of a group of people with common views or goals that wants to have influence in politics."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
         rdfs:label "political party"
     
     SubClassOf: 
@@ -683,7 +684,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00020063
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a license that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "emission certificate"
@@ -695,7 +696,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
 Class: OEO_00020064
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 ton.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
@@ -735,7 +736,7 @@ Class: OEO_00020068
 Class: OEO_00020069
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organization that has the market exchange role.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
         rdfs:label "market exchange"
     
@@ -749,11 +750,12 @@ Class: OEO_00020069
 Class: OEO_00030016
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organizational energy producer is an organization that undertakes the generation of electricity and/or heat.\"",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organizational energy producer"
+        rdfs:label "organisational energy producer"
     
     SubClassOf: 
         OEO_00030022,
@@ -763,7 +765,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organizational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
@@ -777,7 +779,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organizational energy producer whose primary activity is electrical energy and/or heat production.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
@@ -791,10 +793,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030022
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organization is an immaterial entity that has the organization role and there exists some sort of legal framework that recognises the entity and its continued existence.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organisation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
-        rdfs:label "organization"
+        rdfs:label "organisation"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>,
@@ -804,7 +807,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421",
 Class: OEO_00040002
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organization, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
@@ -928,7 +931,7 @@ Class: OEO_00040011
 Class: OEO_00140009
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organization, or project by giving money, allowance of kind, services or other help.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
         rdfs:label "sponsor"@en
@@ -984,7 +987,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
 Class: OEO_00140040
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterized by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
         rdfs:label "demand"@en
@@ -1057,6 +1060,7 @@ Class: OEO_00230016
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301


### PR DESCRIPTION
closes #771 

I tried to match a list of British / American difference pairs with each OEO-module, changed the spelling of American terms and added alternative terms if needed. I also fixed some spelling mistakes I found.

Here is the list of terms I found:
[british-american-terms-oeo-by-module.txt](https://github.com/OpenEnergyPlatform/ontology/files/6672480/british-american-terms-oeo-by-module.txt)
