### PR TITLE
Fix duplicate model factsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,11 @@ Here is a template for new release sections
 - is traded at (#842)
 - commodity, commodity role (#843)
 - producer, primary energy production and subclasses (#845)
+- model descriptor, model factsheet OEO:00000277 (#854)
 
 ### Removed
 - molten state battery (#801)
+- duplicate model factsheet OEO:00020031 (#854)
 
 ## [1.6.1] - 2021-07-07
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -672,11 +672,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "model factsheet"
     
     EquivalentTo: 
-        OEO_00020031
-    
-    SubClassOf: 
-        OEO_00000162,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
+        OEO_00020031,
+        OEO_00000162
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
     
     
 Class: OEO_00000279

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -672,7 +672,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "model factsheet"
     
     EquivalentTo: 
-        OEO_00020031,
+        OEO_00020031
+    
+    SubClassOf: 
         OEO_00000162
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -671,9 +671,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
         rdfs:label "model factsheet"
     
-    EquivalentTo: 
-        OEO_00020031
-    
     SubClassOf: 
         OEO_00000162
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
@@ -1096,9 +1093,6 @@ Class: OEO_00020031
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model factsheet"@en
-    
-    EquivalentTo: 
-        OEO_00000277
     
     SubClassOf: 
         OEO_00020016

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1034,9 +1034,9 @@ Class: OEO_00020016
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model descriptor"@en
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
     
     
 Class: OEO_00020017

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -664,11 +664,13 @@ Class: OEO_00000277
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Since a model facsheet is a model descriptor as well as a factsheet, this class is implemented as equivalent class to OEO_00000277.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
         rdfs:label "model factsheet"
     
     SubClassOf: 
@@ -1081,18 +1083,6 @@ Class: OEO_00020022
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
         rdfs:label "model documentation"@en
-    
-    SubClassOf: 
-        OEO_00020016
-    
-    
-Class: OEO_00020031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model factsheet"@en
     
     SubClassOf: 
         OEO_00020016


### PR DESCRIPTION
Closes #851 

Now only one class `model factsheet`:
![grafik](https://user-images.githubusercontent.com/36884905/132305191-66d449ea-e7d1-46ff-a11b-de992fbe8a41.png)

But is now additionally inferred as subclass of `model descriptor`:
![grafik](https://user-images.githubusercontent.com/36884905/132305562-8acf17b6-a4ff-4a60-982a-71697252731c.png)
