### PR TITLE
bugfix: `good` and `study` to oeo-shared #862

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Here is a template for new release sections
 - producer, primary energy production and subclasses (#845, #860)
 - covers energy carrier, covers sector (#852)
 - model descriptor, model factsheet OEO:00000277 (#854)
-- good, project, study, energy carrier (disposition) (#860)
+- good, project, study, energy carrier (disposition) (#869)
 
 ### Removed
 - molten state battery (#801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Here is a template for new release sections
 - producer, primary energy production and subclasses (#845, #860)
 - covers energy carrier, covers sector (#852)
 - model descriptor, model factsheet OEO:00000277 (#854)
+- good, project, study, energy carrier (disposition) (#860)
 
 ### Removed
 - molten state battery (#801)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -787,15 +787,6 @@ Class: OEO_00000339
     
     
 Class: OEO_00000340
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418",
-        rdfs:label "project"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00000350
@@ -987,16 +978,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
     
 Class: OEO_00020011
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add covers-relation 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764"@en,
-        rdfs:label "study"@en
-    
     SubClassOf: 
-        OEO_00000340,
         OEO_00000522 some OEO_00020072
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1643,17 +1643,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     
 Class: OEO_00000151
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
     
     
 Class: OEO_00000159
@@ -4492,19 +4481,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     
 Class: OEO_00020039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has the disposition energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627",
-        rdfs:label "energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00020040

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -445,6 +445,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
         OEO_00140164 some <http://purl.obolibrary.org/obo/BFO_0000004>
     
     
+Class: OEO_00000340
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "project"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
 Class: OEO_00000350
 
     Annotations: 
@@ -553,6 +568,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     
 Class: OEO_00020011
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
+add covers-relation (oeo-model)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869"@en,
+        rdfs:label "study"@en
+    
+    SubClassOf: 
+        OEO_00000340
+    
     
 Class: OEO_00020015
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -120,6 +120,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
     Annotations: 
@@ -326,6 +329,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000016>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
@@ -400,6 +406,22 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artifici
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    
+Class: OEO_00000151
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
     
     
 Class: OEO_00000206
@@ -600,6 +622,21 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     
 Class: OEO_00020039
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has the disposition energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00020066
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -683,7 +683,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
     SubClassOf: 
         OEO_00140039
     
+
+Class: OEO_00010116  
+  
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a material entity that has the good role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "good"@en
     
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+
+
 Class: OEO_00140003
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -218,18 +218,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict 
         rdfs:label "covers"
     
     
-ObjectProperty: OEO_00010121
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853",
-        rdfs:label "has bearer"@en
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
-
-
 ObjectProperty: OEO_00000523
 
     Annotations: 
@@ -251,6 +239,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     
     Range: 
         OEO_00020039
+    
+    
+ObjectProperty: OEO_00010121
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+        rdfs:label "has bearer"@en
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/RO_0000053>
     
     
 ObjectProperty: OEO_00020056
@@ -522,6 +522,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
     
 Class: OEO_00010116
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a material entity that has the good role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "good"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00010117
 
@@ -578,11 +593,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 add alternative term
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
 subclass of good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+change axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
         rdfs:label "commodity"
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
+        OEO_00010116
          and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
     
     SubClassOf: 
@@ -683,23 +700,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
     SubClassOf: 
         OEO_00140039
     
-
-Class: OEO_00010116  
-  
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a material entity that has the good role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "good"@en
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-
-
 Class: OEO_00140003
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -723,19 +723,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     
     
 Class: OEO_00010116
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a material entity that has the good role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "good"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00010117


### PR DESCRIPTION
closes #862

good:
* moved `good` to oeo-shared
* changed axiom of `commodity` to `good and ('has role' some 'commodity role')`

study
* moved `study` and `project` (parent class) to oeo-shared

energy carrier:
* I also had to move `energy carrier disposition` and `energy carrier` to oeo-shared