### PR TITLE
Add class `gas mixture` #988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Here is a template for new release sections
 - annual, monthly, weekly, daily, hourly (#972)
 - mathematical expression (annotation property) (#990)
 - forecast error (#1002)
+- gas mixture (#1009)
 
 ### Changed
 - biofuel (#965)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Here is a template for new release sections
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
 - has state of matter, has normal state of matter (#1001)
 - peat (#1003)
-- biogas, biomethane, manufactured coal based gas, natural gas, syngas (#1009)
+- air, biogas, biomethane, manufactured coal based gas, natural gas, syngas (#1009)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Here is a template for new release sections
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
 - has state of matter, has normal state of matter (#1001)
 - peat (#1003)
+- biogas, biomethane, manufactured coal based gas, natural gas, syngas (#1009)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -385,6 +385,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838",
 ObjectProperty: owl:topObjectProperty
 
     
+Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portion of matters and that has a gaseous normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "gas mixture"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000529 value OEO_00000182
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1145,7 +1145,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000054
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that consists of a composition of gases that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -389,7 +389,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portion of matters and that has a gaseous normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/988
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "gas mixture"@en
     
@@ -1145,13 +1145,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000054
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a portion of matter that consists of a composition of gases that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that consists of a composition of gases that forms the Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "air",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -1159,7 +1162,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         OEO_00000501 some OEO_00000399,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
@@ -1323,9 +1326,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000074
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a portion of matter produced by anaerobic digestion. It is a gas mixture consisting mainly of methane and carbon dioxide. It has a gaseous state of matter an can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "biogas",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -1333,7 +1339,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000006)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025),
         OEO_00000530 some OEO_00030001,
@@ -2322,11 +2328,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000263
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a portion of matter that is gaseous and manufactured from coal. It is used as fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that manufactured from coal. It is used as fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "manufactured coal based gas"
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
@@ -2388,10 +2397,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000292
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a portion of matter which comprises gases occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+improve definition and make subclass of gas mixture and add disjoints:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
 
 It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
@@ -2402,7 +2415,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
@@ -4811,13 +4824,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
 Class: OEO_00010215
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a portion of matter produced from biogas by removing carbon dioxide. It is a gas mixture consisting mainly of methane. It has a gaseous state of matter an can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "biomethane"@en
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
@@ -6864,8 +6881,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
 Class: OEO_00140160
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a portion of matter which is a fuel gas mixture consisting primarily of hydrogen, carbon monoxide, and very often some carbon dioxide.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often some carbon dioxide that can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
 
@@ -6874,7 +6894,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         rdfs:label "syngas"@en
     
     SubClassOf: 
-        OEO_00000331,
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000220,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
@@ -7196,6 +7216,9 @@ Individual: OEO_00000390
         OEO_00000395
     
     
+DisjointClasses: 
+    OEO_00000074,OEO_00000263,OEO_00000292,OEO_00010215,OEO_00140160
+
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -388,7 +388,7 @@ ObjectProperty: owl:topObjectProperty
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portion of matters and that has a gaseous normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portions of matter and that has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "gas mixture"@en
@@ -2328,7 +2328,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000263
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that manufactured from coal. It is used as fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
@@ -2397,7 +2397,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000292
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
@@ -6881,7 +6881,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
 Class: OEO_00140160
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often some carbon dioxide that can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1152,7 +1152,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 remove origin 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-make subclass of gas mixture:
+make subclass of gas mixture and improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "air",


### PR DESCRIPTION
Add class `gas mixture`: _A gas mixture is a portion of matter that is a composition of different kinds of portion of matters and that has a gaseous normal state of matter._

Make some portions of matter subclasses of `gas mixture` and improve definitions:
* `air`: _Air is a gas mixture that forms the Earth's atmosphere._
* `biogas`: _Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel._
* `biomethane`: _Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel._
* `manufactured coal based gas`: _A manufactured coal based gas is a gas mixture that manufactured from coal. It is used as fossil fuel._
* `natural gas`: _Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, consisting mainly of methane._
* `syngas`: _Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often some carbon dioxide that can be used as fuel._

Closes #988