### PR TITLE
Add class `forecast error` #907

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 - memo item and CRF (2006) sector individuals relating to memo item; has information content entity (#966)
 - annual, monthly, weekly, daily, hourly (#972)
 - mathematical expression (annotation property) (#990)
+- forecast error (#1002)
 
 ### Changed
 - biofuel (#965)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1009,6 +1009,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
         OEO_00000104
     
     
+Class: OEO_00010233
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "forecast error"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
 Class: OEO_00020011
 
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1014,7 +1014,7 @@ Class: OEO_00010233
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
         rdfs:label "forecast error"@en
     
     SubClassOf: 


### PR DESCRIPTION
Add class `forecast error` with definition:
_A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value._

Closes #907.