### PR TITLE
Update definitions of `covers energy carrier` and `covers sector` #846

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Here is a template for new release sections
 - is traded at (#842)
 - commodity, commodity role (#843)
 - producer, primary energy production and subclasses (#845)
+- covers energy carrier, covers sector (#852)
 
 ### Removed
 - molten state battery (#801)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -148,10 +148,10 @@ ObjectProperty: OEO_00000522
 ObjectProperty: OEO_00000523
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change range
 issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722",
-        rdfs:comment "A relation that holds between a publication/model calculation/model and the energy carrier it covers.",
         rdfs:label "covers energy carrier"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -151,7 +151,11 @@ ObjectProperty: OEO_00000523
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change range
 issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
         rdfs:label "covers energy carrier"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -146,23 +146,6 @@ ObjectProperty: OEO_00000522
 
     
 ObjectProperty: OEO_00000523
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Range: 
-        OEO_00020039
     
     
 ObjectProperty: OEO_00000524

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -180,6 +180,22 @@ https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)",
         OEO_00000501
     
     
+ObjectProperty: OEO_00000505
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers sector"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Range: 
+        OEO_00000367
+    
+    
 ObjectProperty: OEO_00000522
 
     Annotations: 
@@ -193,6 +209,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict 
         rdfs:label "covers"
     
     
+ObjectProperty: OEO_00000523
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers energy carrier"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Range: 
+        OEO_00020039
+
+
 ObjectProperty: OEO_00020056
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -192,6 +192,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     SubPropertyOf: 
         OEO_00000522
     
+    Domain: 
+        OEO_00020011
+    
     Range: 
         OEO_00000367
     
@@ -225,10 +228,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     SubPropertyOf: 
         OEO_00000522
     
+    Domain: 
+        OEO_00020011
+    
     Range: 
         OEO_00020039
-
-
+    
+    
 ObjectProperty: OEO_00020056
 
     Annotations: 
@@ -512,6 +518,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
+Class: OEO_00020011
+
+    
 Class: OEO_00020015
 
     Annotations: 
@@ -526,6 +535,9 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
+    
+Class: OEO_00020039
+
     
 Class: OEO_00020066
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -98,6 +98,9 @@ ObjectProperty: OEO_00000505
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
         rdfs:label "covers sector"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -97,7 +97,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/",
 ObjectProperty: OEO_00000505
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a publication/model calculation/model and the sector it models."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
         rdfs:label "covers sector"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -95,19 +95,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/",
     
     
 ObjectProperty: OEO_00000505
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers sector"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Range: 
-        OEO_00000367
     
     
 ObjectProperty: OEO_00000506


### PR DESCRIPTION
New definitions:
- `covers energy carrier`: _A relation that holds between a **study** and the energy carrier it covers._
- `covers sector`: _A relation that holds between a **study** and the sector it **covers**._ 

I moved the relations to the oeo-shared module as the domain (`study`) is in oeo-model and ranges in oeo-physical (`energy carrier`) and oeo-social (`sector`).

closes #846 