### PR TITLE
Add ID 0024 for Kai Schnepf

### DIFF
--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -37,6 +37,7 @@ Annotations:
     dc:contributor "(0015) Ulrich Frey (@litotes18)",
     dc:contributor "(0016) Christoph Muschner (@chrwm)",
     dc:contributor "(0023) Michaja Pehl (@0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q)",
+    dc:contributor "(0024) Kai Schnepf (@KaiSchnepf)",
     dc:contributor "Christian Winger (@wingechr)",
     dc:contributor "Fabian Neuhaus (@fabianneuhaus)",
     dc:contributor "Lara Christmann",


### PR DESCRIPTION
I added my ID 0024 and GitHub name as dc:contributor in the ontology header.