### PR TITLE
Add `memo item`, memo item sector individuals and object properties #858

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Here is a template for new release sections
 ## [1.X.X] - 20XX-XX-XX - Unreleased
 
 ### Added
-- quality memo item and CRF (2006) sector individuals with that quality (#966)
+- memo item and CRF (2006) sector individuals relating to memo item; has information content entity (#966)
 
 ### Changed
 - biofuel (#965)
+- has quantity value, has global warming potential (#966)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Here is a template for new release sections
 ## [1.X.X] - 20XX-XX-XX - Unreleased
 
 ### Added
+- quality memo item and CRF (2006) sector individuals with that quality (#966)
 
 ### Changed
 - biofuel (#965)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -164,7 +164,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
         rdfs:label "has global warming potential"
     
     SubPropertyOf: 
-        owl:topObjectProperty
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00140002
     
     Domain: 
         OEO_00000020

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -116,6 +116,9 @@ Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
+    InverseOf: 
+        OEO_00010231
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
@@ -418,6 +421,21 @@ pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853",
         <http://purl.obolibrary.org/obo/RO_0000053>
     
     
+ObjectProperty: OEO_00010231
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an entity to an information artifact.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "has information content entity"@en
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    
 ObjectProperty: OEO_00020056
 
     Annotations: 
@@ -453,6 +471,12 @@ ObjectProperty: OEO_00140002
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         rdfs:label "has quantity value"@en
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010231
     
     Range: 
         
@@ -934,6 +958,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00010227
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is a quality of a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "memo item"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00020011

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -424,7 +424,7 @@ pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853",
 ObjectProperty: OEO_00010231
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an entity to an information artifact.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "has information content entity"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -960,18 +960,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: OEO_00010227
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is a quality of a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
-        rdfs:label "memo item"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
 Class: OEO_00020011
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -172,7 +172,7 @@ ObjectProperty: OEO_00010231
 ObjectProperty: OEO_00010232
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a sector to memo item.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "has memo item"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -85,6 +85,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
@@ -689,6 +692,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
     
     SubClassOf: 
         OEO_00140150
+    
+    
+Class: OEO_00010227
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is a quality of a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "memo item"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00020015
@@ -2138,6 +2153,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
      OEO_00000504  OEO_00000242,
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
     
+    DifferentFrom: 
+        OEO_00010229
+    
     
 Individual: OEO_00010059
 
@@ -3556,6 +3574,60 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
      OEO_00000503  OEO_00000242,
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010198,
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201
+    
+    
+Individual: OEO_00010228
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "CRF sector (IPCC 2006): CO2 emissions from biomass"@en
+    
+    Types: 
+        OEO_00000367,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+    
+    Facts:  
+     OEO_00000504  OEO_00000242
+    
+    
+Individual: OEO_00010229
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "CRF sector (IPCC 2006): CO2 captured"@en
+    
+    Types: 
+        OEO_00000367,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+    
+    Facts:  
+     OEO_00000504  OEO_00000242
+    
+    DifferentFrom: 
+        OEO_00010058
+    
+    
+Individual: OEO_00010230
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "CRF sector (IPCC 2006): indirect CO2"@en
+    
+    Types: 
+        OEO_00000367,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+    
+    Facts:  
+     OEO_00000504  OEO_00000242
     
     
 DisjointClasses: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -163,6 +163,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
         OEO_00140150 or OEO_00140151
     
     
+ObjectProperty: OEO_00010231
+
+    
+ObjectProperty: OEO_00010232
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a sector to memo item.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "has memo item"
+    
+    SubPropertyOf: 
+        OEO_00010231
+    
+    Domain: 
+        OEO_00000367
+    
+    Range: 
+        OEO_00010227
+    
+    
 ObjectProperty: OEO_00020056
 
     
@@ -3378,7 +3399,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers and multilateral operations"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242,
@@ -3396,7 +3421,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242,
@@ -3415,7 +3444,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international aviation"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242,
@@ -3436,7 +3469,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): maritime navigation"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242,
@@ -3458,7 +3495,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): multilateral operations"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242,
@@ -3490,7 +3531,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector: M.International aviation in the EU ETS"@en
     
     Types: 
-        OEO_00000422
+        OEO_00000422,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00010204,
@@ -3587,7 +3632,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
     
     Types: 
         OEO_00000367,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242
@@ -3604,7 +3649,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
     
     Types: 
         OEO_00000367,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242
@@ -3624,7 +3669,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
     
     Types: 
         OEO_00000367,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
      OEO_00000504  OEO_00000242

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -79,6 +79,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -718,13 +721,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
 Class: OEO_00010227
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is a quality of a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "memo item"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
     
     
 Class: OEO_00020015


### PR DESCRIPTION
Add class:
* `memo item`: _A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo)._

Add individuals:
* `CRF sector (IPCC 2006): 'CO2 emissions from biomass'`: _CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting._
* `CRF sector (IPCC 2006): CO2 captured`: _CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage._
* `CRF sector (IPCC 2006): 'indirect CO2'`: _The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere._

Add object properties:
* `has information content entity`: _A relation that relates an entity to an information artifact._
* `has memo item`: _A relation that relates a sector to memo item._

Add object property `has memo item` to existing individuals:
* `CRF sector (IPCC 2006): international bunkers and multilateral operations`
* `CRF sector (IPCC 2006): international bunkers`
* `CRF sector (IPCC 2006): international aviation`
* `CRF sector (IPCC 2006): maritime navigation`
* `CRF sector (IPCC 2006): multilateral operations`
* `MMR sector: M.International aviation in the EU ETS`

Fix object properties hierachy:
* `has information content entity`
  * `has memo item`
  * `has quantity value`
    * `has global warming potential`
    * `has typical computation time`

Closes #858