### PR TITLE
add `has gross output` and `has net output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
 - uncertainty approach, stochastic and deterministic (#824)
 - has documentation quality (#825)
 - email address (#827)
+- has gross output, has net output (#838)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -329,9 +329,15 @@ pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
         <http://purl.obolibrary.org/obo/RO_0002234>
     
     Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
@@ -376,7 +382,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838",
     Range: 
         OEO_00000150
     
-
+    
 ObjectProperty: owl:topObjectProperty
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -351,6 +351,8 @@ ObjectProperty: OEO_00140175
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has physical output c, and c is the total amount of energy generated during the process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838",
         rdfs:label "has gross output"@en
     
     SubPropertyOf: 
@@ -364,6 +366,8 @@ ObjectProperty: OEO_00140176
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has physical output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838",
         rdfs:label "has net output"@en
     
     SubPropertyOf: 


### PR DESCRIPTION
closes #394

I added 
- `has gross output`: _p has gross output c iff: p has physical output c, and c is the total amount of energy generated during the process._
- `has net output`: _p has net output c iff: p has physical output c, and c is the amount of energy delivered to the consumer._
- domain and range axioms for `has physical output`

The commit history for this branch is a bit weird, because this branch is based on a dev version to which I (accidentally) commited the changes for the feature-branch. But I reverted the dev branch and everything should be fine now.