### PR TITLE
Replace `energy converting device` with `energy converting component` in some definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - has quantity value, has global warming potential (#966)
 - resolution, has resolution and subclasses (#972)
 - origin (#976)
+- heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1994,7 +1994,10 @@ Class: OEO_00000210
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "heater"
     
     SubClassOf: 
@@ -3117,6 +3120,8 @@ Class: OEO_00000425
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "turbine"
     
     SubClassOf: 
@@ -3639,7 +3644,10 @@ Class: OEO_00010021
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "water electrolyser"
     
     SubClassOf: 
@@ -3667,7 +3675,10 @@ Class: OEO_00010022
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "steam reformer"
     
     SubClassOf: 
@@ -3831,7 +3842,10 @@ Class: OEO_00010032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "motor",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -4070,7 +4084,10 @@ Class: OEO_00010090
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "pump"@en
     
     SubClassOf: 
@@ -6628,7 +6645,10 @@ Class: OEO_00140102
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "heat exchanger"@en
     
     SubClassOf: 
@@ -6885,7 +6905,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 
 Make it subclass of power value and add unit axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "power rating"@en
     
     SubClassOf: 
@@ -6923,7 +6946,10 @@ extend to artificial objects:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
 Make it subclass of power value and add unit axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
         rdfs:label "nameplate capacity"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1992,7 +1992,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000210
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting device that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273",
         rdfs:label "heater"
@@ -3116,7 +3116,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000425
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting device that converts energy from a moving fluid flow into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
         rdfs:label "turbine"
     
     SubClassOf: 
@@ -3637,7 +3637,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
 Class: OEO_00010021
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting device that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "water electrolyser"
@@ -3665,7 +3665,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010022
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting device that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "steam reformer"
@@ -3826,7 +3826,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010032
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting device that converts other forms of energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
@@ -4068,7 +4068,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010090
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting device that converts energy into kinetic or potential energy of a fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         rdfs:label "pump"@en
@@ -6626,7 +6626,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140102
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an energy converting device that is used for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734",
         rdfs:label "heat exchanger"@en
@@ -6875,7 +6875,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
 Class: OEO_00230001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power value stating the maximum power an energy converting device can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power value stating the maximum power an energy converting component can convert.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
@@ -6916,7 +6916,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935",
 Class: OEO_00230003
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power value stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting devices of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power value stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 extend to artificial objects:


### PR DESCRIPTION
In PR #895, `energy converting device` was renamed to `energy converting component`.
However, not all definitions of subclasses were adapted. This PR fixes this.
The following classes are affected:
* `heat exchanger`
* `heater`
* `turbine`
* `water electrolyser`
* `steam reformer`
* `motor`
* `pump`
* `power rating`
* `nameplate capacity`