### PR TITLE
Add models-relationship

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -619,7 +619,7 @@ Class: OEO_00000239
     
     
 Class: OEO_00000274
-    
+
     
 Class: OEO_00000275
 
@@ -737,7 +737,8 @@ Class: OEO_00000314
         rdfs:label "optimisation model"
     
     SubClassOf: 
-        OEO_00000274
+        OEO_00000274,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304
     
     
 Class: OEO_00000327
@@ -848,7 +849,8 @@ Class: OEO_00000371
         rdfs:label "simulation model"
     
     SubClassOf: 
-        OEO_00000274
+        OEO_00000274,
+        not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304)
     
     
 Class: OEO_00000372
@@ -932,7 +934,7 @@ Class: OEO_00000408
     
     
 Class: OEO_00000419
-    
+
     
 Class: OEO_00000432
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -262,19 +262,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
         OEO_00000206
     
     
-ObjectProperty: OEO_00140164
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the system it reproduces.",
-        rdfs:label "models"@en
-    
-    Domain: 
-        OEO_00000274
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -631,29 +618,7 @@ Class: OEO_00000239
         <http://purl.obolibrary.org/obo/IAO_0000010>
     
     
-Class: OEO_00000264
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market model is a model is about the EnergyMarket."^^xsd:string,
-        rdfs:label "market model"
-    
-    SubClassOf: 
-        OEO_00000274
-    
-    
 Class: OEO_00000274
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287",
-        rdfs:label "model"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000275
@@ -967,18 +932,6 @@ Class: OEO_00000408
     
     
 Class: OEO_00000419
-
-    
-Class: OEO_00000423
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "electricity transshipment model"
-    
-    SubClassOf: 
-        OEO_00000274
     
     
 Class: OEO_00000432
@@ -1268,18 +1221,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
     
     SubClassOf: 
         OEO_00000364
-    
-    
-Class: OEO_00030015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        OEO_00000274
     
     
 Class: OEO_00030029

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -174,6 +174,9 @@ pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
     
 ObjectProperty: OEO_00000522
 
+    Domain: 
+        OEO_00020011
+    
     
 ObjectProperty: OEO_00020056
 
@@ -259,6 +262,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
         OEO_00000206
     
     
+ObjectProperty: OEO_00140164
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the system it reproduces.",
+        rdfs:label "models"@en
+    
+    Domain: 
+        OEO_00000274
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -332,6 +348,9 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000310>
+
+    
+Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000003>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -338,6 +338,9 @@ ObjectProperty: OEO_00040010
 ObjectProperty: OEO_00140002
 
     
+ObjectProperty: OEO_00140164
+
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -3009,6 +3012,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
     
     
+Class: OEO_00000423
+
+    SubClassOf: 
+        OEO_00140164 some OEO_00000143
+    
+    
 Class: OEO_00000425
 
     Annotations: 
@@ -4716,6 +4725,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130",
     
     SubClassOf: 
         OEO_00000316
+    
+    
+Class: OEO_00030015
+
+    SubClassOf: 
+        OEO_00140164 some OEO_00030024
     
     
 Class: OEO_00030019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -180,7 +180,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)",
 ObjectProperty: OEO_00000522
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study / model calculation / model and the thing it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -328,8 +328,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
 Class: OEO_00000264
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market model is a model is about the EnergyMarket."^^xsd:string,
-        rdfs:label "market model"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model is about the energy market."^^xsd:string,
+        rdfs:label "energy market model"
     
     SubClassOf: 
         OEO_00000274

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -226,6 +226,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
     InverseOf: 
         OEO_00020056
+
+    
+ObjectProperty: OEO_00140164
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the system it reproduces.",
+        rdfs:label "models"@en
+    
+    Domain: 
+        OEO_00000274
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -304,6 +317,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
     
     SubClassOf: 
         OEO_00000061
+
+
+Class: OEO_00000264
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market model is a model is about the EnergyMarket."^^xsd:string,
+        rdfs:label "market model"
+    
+    SubClassOf: 
+        OEO_00000274
+
+
+Class: OEO_00000274
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287",
+        rdfs:label "model"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000350
@@ -354,6 +392,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+
+
+Class: OEO_00000423
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "electricity transshipment model"
+    
+    SubClassOf: 
+        OEO_00000274
     
     
 Class: OEO_00010079
@@ -427,6 +477,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     SubClassOf: 
         OEO_00020067
+
+
+Class: OEO_00030015
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "energy system model"@en
+    
+    SubClassOf: 
+        OEO_00000274
     
     
 Class: OEO_00030031

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -77,6 +77,9 @@ AnnotationProperty: rdfs:seeAlso
 Datatype: rdf:PlainLiteral
 
     
+Datatype: xsd:string
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     Annotations: 
@@ -226,7 +229,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
     InverseOf: 
         OEO_00020056
-
+    
     
 ObjectProperty: OEO_00140164
 
@@ -266,6 +269,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000148>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    
+Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
@@ -317,8 +323,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
     
     SubClassOf: 
         OEO_00000061
-
-
+    
+    
 Class: OEO_00000264
 
     Annotations: 
@@ -327,8 +333,8 @@ Class: OEO_00000264
     
     SubClassOf: 
         OEO_00000274
-
-
+    
+    
 Class: OEO_00000274
 
     Annotations: 
@@ -341,7 +347,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287",
         rdfs:label "model"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00140164 some <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00000350
@@ -392,8 +399,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-
-
+    
+    
 Class: OEO_00000423
 
     Annotations: 
@@ -433,6 +440,9 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
+    
+Class: OEO_00020065
+
     
 Class: OEO_00020066
 
@@ -477,8 +487,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     SubClassOf: 
         OEO_00020067
-
-
+    
+    
 Class: OEO_00030015
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -258,6 +258,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
         OEO_00000323
     
     
+ObjectProperty: OEO_00140164
+
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -478,6 +481,12 @@ Class: OEO_00000238
     
     SubClassOf: 
         OEO_00030022
+    
+    
+Class: OEO_00000264
+
+    SubClassOf: 
+        OEO_00140164 some OEO_00020065
     
     
 Class: OEO_00000315


### PR DESCRIPTION
closes #415 

I added
- `covers`: _A relation between a **study** and the thing it investigates._
- `models`: _A relation between a **model** and the system it reproduces._
- `energy system model` models some `energy system`
- `energy market model` models some `energy market exchange`
- `model` models some `system`
- `electricity transshipment model` models some `electricity grid`
- `optimisation model` has part some `objective function`
- `simulation model` not has part some `objective function`

Additionally, I changed the label of `market model` to `energy market model`. 
I also had to move `model` and some subclasses to oeo-shared, which seems a bit unfortunate to me, because `model` is _the_ class that everyone would expect to find in oeo-model. But the alternative would have been to move a wide range of social and physical classes to oeo-shared and only moving model was the more consistent option.