### PR TITLE
add `has documentation quality`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Here is a template for new release sections
 - waste thermal energy (#813)
 - models (#821)
 - uncertainty approach, stochastic and deterministic (#824)
+- has documentation quality (#825)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -46,6 +46,8 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: OEO_00140170
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
         rdfs:comment "Has documentation quality is the relation between a model and a statement about how well it is documented.",
         rdfs:label "has documentation quality"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -43,6 +43,16 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
+AnnotationProperty: OEO_00140170
+
+    Annotations: 
+        rdfs:comment "Has documentation quality is the relation between a model and a statement about how well it is documented.",
+        rdfs:label "has documentation quality"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
 AnnotationProperty: dc:contributor
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -46,9 +46,9 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: OEO_00140170
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
-        rdfs:comment "Has documentation quality is the relation between a model and a statement about how well it is documented.",
         rdfs:label "has documentation quality"@en
     
     Domain: 


### PR DESCRIPTION
closes #526 

I added the annotation property `has documentation quality`, defined as _Has documentation quality is the relation between a model and a statement about how well it is documented._ 