### PR TITLE
Add `primary energy carrier disposition` to `natural gas`, `coal`, `crude oil` and `peat` #1032

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1439,6 +1439,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000390
     
     
@@ -1539,6 +1540,7 @@ Class: OEO_00000115
     
     SubClassOf: 
         OEO_00000309,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000256
     
     
@@ -2448,6 +2450,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000182
     
     
@@ -2701,6 +2704,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000390
     
     
@@ -5896,7 +5900,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
     
 Class: OEO_00030035
 
-
+    
 Class: OEO_00040011
 
     


### PR DESCRIPTION
This partially solves #1032 by adding the axiom 'has disposition' some 'primary energy carrier disposition' to the classes `natural gas`, `coal`, `crude oil` and `peat`. These will then be inferred as subclasses of `primary energy carrier`:

![grafik](https://user-images.githubusercontent.com/36884905/154656467-6f9de36d-c209-4bdc-9387-e895364c2e25.png)
