### PR TITLE
add cooperative programming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - markup, markdown (#800)
 - syngas, hydrocarbon (#805)
 - ocean/marine energy and water (flow) related classes including power generating units and powerplants (#806)
+- cooperative programming (#808)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1464,6 +1464,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         OEO_00140138
     
     
+Class: OEO_00140161
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative Programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
+        rdfs:label "cooperative programming"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1469,6 +1469,8 @@ Class: OEO_00140161
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative Programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
+https://github.com/OpenEnergyPlatform/ontology/pull/808",
         rdfs:label "cooperative programming"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1467,7 +1467,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140161
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative Programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
 https://github.com/OpenEnergyPlatform/ontology/pull/808",


### PR DESCRIPTION
closes #254 

I added `cooperative programming`: _Cooperative Programming is the process of two or more people working on program code together at the same time (according to a specified routine)._
- alternative term: _collaborative programming_