### PR TITLE
add ENVO mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Here is a template for new release sections
 - syngas, hydrocarbon (#805)
 - ocean/marine energy and water (flow) related classes including power generating units and powerplants (#806)
 - cooperative programming (#808)
+- mapping to ENVO (#810)
+- power plant with electromotive generator (#810)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -49,6 +49,9 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: owl:equivalentClass
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -1315,7 +1318,8 @@ Class: OEO_00030034
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "time series"
+        rdfs:label "time series",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>,

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1319,6 +1319,9 @@ Class: OEO_00030034
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         rdfs:label "time series",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -432,6 +432,9 @@ Class: OEO_00000001
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
         rdfs:label "fuel role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
     
     SubClassOf: 
@@ -447,6 +450,9 @@ Class: OEO_00000003
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000072,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
     
     
@@ -480,6 +486,9 @@ Class: OEO_00000006
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
         rdfs:label "carbon dioxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
     
     SubClassOf: 
@@ -495,6 +504,9 @@ Class: OEO_00000007
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
         rdfs:label "chemical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
     
     SubClassOf: 
@@ -512,6 +524,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000088,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
@@ -631,6 +646,9 @@ Class: OEO_00000017
         OEO_00000503 some 
             (OEO_00000173
              and (OEO_00000529 value OEO_00000182)),
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
     
     
@@ -644,6 +662,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000334,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
@@ -687,6 +708,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000220,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
     
@@ -711,6 +735,9 @@ Class: OEO_00000025
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
         rdfs:label "methane",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
     
     SubClassOf: 
@@ -741,6 +768,9 @@ Class: OEO_00000027
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
         rdfs:label "nitrous oxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
     
     SubClassOf: 
@@ -772,6 +802,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000302,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
@@ -785,6 +818,9 @@ Class: OEO_00000030
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000309,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
@@ -926,6 +962,9 @@ Class: OEO_00000040
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         rdfs:label "uranium",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
     
     SubClassOf: 
@@ -947,6 +986,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000439,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
@@ -958,6 +1000,9 @@ Class: OEO_00000042
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
         rdfs:label "waste role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
     
     SubClassOf: 
@@ -971,6 +1016,9 @@ Class: OEO_00000043
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
         rdfs:label "wind",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
     
     SubClassOf: 
@@ -993,6 +1041,9 @@ Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754",
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         OEO_00000503 some OEO_00000446,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
@@ -1023,6 +1074,9 @@ Class: OEO_00000054
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684",
         rdfs:label "air",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
     
     SubClassOf: 
@@ -1042,6 +1096,9 @@ Class: OEO_00000055
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
         rdfs:label "air pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
     
     SubClassOf: 
@@ -1068,6 +1125,9 @@ Class: OEO_00000058
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
         rdfs:label "anthracite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
     
     SubClassOf: 
@@ -1180,6 +1240,9 @@ Class: OEO_00000074
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
         rdfs:label "biogas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
     
     SubClassOf: 
@@ -1226,6 +1289,9 @@ Class: OEO_00000084
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "charcoal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
     
     SubClassOf: 
@@ -1243,6 +1309,9 @@ Class: OEO_00000088
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
         rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
         rdfs:label "coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
     
     SubClassOf: 
@@ -1260,6 +1329,9 @@ Class: OEO_00000089
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "coal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
     
     SubClassOf: 
@@ -1430,6 +1502,9 @@ alternative term electricity:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621",
         rdfs:label "electrical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
     
     SubClassOf: 
@@ -1522,6 +1597,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
         rdfs:comment "Energy is power integrated over time.",
         rdfs:label "energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
     
     SubClassOf: 
@@ -1745,6 +1823,9 @@ Class: OEO_00000191
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         rdfs:label "geothermal energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
     
     SubClassOf: 
@@ -1759,6 +1840,9 @@ Class: OEO_00000192
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "geothermal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
     
     SubClassOf: 
@@ -1773,6 +1857,9 @@ Class: OEO_00000198
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "greenhouse effect disposition",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
     
     SubClassOf: 
@@ -1845,6 +1932,9 @@ Class: OEO_00000207
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
         rdfs:label "thermal energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
     
     SubClassOf: 
@@ -1925,6 +2015,9 @@ Class: OEO_00000220
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
         rdfs:label "hydrogen",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
     
     SubClassOf: 
@@ -2045,6 +2138,9 @@ Class: OEO_00000251
 
 This includes the portion of the oil shale or tar sands consumed in the transformation process.",
         rdfs:label "lignite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
     
     SubClassOf: 
@@ -2063,6 +2159,9 @@ Class: OEO_00000252
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "lignite power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
     
     SubClassOf: 
@@ -2214,6 +2313,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
 
 It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
         rdfs:label "natural gas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
     
     SubClassOf: 
@@ -2300,6 +2402,9 @@ convertion to nuclear binding energy
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
         rdfs:label "nuclear binding energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
     
     SubClassOf: 
@@ -2330,6 +2435,9 @@ Class: OEO_00000303
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "nuclear power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
     
     SubClassOf: 
@@ -2358,6 +2466,9 @@ Class: OEO_00000309
 It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
         rdfs:label "oil and petroleum products",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002985"
     
     SubClassOf: 
@@ -2417,6 +2528,9 @@ Class: OEO_00000318
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "particulate matter",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
     
     SubClassOf: 
@@ -2433,6 +2547,9 @@ Class: OEO_00000320
 This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "peat",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
     
     SubClassOf: 
@@ -2475,6 +2592,9 @@ Class: OEO_00000330
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
     
     SubClassOf: 
@@ -2711,6 +2831,9 @@ Class: OEO_00000386
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "solar power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
     
     SubClassOf: 
@@ -2844,6 +2967,9 @@ Class: OEO_00000401
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "sub bituminous coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
     
     SubClassOf: 
@@ -2920,6 +3046,9 @@ Class: OEO_00000437
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "volatile organic compound",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
     
     EquivalentTo: 
@@ -2970,6 +3099,9 @@ Class: OEO_00000441
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
         <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
@@ -2978,6 +3110,9 @@ add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684",
         rdfs:label "water",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
     
     SubClassOf: 
@@ -3094,6 +3229,9 @@ Class: OEO_00010000
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "ammonia"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
     
     SubClassOf: 
@@ -3110,6 +3248,9 @@ Class: OEO_00010001
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "carbon monoxide"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
     
     SubClassOf: 
@@ -3126,6 +3267,9 @@ Class: OEO_00010002
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "nitrogen oxides"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
     
     SubClassOf: 
@@ -3186,6 +3330,9 @@ Class: OEO_00010009
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "PM10"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
     
     SubClassOf: 
@@ -3200,6 +3347,9 @@ Class: OEO_00010010
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "PM2.5"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
     
     SubClassOf: 
@@ -3376,6 +3526,9 @@ Class: OEO_00010023
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
         rdfs:label "vehicle"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
     
     SubClassOf: 
@@ -3504,6 +3657,9 @@ Class: OEO_00010032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A motor is an energy converting device that converts other forms of energy into rotational kinetic energy.",
         rdfs:label "motor",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
     
     SubClassOf: 
@@ -4064,6 +4220,9 @@ Class: OEO_00020001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
@@ -4072,6 +4231,9 @@ axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
         rdfs:label "ethanol"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
     
     SubClassOf: 
@@ -4204,6 +4366,9 @@ Class: OEO_00020037
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
         rdfs:label "radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
     
     SubClassOf: 
@@ -4218,6 +4383,9 @@ Class: OEO_00020038
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
         rdfs:label "solar radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
     
     SubClassOf: 
@@ -4247,6 +4415,9 @@ Class: OEO_00020040
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
         rdfs:label "radiative energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
     
     SubClassOf: 
@@ -4279,6 +4450,9 @@ Class: OEO_00020045
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
         rdfs:label "potential energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
     
     SubClassOf: 
@@ -5647,6 +5821,8 @@ Class: OEO_00140162
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
         rdfs:label "power plant with electro motive generator"@en,
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
     
@@ -5723,6 +5899,9 @@ Class: OEO_00230020
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
         rdfs:label "kinetic energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
     
     SubClassOf: 
@@ -5740,6 +5919,9 @@ add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684"@en,
         rdfs:label "photon"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -431,7 +431,8 @@ Class: OEO_00000001
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
-        rdfs:label "fuel role"
+        rdfs:label "fuel role",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -445,16 +446,17 @@ Class: OEO_00000003
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000072
+        OEO_00000503 some OEO_00000072,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
     
     
 Class: OEO_00000004
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas powerplant is a biofuel powerplant that has biogas power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biogas powerplant"
+        rdfs:label "biogas power plant"
     
     SubClassOf: 
         OEO_00000073,
@@ -477,7 +479,8 @@ Class: OEO_00000006
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide"
+        rdfs:label "carbon dioxide",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
     
     SubClassOf: 
         OEO_00000331,
@@ -491,7 +494,8 @@ Class: OEO_00000007
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
-        rdfs:label "chemical energy"
+        rdfs:label "chemical energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
     
     SubClassOf: 
         OEO_00000150
@@ -508,6 +512,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000088,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
@@ -625,7 +630,8 @@ Class: OEO_00000017
         OEO_00000334,
         OEO_00000503 some 
             (OEO_00000173
-             and (OEO_00000529 value OEO_00000182))
+             and (OEO_00000529 value OEO_00000182)),
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
     
     
 Class: OEO_00000019
@@ -638,6 +644,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     
     SubClassOf: 
         OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
@@ -680,6 +687,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000220,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
     
     
@@ -702,7 +710,8 @@ Class: OEO_00000025
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "methane"
+        rdfs:label "methane",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
     
     SubClassOf: 
         OEO_00140159,
@@ -731,7 +740,8 @@ Class: OEO_00000027
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
-        rdfs:label "nitrous oxide"
+        rdfs:label "nitrous oxide",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
     
     SubClassOf: 
         OEO_00000331,
@@ -762,6 +772,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000302,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
@@ -774,13 +785,14 @@ Class: OEO_00000030
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000309,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
 Class: OEO_00000031
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A powerplant is an artificial object consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an artificial object consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
 
@@ -789,7 +801,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646",
-        rdfs:label "powerplant"
+        rdfs:label "power plant"
     
     SubClassOf: 
         OEO_00000061,
@@ -862,10 +874,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000036
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass powerplant is a biofuel powerplant that has solid biomass power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solid biomass powerplant"
+        rdfs:label "solid biomass power plant"
     
     SubClassOf: 
         OEO_00000073,
@@ -913,7 +925,8 @@ Class: OEO_00000040
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium"
+        rdfs:label "uranium",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
     
     SubClassOf: 
         OEO_00000331,
@@ -934,6 +947,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
     SubClassOf: 
         OEO_00000334,
         OEO_00000503 some OEO_00000439,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
     
     
@@ -943,7 +957,8 @@ Class: OEO_00000042
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:label "waste role"
+        rdfs:label "waste role",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -955,7 +970,8 @@ Class: OEO_00000043
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind"
+        rdfs:label "wind",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -977,6 +993,7 @@ Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754",
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         OEO_00000503 some OEO_00000446,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
     
@@ -1005,7 +1022,8 @@ Class: OEO_00000054
         <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684",
-        rdfs:label "air"
+        rdfs:label "air",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
     
     SubClassOf: 
         OEO_00000331,
@@ -1023,7 +1041,8 @@ Class: OEO_00000055
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution"
+        rdfs:label "air pollution",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
     
     SubClassOf: 
         OEO_00000330,
@@ -1048,7 +1067,8 @@ Class: OEO_00000058
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite"
+        rdfs:label "anthracite",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
     
     SubClassOf: 
         OEO_00000204
@@ -1145,10 +1165,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400",
 Class: OEO_00000073
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel powerplant is a powerplant that has biofuel power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biofuel powerplant"
+        rdfs:label "biofuel power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -1159,7 +1179,8 @@ Class: OEO_00000074
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas is a biofuel which has a gaseous state and is composed principally of methane and carbon dioxide produced by anaerobic digestion of biomass. It is used as a biofuel.",
-        rdfs:label "biogas"
+        rdfs:label "biogas",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
     
     SubClassOf: 
         OEO_00000072,
@@ -1204,7 +1225,8 @@ Class: OEO_00000084
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter consisting of the solid residue of the destructive distillation and pyrolysis of wood and other vegetal material.It is used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "charcoal"
+        rdfs:label "charcoal",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
     
     SubClassOf: 
         OEO_00000331,
@@ -1217,9 +1239,11 @@ Class: OEO_00000084
 Class: OEO_00000088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams. Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:label "coal"
+        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
+        rdfs:label "coal",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
     
     SubClassOf: 
         OEO_00000331,
@@ -1232,10 +1256,11 @@ Class: OEO_00000088
 Class: OEO_00000089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal powerplant is a powerplant that has coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal powerplant"
+        rdfs:label "coal power plant",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
     
     SubClassOf: 
         OEO_00000031,
@@ -1404,7 +1429,8 @@ pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
 alternative term electricity:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621",
-        rdfs:label "electrical energy"
+        rdfs:label "electrical energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
     
     SubClassOf: 
         OEO_00000150
@@ -1495,7 +1521,8 @@ update definition
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
         rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
+        rdfs:label "energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -1530,9 +1557,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
 Class: OEO_00000165
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic powerplant (also: solar farm, solar park) is a photovoltaic powerplant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
-        rdfs:label "field photovoltaic powerplant"
+        rdfs:label "field photovoltaic power plant"
     
     SubClassOf: 
         OEO_00000324
@@ -1576,10 +1603,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00000174
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled powerplant is a powerplant that has fueled power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled powerplant"
+        rdfs:label "fueled power plant"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
@@ -1634,10 +1661,10 @@ Class: OEO_00000183
 Class: OEO_00000184
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas powerplant is a powerplant that has gas fired power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "gas powerplant"
+        rdfs:label "gas power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -1717,7 +1744,8 @@ Class: OEO_00000191
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "geothermal energy"
+        rdfs:label "geothermal energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
     
     SubClassOf: 
         OEO_00000207,
@@ -1727,10 +1755,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
 Class: OEO_00000192
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal powerplant is a powerplant that has geothermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal powerplant"
+        rdfs:label "geothermal power plant",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
     
     SubClassOf: 
         OEO_00000031,
@@ -1743,7 +1772,8 @@ Class: OEO_00000198
         <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse effect disposition"
+        rdfs:label "greenhouse effect disposition",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -1798,10 +1828,10 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal powerplant is a coal powerplant that has hard coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hard coal powerplant"
+        rdfs:label "hard coal power plant"
     
     SubClassOf: 
         OEO_00000089,
@@ -1814,7 +1844,8 @@ Class: OEO_00000207
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "thermal energy"@en
+        rdfs:label "thermal energy"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
     
     SubClassOf: 
         OEO_00000150
@@ -1893,7 +1924,8 @@ Class: OEO_00000220
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen"
+        rdfs:label "hydrogen",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
     
     SubClassOf: 
         OEO_00000331,
@@ -1905,10 +1937,10 @@ Class: OEO_00000220
 Class: OEO_00000221
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen powerplant is a powerplant that has hydrogen power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hydrogen powerplant"
+        rdfs:label "hydrogen power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2007,13 +2039,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000251
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis.	
-
-Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "lignite"
+        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process.",
+        rdfs:label "lignite",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
     
     SubClassOf: 
         OEO_00000088,
@@ -2027,10 +2059,11 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
 Class: OEO_00000252
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite powerplant is a coal powerplant that has lignite power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "lignite powerplant"
+        rdfs:label "lignite power plant",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
     
     SubClassOf: 
         OEO_00000089,
@@ -2173,15 +2206,15 @@ Class: OEO_00000290
 Class: OEO_00000292
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane.
-
-It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "natural gas"
+        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
+        rdfs:label "natural gas",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
     
     SubClassOf: 
         OEO_00000331,
@@ -2266,7 +2299,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 convertion to nuclear binding energy
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear binding energy"
+        rdfs:label "nuclear binding energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
     
     SubClassOf: 
         OEO_00000150
@@ -2292,10 +2326,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000303
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear powerplant is a powerplant that has nuclear power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear powerplant"
+        rdfs:label "nuclear power plant",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
     
     SubClassOf: 
         OEO_00000031,
@@ -2322,7 +2357,8 @@ Class: OEO_00000309
 
 It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
-        rdfs:label "oil and petroleum products"
+        rdfs:label "oil and petroleum products",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002985"
     
     SubClassOf: 
         OEO_00000331,
@@ -2338,10 +2374,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
 Class: OEO_00000310
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil powerplant is a powerplant that has oil power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "oil powerplant"
+        rdfs:label "oil power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2380,7 +2416,8 @@ Class: OEO_00000318
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter"
+        rdfs:label "particulate matter",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
     
     SubClassOf: 
         OEO_00000331,
@@ -2395,7 +2432,8 @@ Class: OEO_00000320
 
 This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "peat"
+        rdfs:label "peat",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
     
     SubClassOf: 
         OEO_00000331,
@@ -2420,10 +2458,10 @@ Class: OEO_00000322
 Class: OEO_00000324
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic powerplant is a solar powerplant that has PV panels as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "photovoltaic powerplant"
+        rdfs:label "photovoltaic power plant"
     
     SubClassOf: 
         OEO_00000386,
@@ -2436,7 +2474,8 @@ Class: OEO_00000330
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution"
+        rdfs:label "pollution",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
     
     SubClassOf: 
         OEO_00000147
@@ -2596,8 +2635,8 @@ Class: OEO_00000356
 Class: OEO_00000361
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic powerplant is a photovoltaic powerplant that is installed on top of the roof of a building."@en,
-        rdfs:label "rooftop photovoltaic powerplant"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic power plant"
     
     SubClassOf: 
         OEO_00000324
@@ -2668,10 +2707,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
 Class: OEO_00000386
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar powerplant is a powerplant that has solar power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar power plant"
+        rdfs:label "solar power plant",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
     
     SubClassOf: 
         OEO_00000031,
@@ -2716,10 +2756,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000389
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal powerplant is a solar powerplant that has solar thermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar thermal powerplant"
+        rdfs:label "solar thermal power plant"
     
     SubClassOf: 
         OEO_00000386,
@@ -2803,7 +2843,8 @@ Class: OEO_00000401
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal"
+        rdfs:label "sub bituminous coal",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
     
     SubClassOf: 
         OEO_00000088
@@ -2878,7 +2919,8 @@ Class: OEO_00000437
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound"
+        rdfs:label "volatile organic compound",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
     
     EquivalentTo: 
         OEO_00000025 or OEO_00000298
@@ -2914,10 +2956,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
 Class: OEO_00000440
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste powerplant is a powerplant that has waste power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "waste powerplant"
+        rdfs:label "waste power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2928,13 +2970,15 @@ Class: OEO_00000441
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
         <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
 add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684",
-        rdfs:label "water"
+        rdfs:label "water",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
     
     SubClassOf: 
         OEO_00000331,
@@ -2993,7 +3037,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
 Class: OEO_00000447
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a powerplant that has wind energy converting units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "wind farm"
@@ -3049,7 +3093,8 @@ Class: OEO_00010000
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "ammonia"@en
+        rdfs:label "ammonia"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
     
     SubClassOf: 
         OEO_00000331,
@@ -3064,7 +3109,8 @@ Class: OEO_00010001
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en
+        rdfs:label "carbon monoxide"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
     
     SubClassOf: 
         OEO_00000331,
@@ -3079,7 +3125,8 @@ Class: OEO_00010002
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en
+        rdfs:label "nitrogen oxides"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
     
     SubClassOf: 
         OEO_00000331,
@@ -3138,7 +3185,8 @@ Class: OEO_00010009
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en
+        rdfs:label "PM10"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
     
     SubClassOf: 
         OEO_00000318
@@ -3151,7 +3199,8 @@ Class: OEO_00010010
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en
+        rdfs:label "PM2.5"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
     
     SubClassOf: 
         OEO_00000318
@@ -3326,7 +3375,8 @@ Class: OEO_00010023
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artifical object that is used for transporting people or goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle"@en
+        rdfs:label "vehicle"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
     
     SubClassOf: 
         OEO_00000061
@@ -3453,7 +3503,8 @@ Class: OEO_00010032
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A motor is an energy converting device that converts other forms of energy into rotational kinetic energy.",
-        rdfs:label "motor"
+        rdfs:label "motor",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
     
     SubClassOf: 
         OEO_00000011,
@@ -3621,10 +3672,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010086
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro powerplant is a powerplant having an aggregate of hydro power generating units as its power generating unit parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro powerplant"@en
+        rdfs:label "hydro power plant"@en
     
     SubClassOf: 
         OEO_00000031,
@@ -3636,11 +3687,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river powerplant is a hydro powerplant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river powerplant and an hydro storage powerplant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and an hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "run of river powerplant"@en
+        rdfs:label "run of river power plant"@en
     
     SubClassOf: 
         OEO_00010086,
@@ -3651,12 +3702,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010088
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage powerplant is a hydro powerplant that uses the available hydro energy of a stationary water storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river powerplant and an hydro storage powerplant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storage powerplant",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and an hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro storage powerplant"@en
+        rdfs:label "hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010086,
@@ -3668,10 +3719,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage powerplant is a hydro storage powerplant which has some pumps as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "pumped hydro storage powerplant"@en
+        rdfs:label "pumped hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010088,
@@ -3702,10 +3753,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010091
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "open-loop pumped hydro storage powerplant"@en
+        rdfs:label "open-loop pumped hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010089,
@@ -3715,10 +3766,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010092
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage powerplant is a pumped hydro storage powerplant that has no natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "closed-loop pumped hydro storage powerplant"@en
+        rdfs:label "closed-loop pumped hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010089,
@@ -3746,10 +3797,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010094
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage powerplant is a hydro storage powerplant that has no pump.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
-        rdfs:label "reservoir hydro storage powerplant"@en
+        rdfs:label "reservoir hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010088,
@@ -3970,10 +4021,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010111
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy powerplant is a powerplant that has marine current energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine current energy powerplant"@en
+        rdfs:label "marine current energy power plant"@en
     
     SubClassOf: 
         OEO_00010086,
@@ -3984,10 +4035,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010112
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy powerplant is a powerplant that has marine tidal energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine tidal energy powerplant"@en
+        rdfs:label "marine tidal energy power plant"@en
     
     SubClassOf: 
         OEO_00010086,
@@ -3998,10 +4049,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010113
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy powerplant is a powerplant that has marine wave energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy powerplant"@en
+        rdfs:label "marine wave energy power plant"@en
     
     SubClassOf: 
         OEO_00010086,
@@ -4013,13 +4064,15 @@ Class: OEO_00020001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
 axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
-        rdfs:label "ethanol"@en
+        rdfs:label "ethanol"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
     
     SubClassOf: 
         OEO_00000331,
@@ -4150,7 +4203,8 @@ Class: OEO_00020037
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "radiation"
+        rdfs:label "radiation",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -4163,7 +4217,8 @@ Class: OEO_00020038
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "solar radiation"
+        rdfs:label "solar radiation",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
     
     SubClassOf: 
         OEO_00020037
@@ -4191,7 +4246,8 @@ Class: OEO_00020040
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
-        rdfs:label "radiative energy"
+        rdfs:label "radiative energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
     
     SubClassOf: 
         OEO_00000150
@@ -4222,7 +4278,8 @@ Class: OEO_00020045
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy"
+        rdfs:label "potential energy",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
     
     SubClassOf: 
         OEO_00000150
@@ -5586,6 +5643,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
+Class: OEO_00140162
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
+        rdfs:label "power plant with electro motive generator"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010)
+    
+    SubClassOf: 
+        OEO_00000031
+    
+    
 Class: OEO_00230000
 
     Annotations: 
@@ -5650,7 +5722,8 @@ Class: OEO_00230020
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "kinetic energy"@en
+        rdfs:label "kinetic energy"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
     
     SubClassOf: 
         OEO_00000150
@@ -5666,7 +5739,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
 add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684"@en,
-        rdfs:label "photon"@en
+        rdfs:label "photon"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
     
     SubClassOf: 
         OEO_00000331,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -767,6 +767,10 @@ Class: OEO_00000027
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
         rdfs:label "nitrous oxide",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -320,6 +320,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
         rdfs:label "quantity value",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
     
     SubClassOf: 
@@ -499,6 +502,9 @@ Class: OEO_00140003
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
         rdfs:label "transport"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -319,7 +319,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value"
+        rdfs:label "quantity value",
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
@@ -497,7 +498,8 @@ Class: OEO_00140003
         <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "transport"@en
+        rdfs:label "transport"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -139,7 +139,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000016>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
-
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
@@ -166,6 +165,12 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
+
+    
+Class: OEO_00000010
+
+    
+Class: OEO_00000031
 
     
 Class: OEO_00000064
@@ -196,3 +201,5 @@ Class: OEO_00020012
     
     
 Class: OEO_00140009
+    
+    

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -167,12 +167,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 
     
-Class: OEO_00000010
-
-    
-Class: OEO_00000031
-
-    
 Class: OEO_00000064
 
     
@@ -201,5 +195,3 @@ Class: OEO_00020012
     
     
 Class: OEO_00140009
-    
-    


### PR DESCRIPTION
closes #636 

- add owl:equivalentClasses axioms
- split up definitions of `coal`, `lignite` and `natural gas` into a definition and comment part
- add chemical formulas as alternative term to `ethanol`, `water`
- add class `power plant with electromotive generator` and corresponding axioms
- change spelling of `powerplant` to `power plant`