### PR TITLE
Delete `oil and petroleum products` #811

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,12 @@ Here is a template for new release sections
 - study, methodical focus (#1011)
 - energy demand sector (#1015)
 - duration / time span (#1017)
+- crude oil, gas diesel oil, gasoline, kerosene (#1024)
 
 ### Removed
 - cost in oeo-social (#977)
 - organisation in oeo-social (#992)
+- oil and petroleum products (#1024)
 
 ## [1.8.0] - 2021-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Here is a template for new release sections
 - study, methodical focus (#1011)
 - energy demand sector (#1015)
 - duration / time span (#1017)
-- crude oil, gas diesel oil, gasoline, kerosene (#1024)
+- crude oil, gas diesel oil, gasoline, kerosene, oil power unit (#1024)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -908,7 +908,6 @@ Class: OEO_00000030
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000309,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -1530,12 +1529,16 @@ Class: OEO_00000102
 Class: OEO_00000115
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is an oil and petroleum product of natural origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "crude oil"
     
     SubClassOf: 
-        OEO_00000309,
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000256
     
     
@@ -1802,25 +1805,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000181
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is an oil and petroleum product that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "gas diesel oil"
     
     SubClassOf: 
-        OEO_00000309,
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000183
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is an oil and petroleum product in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         rdfs:label "gasoline"
     
     SubClassOf: 
-        OEO_00000309,
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000256
     
     
@@ -2202,7 +2213,7 @@ Class: OEO_00000245
 Class: OEO_00000246
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is an oil and petroleum product consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
 [...]
 
 Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
@@ -2210,7 +2221,11 @@ Kerosene is widely used to power jet engines of aircraft (jet fuel) and some roc
         rdfs:label "kerosene"
     
     SubClassOf: 
-        OEO_00000309,
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         OEO_00000529 value OEO_00000256
     
     
@@ -2580,30 +2595,6 @@ Class: OEO_00000308
     
     DisjointWith: 
         OEO_00000311
-    
-    
-Class: OEO_00000309
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum (/pəˈtroʊliəm/) is a naturally occurring, yellowish-black liquid found in geological formations beneath the Earth's surface. It is commonly refined into various types of fuels. Components of petroleum are separated using a technique called fractional distillation, i.e. separation of a liquid mixture into fractions differing in boiling point by means of distillation, typically using a fractionating column.
-
-It consists of hydrocarbons of various molecular weights and other organic compounds. The name petroleum covers both naturally occurring unprocessed crude oil and petroleum products that are made up of refined crude oil. A fossil fuel, petroleum is formed when large quantities of dead organisms, mostly zooplankton and algae, are buried underneath sedimentary rock and subjected to both intense heat and pressure."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Petroleum&oldid=868006507"@en,
-        rdfs:label "oil and petroleum products",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002985"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00000310

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -909,6 +909,11 @@ Class: OEO_00000030
     SubClassOf: 
         OEO_00000334,
         
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024"
+        OEO_00000503 some 
+            (OEO_00000181 or OEO_00000183),
+        
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1531,6 +1531,9 @@ Class: OEO_00000115
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "crude oil"
     
     SubClassOf: 
@@ -1807,6 +1810,9 @@ Class: OEO_00000181
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "gas diesel oil"
     
     SubClassOf: 
@@ -1824,6 +1830,9 @@ Class: OEO_00000183
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "gasoline"
     
     SubClassOf: 
@@ -2218,6 +2227,9 @@ Class: OEO_00000246
 
 Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "kerosene"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1534,9 +1534,9 @@ Class: OEO_00000102
 Class: OEO_00000115
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "crude oil"
@@ -1815,7 +1815,7 @@ Class: OEO_00000181
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "gas diesel oil"
@@ -1835,7 +1835,7 @@ Class: OEO_00000183
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "gasoline"
@@ -2232,7 +2232,7 @@ Class: OEO_00000246
 
 Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and inherit axioms from old class 'oil and petroleum products'
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         rdfs:label "kerosene"


### PR DESCRIPTION
This is part of solving #811:

* Delete `oil and petroleum products` #811
* Make subclasses (`crude oil`, `gas diesel oil`, `gasoline`, `kerosene`) direct subclasses of `portion of matter`
  * adapt definitions
  * inherit axioms from old class `oil and petroleum products`