### PR TITLE
Axiom change for `energy transformation`, subclasses and related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 - heat exchanger, heater, turbine, water electrolyser, steam reformer, motor, pump, power rating, nameplate capacity (#993)
 - has state of matter, has normal state of matter (#1001)
 - peat (#1003)
+- energy transformation and subclasses, energy transformation unit (#1010)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3964,7 +3964,12 @@ Class: OEO_00010080
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add 'has physical output' some 'electrical energy'
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+add 'has physical output' some 'electrical energy'
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
@@ -5052,6 +5057,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00000533 some OEO_00000150,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
     
@@ -5242,7 +5250,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 has input relation:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+delete has physical output relation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
         rdfs:label "solar energy transformation"
     
     SubClassOf: 
@@ -5260,6 +5271,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
     
     SubClassOf: 
         OEO_00020046,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         OEO_00000533 some OEO_00000388,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
     
@@ -5274,6 +5288,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
     
     SubClassOf: 
         OEO_00020046,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         OEO_00000533 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
     
@@ -5458,6 +5475,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
     
     SubClassOf: 
         OEO_00000061,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3963,7 +3963,7 @@ Class: OEO_00010079
 Class: OEO_00010080
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam power process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add 'has physical output' some 'electrical energy'
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -625,7 +625,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000011
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit, e.g. a power generating unit, with the function of transforming or changing a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
@@ -633,7 +633,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
 
 renaming to component
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+redefine
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
         rdfs:comment "formerly called energy transformer and formerly called energy converting device",
         rdfs:label "energy converting component"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3977,7 +3977,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701",
     
     SubClassOf: 
         OEO_00020046,
-        OEO_00000533 some OEO_00000139
+        OEO_00000533 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
     
     
 Class: OEO_00010081
@@ -5050,6 +5052,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00000533 some OEO_00000150,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
     
     
@@ -5244,8 +5247,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000384,
-        OEO_00000533 some OEO_00000388
+        OEO_00000532 some OEO_00000384
     
     
 Class: OEO_00020047
@@ -5258,6 +5260,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
     
     SubClassOf: 
         OEO_00020046,
+        OEO_00000533 some OEO_00000388,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
     
     
@@ -5271,6 +5274,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
     
     SubClassOf: 
         OEO_00020046,
+        OEO_00000533 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
     
     
@@ -5454,6 +5458,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
     
     SubClassOf: 
         OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
     


### PR DESCRIPTION
closes #980 
closes #938 
I struggle with: `'energy transformation unit' 'has part' some 'energy converting component'`
The definition of `energy transformation unit` is: _An energy transformation unit is an artificial object that transforms, changes **or** transfers a certain type of energy._
For example, `grid component`, subclass of `energy transformation unit`, does not have to convert anything. I am thinking of a boring gas pipe without any pumps or anything else.
I implemented `'energy transformation unit' 'has part' some 'energy converting component'` but would prefer to delete it and add it for `power generating unit`, `power plant` and `power-to-gas system`.
