### PR TITLE
Redefine `origin` and add rdf:comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Here is a template for new release sections
 - biofuel (#965)
 - has quantity value, has global warming potential (#966)
 - resolution, has resolution and subclasses (#972)
+- origin (#976)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2580,12 +2580,20 @@ Class: OEO_00000311
 Class: OEO_00000316
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality that indicates where a portion of matter or energy comes from (its source).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
 change def
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+change definition and add comment with examples:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976",
+        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
+* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
+* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
         rdfs:label "origin"
     
     SubClassOf: 


### PR DESCRIPTION
New definition of `origin`:
_Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources._

Examples as rdf:comment:
- Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
- Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
- Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin

Closes #974