### PR TITLE
add definition and axiom for geographic coordinate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ Here is a template for new release sections
 - power plant portfolio, dispatch assignment (#792)
 - yield profile, demand trader, direct marketer, merit order, full load hours (#793)
 - energy demand (#796)
-- markup, markdown #800
+- markup, markdown (#800)
 
 ### Changed
+- geographic coordinate (#803)
+
 ### Removed
 
 ## [1.6.1] - 2021-07-07

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -73,6 +73,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
     
@@ -354,6 +357,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000018>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -1687,10 +1693,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000189
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
         rdfs:label "geographic coordinate"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
+        <http://purl.obolibrary.org/obo/BFO_0000141>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
     
     
 Class: OEO_00000191

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1699,7 +1699,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
         rdfs:label "geographic coordinate"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
         <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1694,6 +1694,8 @@ Class: OEO_00000189
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
         rdfs:label "geographic coordinate"
     
     SubClassOf: 


### PR DESCRIPTION
closes #795 

I added the following definition: 
_A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system._
and the axiom `is about some zero-dimensional spatial region`