### PR TITLE
Redefine `peat` #942

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Here is a template for new release sections
 - origin (#976)
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
 - has state of matter, has normal state of matter (#1001)
+- peat (#1003)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2631,10 +2631,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000320
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a portion of matter consisting of combustible soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state), easily cut, of light to dark brown colour. Peat used for non-energy purposes is not included.
-
-This definition is without prejudice to the definition of renewable energy sources in Directive 2001/77/EC and to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
         rdfs:label "peat",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -2644,6 +2644,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     SubClassOf: 
         OEO_00000331,
         OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000390


### PR DESCRIPTION
New definition:
_Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin._

Closes #942