### PR TITLE
Added domain and range axioms from RO to relevant object properties

### DIFF
--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -131,18 +131,90 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "has characteristic"
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
     InverseOf: 
         OEO_00010121
     
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001025>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002222>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
+
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
@@ -453,6 +525,9 @@ ObjectProperty: OEO_00010121
 pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853",
         rdfs:label "has bearer"@en
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
     InverseOf: 
         <http://purl.obolibrary.org/obo/RO_0000053>
     
@@ -596,6 +671,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000020>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
@@ -603,6 +681,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000030>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000031>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000034>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000038>


### PR DESCRIPTION
Added domain and range axioms to relevant RO-imported object properties. Axioms were added to the oeo-shared module as they need the vocabulary from the BFO module. 

Closes #617 