### PR TITLE
Fix typos

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -771,7 +771,7 @@ Class: OEO_00000024
 Class: OEO_00000025
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formular CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
@@ -2066,7 +2066,7 @@ Class: OEO_00000219
 Class: OEO_00000220
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formular H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
         rdfs:label "hydrogen",


### PR DESCRIPTION
It is called _[chemical formula](https://en.wikipedia.org/wiki/Chemical_formula)_ and not _chemical formula**r**_.