### PR TITLE
Fix SubclassOf for `biofuel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,14 @@ Here is a template for new release sections
 
 ```
 
-```
 ## [1.X.X] - 20XX-XX-XX - Unreleased
 
 ### Added
 
 ### Changed
+- biofuel (#965)
 
 ### Removed
-
-```
 
 ## [1.8.0] - 2021-12-01
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1266,7 +1266,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
 remove origin 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 
-redefine:",
+redefine:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+fix subclassof:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "biofuel"
     
     EquivalentTo: 
@@ -1274,7 +1279,7 @@ redefine:",
          and (OEO_00000530 some OEO_00030001)
     
     SubClassOf: 
-        OEO_00000173,
+        OEO_00000099,
         OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086
@@ -7066,20 +7071,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
         OEO_00000533 some OEO_00000139
     
     
-
-Class: OEO_00240016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946",
-        rdfs:label "net capacity factor"
-    
-    SubClassOf: 
-        OEO_00000350
-
 Class: OEO_00240015
 
     Annotations: 
@@ -7092,7 +7083,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
         OEO_00240003,
         OEO_00000532 some OEO_00000054,
         OEO_00000533 some OEO_00000257
+    
+    
+Class: OEO_00240016
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946",
+        rdfs:label "net capacity factor"
+    
+    SubClassOf: 
+        OEO_00000350
     
     
 Individual: OEO_00000182


### PR DESCRIPTION
In pull request #952 the class `biofuel` got the new definition _A biofuel is a combustion fuel that has a biogenic origin._
The axiom `EquivalentTo 'combustion fuel' and ('has origin' some biogenic)` was added.
However, it was missed to change at the same time `SubclassOf fuel` to `SubclassOf combustion fuel`.

I think we can do here a quick fix without opening an issue for that.