### PR TITLE
Update `has state of matter` and `has normal state of matter` #989

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Here is a template for new release sections
 - resolution, has resolution and subclasses (#972)
 - origin (#976)
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
-- has normal state of matter (#1001)
+- has state of matter, has normal state of matter (#1001)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Here is a template for new release sections
 - resolution, has resolution and subclasses (#972)
 - origin (#976)
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
+- has normal state of matter (#1001)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -241,10 +241,13 @@ ObjectProperty: OEO_00000529
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
         rdfs:label "has normal state of matter"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
+        OEO_00000531
     
     Domain: 
         OEO_00000331
@@ -276,6 +279,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
 ObjectProperty: OEO_00000531
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter x and a state of matter y that indicates the state of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
         rdfs:label "has state of matter"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -279,7 +279,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
 ObjectProperty: OEO_00000531
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter x and a state of matter y that indicates the state of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
         rdfs:label "has state of matter"


### PR DESCRIPTION
* Add definition to `has state of matter`: _A relation between a portion of matter x and a state of matter y that indicates the state of matter x under certain given conditions._
* Make `has normal state of matter` a subproperty of `has state of matter`.
* Closes #989.