### PR TITLE
Adapt `ammonia`, add `synthetic ammonia` and `power-to-ammonia process` #939

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Here is a template for new release sections
 - variable (production) cost (#953)
 - energy use, non-energy use (#950)
 - conventional (energy carrier disposition), fossil energy (#955) 
+- synthetic ammonia (#958)
 
 ### Changed
 - energy converting device / component, unit of measurement (#895)
@@ -55,6 +56,7 @@ Here is a template for new release sections
 - liquid air (#945)
 - renewable energy (#955)
 - PtL fuel (formerly: synthetic liquid fuel) (#957)
+- ammonia (#958)
 
 ### Removed
 
@@ -342,7 +344,6 @@ Here is a template for new release sections
 - energy transformation (#77)
 - synthetic fuels and respective energy converting devices (#411)
 - process attribute (#386)
-
 
 ### Changed
 - Restructured the repository to add a 'src' folder with an 'ontology' sub-folder with sub-folders for editable modules and import modules (#200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Here is a template for new release sections
 - variable (production) cost (#953)
 - energy use, non-energy use (#950)
 - conventional (energy carrier disposition), fossil energy (#955) 
-- synthetic ammonia (#958)
+- synthetic ammonia (#959)
 
 ### Changed
 - energy converting device / component, unit of measurement (#895)
@@ -56,7 +56,7 @@ Here is a template for new release sections
 - liquid air (#945)
 - renewable energy (#955)
 - PtL fuel (formerly: synthetic liquid fuel) (#957)
-- ammonia (#958)
+- ammonia (#959)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Here is a template for new release sections
 - variable (production) cost (#953)
 - conventional (energy carrier disposition), fossil energy (#955) 
 - carbon tax, social cost of carbon, carbon price (#956)
-- synthetic ammonia (#959)
+- synthetic ammonia, power-to-ammonia process (#959)
 
 ### Changed
 - energy converting device / component, unit of measurement (#895)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2746,6 +2746,7 @@ Class: OEO_00000335
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-gas system"
@@ -3549,6 +3550,7 @@ Class: OEO_00010018
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
@@ -4761,6 +4763,7 @@ Class: OEO_00010216
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-gas process"@en
@@ -4777,6 +4780,7 @@ Class: OEO_00010217
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-methane process"@en
@@ -4860,6 +4864,7 @@ Class: OEO_00010222
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "power-to-ammonia process"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1624,10 +1624,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
     
     
 Class: OEO_00000147
-    
+
     
 Class: OEO_00000148
-    
+
     
 Class: OEO_00000150
 
@@ -3603,7 +3603,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
 Class: OEO_00010021
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "water electrolyser"
@@ -4722,6 +4722,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
     
     DisjointWith: 
         OEO_00010210
+    
+    
 Class: OEO_00010214
 
     Annotations: 
@@ -4807,7 +4809,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010219
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electric energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "water electrolysis process"@en
@@ -4841,7 +4843,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010221
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Synthetic ammonia is ammonia that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
 https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "synthetic ammonia"@en
@@ -4852,6 +4854,19 @@ https://github.com/OpenEnergyPlatform/ontology/pull/959",
     
     SubClassOf: 
         OEO_00010000
+    
+    
+Class: OEO_00010222
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
+https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "power-to-ammonia process"@en
+    
+    SubClassOf: 
+        OEO_00010216,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010000
     
     
 Class: OEO_00020001
@@ -6427,7 +6442,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
     
     
 Class: OEO_00140081
-    
+
     
 Class: OEO_00140082
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3325,10 +3325,16 @@ Class: OEO_00000449
 Class: OEO_00010000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. Synonyms are trihydridonitrogen and nitrogen trihydride.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "trihydridonitrogen",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+Adapt definiton and axioms, add alternative  terms:
+https://github.com/OpenEnergyPlatform/ontology/issues/939
+https://github.com/OpenEnergyPlatform/ontology/pull/958",
         rdfs:label "ammonia"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -3338,6 +3344,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     SubClassOf: 
         OEO_00000331,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000182
     
     
@@ -4702,6 +4710,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
     
     DisjointWith: 
         OEO_00010210
+    
+    
+Class: OEO_00010221
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Synthetic ammonia is ammonia that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
+https://github.com/OpenEnergyPlatform/ontology/pull/958",
+        rdfs:label "synthetic ammonia"@en
+    
+    EquivalentTo: 
+        OEO_00010000
+         and (OEO_00000530 some OEO_00030005)
+    
+    SubClassOf: 
+        OEO_00010000
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3334,7 +3334,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
 
 Adapt definiton and axioms, add alternative  terms:
 https://github.com/OpenEnergyPlatform/ontology/issues/939
-https://github.com/OpenEnergyPlatform/ontology/pull/958",
+https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "ammonia"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -4717,7 +4717,7 @@ Class: OEO_00010221
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "Synthetic ammonia is ammonia that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
-https://github.com/OpenEnergyPlatform/ontology/pull/958",
+https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "synthetic ammonia"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3323,8 +3323,8 @@ Class: OEO_00010000
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
 
 Adapt definiton and axioms, add alternative  terms:
-https://github.com/OpenEnergyPlatform/ontology/issues/939
-https://github.com/OpenEnergyPlatform/ontology/pull/959",
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "ammonia"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -4844,8 +4844,8 @@ Class: OEO_00010221
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
-https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "synthetic ammonia"@en
     
     EquivalentTo: 
@@ -4860,8 +4860,8 @@ Class: OEO_00010222
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/939
-https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         rdfs:label "power-to-ammonia process"@en
     
     SubClassOf: 


### PR DESCRIPTION
Adapt:
* `ammonia`: _Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel._

Add:
* `synthetic ammonia`: _Synthetic ammonia is ammonia that has a synthetic origin._
* `power-to-ammonia process`: _A power-to-ammonia process is a power-to-gas process that has ammonia as output._

Minor changes:
* Editorial changes to `water electrolyser` and `water electrolysis process`.
* Add alternative terms:
  * `power-to-gas` to `power-to-gas process` and `power-to-gas system`
  * `power to gas` to `synthetic methane`
  * `power to methane` to `power-to-methane process`.

Closes #939.