### PR TITLE
add scenario year, meteorological year, scenario horizon #474

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Here is a template for new release sections
 - axioms of hydro energy (incl. subclasses), wind energy, study, study report and model calculation (#871)
 - hydrogen turbine (#877)
 - has objective (#878)
-- typical day / year (#882)
 
 ### Removed
 - molten state battery (#801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Here is a template for new release sections
 - objective variable (#878)
 - metric ton (#879)
 - target description (#881)
+- scenario year, scenario horizon, meteorological year, weather time series, scenario time series (#882) 
 
 ### Changed
 - battery and subclasses (#801)
@@ -69,6 +70,7 @@ Here is a template for new release sections
 - axioms of hydro energy (incl. subclasses), wind energy, study, study report and model calculation (#871)
 - hydrogen turbine (#877)
 - has objective (#878)
+- typical day / year (#882)
 
 ### Removed
 - molten state battery (#801)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1267,6 +1267,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
     
     SubClassOf: 
         OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
         <http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00030035
              and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
@@ -1283,6 +1284,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
     
     SubClassOf: 
         OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
         <http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00030035
              and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -382,6 +382,9 @@ Class: <http://purl.obolibrary.org/obo/RO_0002577>
 Class: <http://purl.obolibrary.org/obo/UO_0000003>
 
     
+Class: <http://purl.obolibrary.org/obo/UO_0000033>
+
+    
 Class: <http://purl.obolibrary.org/obo/UO_0000036>
 
     
@@ -1205,11 +1208,17 @@ Class: OEO_00020090
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "typical year"
     
     SubClassOf: 
-        OEO_00020089
+        OEO_00020089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
     
     DisjointWith: 
         OEO_00020091
@@ -1220,11 +1229,17 @@ Class: OEO_00020091
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "typical day"
     
     SubClassOf: 
-        OEO_00020089
+        OEO_00020089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000033>)
+             and (OEO_00140178 value 1))
     
     DisjointWith: 
         OEO_00020090

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1304,6 +1304,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
              and (OEO_00140178 value 1))
     
     
+Class: OEO_00020100
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "weather time series"
+    
+    SubClassOf: 
+        OEO_00030034,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020099
+    
+    
+Class: OEO_00020101
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario time series"
+    
+    SubClassOf: 
+        OEO_00030034,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
+    
+    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1236,6 +1236,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
 Class: OEO_00020097
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario year"
     
     SubClassOf: 
@@ -1245,6 +1248,9 @@ Class: OEO_00020097
 Class: OEO_00020098
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario horizon"
     
     SubClassOf: 
@@ -1254,6 +1260,9 @@ Class: OEO_00020098
 Class: OEO_00020099
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "meteorological year"
     
     SubClassOf: 
@@ -1344,8 +1353,7 @@ Class: OEO_00030033
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "time step"
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -76,6 +76,9 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
+Datatype: xsd:integer
+
+    
 Datatype: xsd:string
 
     
@@ -298,6 +301,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
 ObjectProperty: owl:topObjectProperty
 
     
+DataProperty: OEO_00140178
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
@@ -374,6 +380,9 @@ Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000003>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000036>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
@@ -1242,7 +1251,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario year"
     
     SubClassOf: 
-        OEO_00030033
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
     
     
 Class: OEO_00020098
@@ -1254,7 +1267,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario horizon"
     
     SubClassOf: 
-        OEO_00030033
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
     
     
 Class: OEO_00020099
@@ -1266,7 +1282,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "meteorological year"
     
     SubClassOf: 
-        OEO_00030033
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
     
     
 Class: OEO_00030007

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1233,6 +1233,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00020097
+
+    Annotations: 
+        rdfs:label "scenario year"
+    
+    SubClassOf: 
+        OEO_00030033
+    
+    
+Class: OEO_00020098
+
+    Annotations: 
+        rdfs:label "scenario horizon"
+    
+    SubClassOf: 
+        OEO_00030033
+    
+    
+Class: OEO_00020099
+
+    Annotations: 
+        rdfs:label "meteorological year"
+    
+    SubClassOf: 
+        OEO_00030033
+    
+    
 Class: OEO_00030007
 
     Annotations: 


### PR DESCRIPTION
closes #474 

- add `scenario year`, `scenario horizon`, `meteorological year`
- add axiom `'has part' some (duration and 'has unit' some year and 'has number' value 1)` (for scenario horizon I left the `has number value 1` out)
- add axiom to `typical day` / `typical year`

Also add `weather time series`, `scenario time series` as proposed by @sfluegel05 in #474. I'm not 100% happy with it: especially weather time series doen't have to be about 1 year... please check when reviewing, thanks!