### PR TITLE
Restructure power-to-gas related classes #940

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Here is a template for new release sections
 - CRF sector individuals: energy industry; fugitive emissions; industrial processes and product use; agriculture; LULUCF; waste (#941)
 - European Union Emissions Trading System (#944)
 - liquid air (#945)
-- synthetic methane (#954)
+- power-to-gas system, synthetic methane (#954)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Here is a template for new release sections
 - liquid air production (#945)
 - rotor diameter (#949)
 - energy use, non-energy use (#950)
+- power-to-gas process, power-to-methane process, methanation, oxygen, water electrolysis process (#954)
 
 ### Changed
 - energy converting device / component, unit of measurement (#895)
@@ -50,6 +51,7 @@ Here is a template for new release sections
 - CRF sector individuals: energy industry; fugitive emissions; industrial processes and product use; agriculture; LULUCF; waste (#941)
 - European Union Emissions Trading System (#944)
 - liquid air (#945)
+- synthetic methane (#954)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Here is a template for new release sections
 - CRF sector individuals: energy industry; fugitive emissions; industrial processes and product use; agriculture; LULUCF; waste (#941)
 - European Union Emissions Trading System (#944)
 - liquid air (#945)
-- power-to-gas system, synthetic methane (#954)
+- power-to-gas system, synthetic methane, synthetic hydrogen, fossil hydrogen (#954)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3532,7 +3532,11 @@ Class: OEO_00010018
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+Re-definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "synthetic methane"
     
     EquivalentTo: 
@@ -4695,6 +4699,93 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
     
     DisjointWith: 
         OEO_00010210
+    
+    
+Class: OEO_00010216
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "power-to-gas process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000139)
+         and (OEO_00000532 some OEO_00000331),
+        (OEO_00000533 some OEO_00000007)
+         and (OEO_00000533 some OEO_00010155)
+    
+    
+Class: OEO_00010217
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power-to-methane is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "power-to-methane process"@en
+    
+    SubClassOf: 
+        OEO_00010216,
+        (OEO_00000532 some OEO_00000006)
+         and (OEO_00000532 some OEO_00000139)
+         and (OEO_00000532 some OEO_00000441),
+        (OEO_00000533 some OEO_00000007)
+         and (OEO_00000533 some OEO_00010018)
+         and (OEO_00000533 some OEO_00010219),
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010220
+    
+    
+Class: OEO_00010218
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "oxygen"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010219
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "water electrolysis process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000139)
+         and (OEO_00000532 some OEO_00000441),
+        (OEO_00000533 some OEO_00000007)
+         and (OEO_00000533 some OEO_00000220)
+         and (OEO_00000533 some OEO_00010218),
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010021
+    
+    
+Class: OEO_00010220
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "methanation"@en
+    
+    SubClassOf: 
+        OEO_00140034,
+        (OEO_00000532 some OEO_00000006)
+         and (OEO_00000532 some OEO_00000220),
+        (OEO_00000533 some OEO_00000006)
+         and (OEO_00000533 some OEO_00000441)
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2753,7 +2753,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000335
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4741,7 +4741,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010217
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power-to-methane is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-methane process"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4820,7 +4820,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010219
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "water electrolysis process"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2753,15 +2753,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000335
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "a power-to-gas (often abbreviated P2G) system is an energy storage object that converts electrical power to a gas fuel. When using surplus power from wind generation, the concept is sometimes called windgas. There are currently three methods in use; all use electricity to split water into hydrogen and oxygen by means of electrolysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Power-to-gas&oldid=907220452"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-gas system"
     
     SubClassOf: 
-        OEO_00000159,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
     
     
 Class: OEO_00000343
@@ -3531,6 +3534,9 @@ Class: OEO_00010018
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3530,14 +3530,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
 Class: OEO_00010018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is synthetic fuel produced in a power-to-gas system from water and carbon dioxide using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "synthetic methane"
     
+    EquivalentTo: 
+        OEO_00000025
+         and (OEO_00000530 some OEO_00030005)
+    
     SubClassOf: 
-        OEO_00000025,
-        OEO_00000530 some OEO_00030005
+        OEO_00000025
     
     
 Class: OEO_00010019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4734,8 +4734,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
          and (OEO_00000532 some OEO_00000139)
          and (OEO_00000532 some OEO_00000441),
         (OEO_00000533 some OEO_00000007)
-         and (OEO_00000533 some OEO_00010018)
-         and (OEO_00000533 some OEO_00010219),
+         and (OEO_00000533 some OEO_00010018),
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010220
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3494,9 +3494,15 @@ Class: OEO_00010015
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "fossil hydrogen"
     
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        OEO_00000220
+         and (OEO_00000530 some OEO_00030002)
+    
     SubClassOf: 
-        OEO_00000220,
-        OEO_00000530 some OEO_00030002
+        OEO_00000220
     
     
 Class: OEO_00010016
@@ -3507,9 +3513,15 @@ Class: OEO_00010016
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "synthetic hydrogen"
     
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        OEO_00000220
+         and (OEO_00000530 some OEO_00030005)
+    
     SubClassOf: 
-        OEO_00000220,
-        OEO_00000530 some OEO_00030005
+        OEO_00000220
     
     
 Class: OEO_00010017


### PR DESCRIPTION
Redefine:
* `power-to-gas system`: _A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process._
* `synthetic methane`: _Synthetic methane is methane that has a synthetic origin._

Add:
* `power-to-gas process`: _A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel._
* `power-to-methane process`: _A power-to-methane process is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation._
* `water electrolysis process`: _A water electrolysis process is energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat)._
* `methanation`: _A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water._
* `oxygen`: _Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter._

Make equivalent classes:
* `'synthetic hydrogen' equivalentTo hydrogen and ('has origin' some synthetic)'`
* `'fossil hydrogen' equivalentTo hydrogen and ('has origin' some fossil)'`

Closes #940 