### PR TITLE
remove domain of is traded at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Here is a template for new release sections
 - river (#806)
 - air pollutant (#816)
 - motor, electric motor, internal combustion engine (#817)
+- is traded at (#842)
 
 ### Removed
 - molten state battery (#801)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -182,7 +182,11 @@ ObjectProperty: OEO_00020070
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+change domain: 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/791
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842",
         rdfs:label "is traded at"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -188,9 +188,6 @@ ObjectProperty: OEO_00020070
     SubPropertyOf: 
         owl:topObjectProperty
     
-    Domain: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
     Range: 
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
     


### PR DESCRIPTION
closes #791 

I removed the domain of `is traded at`, so that everything can be traded, including energies and licences.