### PR TITLE
Add editor note to all gasoline-related classes #1028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Here is a template for new release sections
 - study, study report (#1025)
 - biogasoline, biodiesel, (fossil) gasoline/diesel fuel (#1027)
 - natural gas, coal, crude oil, peat, wood (#1033)
-- editor note on gasoline-related classed (#1036)
+- editor note on gasoline-related classed (#1037)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Here is a template for new release sections
 - study, study report (#1025)
 - biogasoline, biodiesel, (fossil) gasoline/diesel fuel (#1027)
 - natural gas, coal, crude oil, peat, wood (#1033)
+- editor note on gasoline-related classed (#1036)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -487,6 +487,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel role is a fuel role that expresses that a portion of matter can be used in a gasoline engine.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel role"@en
@@ -511,6 +515,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel is a combustion fuel that has a gasoline fuel role.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel"@en
@@ -543,6 +551,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline engine is an internal combustion engine that uses a gasoline fuel.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasoline motor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
@@ -571,6 +583,10 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline vehicle is an internal combustion vehicle that has only a gasoline engine as motor for propulsion.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline vehicle"@en
@@ -1459,6 +1475,10 @@ Class: OEO_00000066
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "aviation gasoline"
     
@@ -1580,7 +1600,10 @@ Class: OEO_00000075
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
 
@@ -2061,6 +2084,10 @@ Class: OEO_00000183
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
@@ -2670,6 +2697,10 @@ Class: OEO_00000286
         <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
 
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "motor gasoline"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -490,7 +490,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel role"@en
@@ -518,7 +518,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel"@en
@@ -554,7 +554,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasoline motor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
@@ -586,7 +586,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline vehicle"@en
@@ -1478,7 +1478,7 @@ Class: OEO_00000066
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "aviation gasoline"
     
@@ -1600,7 +1600,7 @@ Class: OEO_00000075
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037",
@@ -2087,7 +2087,7 @@ Class: OEO_00000183
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
@@ -2700,7 +2700,7 @@ Includes motor gasoline blending components (excluding additives/oxygenates), e.
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "motor gasoline"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -489,7 +489,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel role is a fuel role that expresses that a portion of matter can be used in a gasoline engine.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
@@ -517,7 +517,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel is a combustion fuel that has a gasoline fuel role.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
@@ -553,7 +553,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline engine is an internal combustion engine that uses a gasoline fuel.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasoline motor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
@@ -585,7 +585,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline vehicle is an internal combustion vehicle that has only a gasoline engine as motor for propulsion.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
@@ -1477,7 +1477,7 @@ Class: OEO_00000066
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "aviation gasoline"
@@ -1603,7 +1603,7 @@ Class: OEO_00000075
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036",
+https://github.com/OpenEnergyPlatform/ontology/pull/1037",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
 
@@ -2086,7 +2086,7 @@ Class: OEO_00000183
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
@@ -2699,7 +2699,7 @@ Class: OEO_00000286
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1036"
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the preference of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "motor gasoline"


### PR DESCRIPTION
_The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO._

Closes #1028