### PR TITLE
Add classes `energy use` and `non-energy use` #718

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - GovReg sector division, MMR sector division and further CRF (2006) sector individuals (#941, #944)
 - total emissions including/exluding LULUCF, international aviation, maritime navigation, multilateral operations and related sector individuals (#944)
 - liquid air production (#945)
+- energy use, non-energy use (#950)
 
 ### Changed
 - energy converting device / component, unit of measurement (#895)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4664,7 +4664,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935",
 Class: OEO_00010210
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy they carry.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
         rdfs:label "energy use"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4665,6 +4665,8 @@ Class: OEO_00010210
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy they carry.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
         rdfs:label "energy use"@en
     
     SubClassOf: 
@@ -4679,6 +4681,8 @@ Class: OEO_00010211
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy they carry.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
         rdfs:label "non-energy use"@en
     
     SubClassOf: 
@@ -5641,6 +5645,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
     
     SubClassOf: 
         OEO_00140039,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211),
         OEO_00140002 some OEO_00050019
     
     
@@ -5661,6 +5670,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
     
     SubClassOf: 
         OEO_00140039,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210),
         OEO_00140002 some OEO_00050019
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4661,6 +4661,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
     
     
+Class: OEO_00010210
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy they carry.",
+        rdfs:label "energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
+    
+    DisjointWith: 
+        OEO_00010211
+    
+    
+Class: OEO_00010211
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy they carry.",
+        rdfs:label "non-energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    DisjointWith: 
+        OEO_00010210
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4680,7 +4680,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
 Class: OEO_00010211
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy they carry.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
         rdfs:label "non-energy use"@en


### PR DESCRIPTION
Add classes:
* `energy use`: _Energy use is the consumption of an energy carrier making use of the energy they carry._
* `non-energy use`: _Non-energy use is the consumption of an energy carrier without making use the energy they carry._

Add axioms:
* `'gross inland energy consumption' ('has part' some 'energy use') and ('has part' some 'non-energy use')`
* `'primary energy consumption' ('has part' some 'energy use') and not ('has part' some 'non-energy use')`

Closes #718