### PR TITLE
Marine energy and related classes #762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Here is a template for new release sections
 
 ### Changed
 - commodity (#789)
+- river (#806)
 
 ## [1.6.0] - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Here is a template for new release sections
 
 ### Changed
 - commodity (#789)
-- river (#806)
 
 ## [1.6.0] - 2021-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Here is a template for new release sections
 - energy demand (#796)
 - policy, policy instrument, transformative measure (#797)
 - markup, markdown (#800)
+- ocean/marine energy related classes (#806)
 
 ### Changed
 - battery and subclasses (#801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Here is a template for new release sections
 - energy demand (#796)
 - policy, policy instrument, transformative measure (#797)
 - markup, markdown (#800)
-- ocean/marine energy related classes (#806)
+- ocean/marine energy and water (flow) related classes (#806)
 
 ### Changed
 - battery and subclasses (#801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Here is a template for new release sections
 - energy demand (#796)
 - policy, policy instrument, transformative measure (#797)
 - markup, markdown (#800)
-- ocean/marine energy and water (flow) related classes (#806)
+- ocean/marine energy and water (flow) related classes including power generating units and powerplants (#806)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3765,7 +3765,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010097
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the hydro energy of moving marine water.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the hydro energy of an ocean current.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy"@en
@@ -3784,6 +3784,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010107
     
@@ -3830,10 +3831,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010102
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the hydro energy of a tidal flow.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy"@en,
-        owl:equivalentClass "Marine current energy is the hydro energy of moving marine water."
+        rdfs:label "marine wave energy"@en
     
     SubClassOf: 
         OEO_00000218
@@ -3843,7 +3844,7 @@ Class: OEO_00010103
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine wave energy transformation"@en
     
@@ -3895,6 +3896,8 @@ Class: OEO_00010107
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "ocean current"@en
     
     SubClassOf: 
@@ -3908,6 +3911,9 @@ Class: OEO_00010108
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy converting unit"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
     
     SubClassOf: 
         OEO_00010085
@@ -3923,7 +3929,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
     
     
 Class: OEO_00010110
@@ -3949,7 +3955,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010108
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010108,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
     
     
 Class: OEO_00010112
@@ -3976,7 +3983,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010110
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010110,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3922,7 +3922,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine tidal energy converting unit"@en
     
     SubClassOf: 
-        OEO_00010085
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
     
     
 Class: OEO_00010110
@@ -3934,7 +3935,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine wave energy converting unit"@en
     
     SubClassOf: 
-        OEO_00010085
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
     
     
 Class: OEO_00010111
@@ -3960,7 +3962,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010109
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010109,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
     
     
 Class: OEO_00010113

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1867,7 +1867,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681",
         rdfs:label "hydro energy"
     
     SubClassOf: 
-        OEO_00230020
+        OEO_00230020,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
+        OEO_00000503 some OEO_00110002
     
     
 Class: OEO_00000219
@@ -3786,7 +3790,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy"@en
     
     SubClassOf: 
-        OEO_00000218
+        OEO_00000218,
+        OEO_00000503 some OEO_00010107
     
     
 Class: OEO_00010098
@@ -3799,6 +3804,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
+        OEO_00000532 some OEO_00010097,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010107
     
@@ -3813,6 +3819,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
+        OEO_00000532 some OEO_00010100,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010101
     
@@ -3826,7 +3833,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine tidal energy"@en
     
     SubClassOf: 
-        OEO_00000218
+        OEO_00000218,
+        OEO_00000503 some OEO_00010101
     
     
 Class: OEO_00010101
@@ -3845,13 +3853,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010102
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the hydro energy of a tidal flow.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the hydro energy of a wave.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine wave energy"@en
     
     SubClassOf: 
-        OEO_00000218
+        OEO_00000218,
+        OEO_00000503 some OEO_00010106
     
     
 Class: OEO_00010103
@@ -3864,6 +3873,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
+        OEO_00000532 some OEO_00010102,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010106
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3927,11 +3927,9 @@ Class: OEO_00010108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy converting unit"@en
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
-    
     SubClassOf: 
-        OEO_00010085
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
     
     
 Class: OEO_00010109

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3799,7 +3799,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010107
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3758,7 +3758,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine thermal energy transfer"@en
     
     SubClassOf: 
-        OEO_00140101
+        OEO_00140101,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105
     
     
 Class: OEO_00010097
@@ -3782,7 +3783,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy transformation"@en
     
     SubClassOf: 
-        OEO_00110005
+        OEO_00110005,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010107
     
     
 Class: OEO_00010099
@@ -3794,7 +3797,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine tidal energy transformation"@en
     
     SubClassOf: 
-        OEO_00110005
+        OEO_00110005,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010101
     
     
 Class: OEO_00010100
@@ -3843,7 +3848,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine wave energy transformation"@en
     
     SubClassOf: 
-        OEO_00110005
+        OEO_00110005,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010106
     
     
 Class: OEO_00010104
@@ -3939,7 +3946,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine current energy powerplant"@en
     
     SubClassOf: 
-        OEO_00010086
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010108
     
     
 Class: OEO_00010112
@@ -3951,7 +3959,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine tidal energy powerplant"@en
     
     SubClassOf: 
-        OEO_00010086
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010109
     
     
 Class: OEO_00010113
@@ -3963,7 +3972,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine wave energy powerplant"@en
     
     SubClassOf: 
-        OEO_00010086
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010110
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3737,6 +3737,8 @@ Class: OEO_00010095
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine thermal energy"@en
     
     SubClassOf: 
@@ -3747,10 +3749,95 @@ Class: OEO_00010096
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "marine thermal energy transfer"@en
     
     SubClassOf: 
         OEO_00140101
+    
+    
+Class: OEO_00010097
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the hydro energy of moving marine water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy"@en
+    
+    SubClassOf: 
+        OEO_00000218
+    
+    
+Class: OEO_00010098
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005
+    
+    
+Class: OEO_00010099
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005
+    
+    
+Class: OEO_00010100
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the hydro energy of a tidal flow.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy"@en
+    
+    SubClassOf: 
+        OEO_00000218
+    
+    
+Class: OEO_00010101
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
+        rdfs:label "tidal flow"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00010102
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy"@en,
+        owl:equivalentClass "Marine current energy is the hydro energy of moving marine water."
+    
+    SubClassOf: 
+        OEO_00000218
+    
+    
+Class: OEO_00010103
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3709,14 +3709,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010093
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is liquid water that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
+
+Make river a subclass of water body:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "river"@en,
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
     
     SubClassOf: 
-        OEO_00110000,
+        OEO_00010104,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110002
     
     
@@ -3809,11 +3813,13 @@ Class: OEO_00010101
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         rdfs:label "tidal flow"@en,
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        OEO_00110002
     
     
 Class: OEO_00010102
@@ -3838,6 +3844,54 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005
+    
+    
+Class: OEO_00010104
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "water body"@en
+    
+    SubClassOf: 
+        OEO_00110000
+    
+    
+Class: OEO_00010105
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "ocean"@en
+    
+    SubClassOf: 
+        OEO_00010104
+    
+    
+Class: OEO_00010106
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "wave"@en
+    
+    SubClassOf: 
+        OEO_00110002
+    
+    
+Class: OEO_00010107
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
+        rdfs:label "ocean current"@en
+    
+    SubClassOf: 
+        OEO_00110002
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3733,6 +3733,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
         not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090)
     
     
+Class: OEO_00010095
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
+        rdfs:label "marine thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00140104
+    
+    
+Class: OEO_00010096
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
+        rdfs:label "marine thermal energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00140101
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -5414,3 +5434,4 @@ Individual: OEO_00000390
     
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
+

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3894,6 +3894,78 @@ Class: OEO_00010107
         OEO_00110002
     
     
+Class: OEO_00010108
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085
+    
+    
+Class: OEO_00010109
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085
+    
+    
+Class: OEO_00010110
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085
+    
+    
+Class: OEO_00010111
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy powerplant is a powerplant that has marine current energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy powerplant"@en
+    
+    SubClassOf: 
+        OEO_00010086
+    
+    
+Class: OEO_00010112
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy powerplant is a powerplant that has marine tidal energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy powerplant"@en
+    
+    SubClassOf: 
+        OEO_00010086
+    
+    
+Class: OEO_00010113
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy powerplant is a powerplant that has marine wave energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy powerplant"@en
+    
+    SubClassOf: 
+        OEO_00010086
+    
+    
 Class: OEO_00020001
 
     Annotations: 


### PR DESCRIPTION
New classes:
* Subclasses of `energy`:
  * `marine thermal energy`
  * `marine current energy`
  * `marine tidal energy`
  * `marine wave energy`
* Subclasses of `energy transformation`:
  * `marine thermal energy transfer`
  * `marine current energy transformation`
  * `marine tidal energy transformation`
  * `marine wave energy transformation`
* Subclasses of `water flow`:
  * `tidal flow`
  * `wave`
  * `ocean current`
* Subclasses of `liquid water`:
  * `water body`
    * `ocean`
* Subclasses of `hydro power unit`:
  * `marine current energy converting unit`
  * `marine tidal energy converting unit`
  * `marine wave energy converting unit`
* Subclasses of `hydro powerplant`:
  * `marine current energy powerplant`
  * `marine tidal energy powerplant`
  * `marine wave energy powerplant`

Changed class:
* `river`: now a subclass of `water body`

Closes #762.