### PR TITLE
add `has number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
 - uncertainty approach, stochastic and deterministic (#824)
 - has documentation quality (#825)
 - email address (#827)
+- has number (#840)
 
 ### Changed
 - battery and subclasses (#801)

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -248,6 +248,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
         <http://purl.obolibrary.org/obo/BFO_0000004>
     
     
+DataProperty: OEO_00140178
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data property that links a quantity value to a number that defines the quantity value.",
+        rdfs:label "has number"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -251,7 +251,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
 DataProperty: OEO_00140178
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data property that links a quantity value to a number that defines the quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
         rdfs:label "has number"@en
     
     Domain: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -252,6 +252,8 @@ DataProperty: OEO_00140178
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/840",
         rdfs:label "has number"@en
     
     Domain: 


### PR DESCRIPTION
closes #829 

I decided to add `has number` to oeo-shared, since it is the place where `quantity value` and `has unit` are as well.