### PR TITLE
Add subclasses (public & private) funder #246

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Here is a template for new release sections
 - emission certificate (#740)
 - natural / artificial ambient thermal energy, ambient thermal energy transfer (#742)
 - energy market exchange (#748)
+- public and private funders (#246)
+
 
 ### Changed
 - has physical output, has constraint (#716)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -520,7 +520,7 @@ Class: OEO_00000350
 
     
 Class: OEO_00000367
-    
+
     
 Class: OEO_00000368
 
@@ -924,6 +924,36 @@ https://github.com/OpenEnergyPlatform/ontology/pull/643",
     
 Class: OEO_00040011
 
+    
+Class: OEO_00090001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
+        rdfs:label "funder"@en
+    
+    SubClassOf: 
+        OEO_00140009
+    
+    
+Class: OEO_00090002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
+        rdfs:label "public funder"@en
+    
+    SubClassOf: 
+        OEO_00090001
+    
+    
+Class: OEO_00090003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
+        rdfs:label "private funder"@en
+    
+    SubClassOf: 
+        OEO_00090001
+    
     
 Class: OEO_00140009
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -929,6 +929,8 @@ Class: OEO_00090001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
         rdfs:label "funder"@en
     
     SubClassOf: 
@@ -939,6 +941,8 @@ Class: OEO_00090002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
         rdfs:label "public funder"@en
     
     SubClassOf: 
@@ -949,6 +953,8 @@ Class: OEO_00090003
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
         rdfs:label "private funder"@en
     
     SubClassOf: 


### PR DESCRIPTION
Add subclasses to `sponsor`. This adds a subclass `funder` as well as the sub-subclasses `public funder` and `private funder`.

Closes #246 