### PR TITLE
Use axiom `has energy input` / `has energy output` for `energy transformation` and subclasses #994

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Here is a template for new release sections
 - biogasoline, biodiesel, (fossil) gasoline/diesel fuel (#1027)
 - natural gas, coal, crude oil, peat, wood (#1033)
 - editor note on gasoline-related classed (#1037)
+- use has energy input / output for energy transformation and subclasses (#1041)
 
 ### Removed
 - cost in oeo-social (#977)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4376,7 +4376,11 @@ Class: OEO_00010081
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "solar chemical energy transformation"@en
     
     SubClassOf: 
@@ -4632,7 +4636,11 @@ Class: OEO_00010099
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "marine tidal energy transformation"@en
     
     SubClassOf: 
@@ -4698,7 +4706,11 @@ Class: OEO_00010103
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "marine wave energy transformation"@en
     
     SubClassOf: 
@@ -6526,7 +6538,11 @@ Class: OEO_00050020
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
         rdfs:label "steam-electric process"@en
     
     SubClassOf: 
@@ -7599,7 +7615,11 @@ Class: OEO_00240014
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "electricity generation process"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5277,8 +5277,8 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         (OEO_00000532 some OEO_00000006)
          and (OEO_00000532 some OEO_00000441)
          and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00000007)
-         and (OEO_00000533 some OEO_00010018),
+        (OEO_00000533 some OEO_00010018)
+         and (OEO_00010235 some OEO_00000007),
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010220
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4353,7 +4353,11 @@ add 'has physical output' some 'electrical energy'
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "solar-steam-electric process"@en
     
     EquivalentTo: 
@@ -4362,7 +4366,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701",
     
     SubClassOf: 
         OEO_00020046,
-        OEO_00000533 some OEO_00000139,
+        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
     
@@ -4377,7 +4381,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735",
     
     SubClassOf: 
         OEO_00020046,
-        OEO_00000533 some OEO_00000007
+        OEO_00010235 some OEO_00000007
     
     
 Class: OEO_00010084
@@ -4609,12 +4613,16 @@ Class: OEO_00010098
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "marine current energy transformation"@en
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00000532 some OEO_00010097,
+        OEO_00010234 some OEO_00010097,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010107
     
@@ -4629,7 +4637,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00000532 some OEO_00010100,
+        OEO_00010234 some OEO_00010100,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010101
     
@@ -4695,7 +4703,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00000532 some OEO_00010102,
+        OEO_00010234 some OEO_00010102,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00010106
     
@@ -5216,31 +5224,39 @@ Class: OEO_00010216
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "power-to-gas process"@en
     
     SubClassOf: 
         OEO_00020003,
-        (OEO_00000532 some OEO_00000139)
-         and (OEO_00000532 some OEO_00000331),
-        (OEO_00000533 some OEO_00000007)
-         and (OEO_00000533 some OEO_00010155)
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010155)
+         and (OEO_00010235 some OEO_00000007)
     
     
 Class: OEO_00010217
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "power-to-methane process"@en
     
     SubClassOf: 
         OEO_00010216,
         (OEO_00000532 some OEO_00000006)
-         and (OEO_00000532 some OEO_00000139)
-         and (OEO_00000532 some OEO_00000441),
+         and (OEO_00000532 some OEO_00000441)
+         and (OEO_00010234 some OEO_00000139),
         (OEO_00000533 some OEO_00000007)
          and (OEO_00000533 some OEO_00010018),
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
@@ -5266,16 +5282,20 @@ Class: OEO_00010219
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "water electrolysis process"@en
     
     SubClassOf: 
         OEO_00020003,
-        (OEO_00000532 some OEO_00000139)
-         and (OEO_00000532 some OEO_00000441),
-        (OEO_00000533 some OEO_00000007)
-         and (OEO_00000533 some OEO_00000220)
-         and (OEO_00000533 some OEO_00010218),
+        (OEO_00000532 some OEO_00000441)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00000220)
+         and (OEO_00000533 some OEO_00010218)
+         and (OEO_00010235 some OEO_00000007),
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010021
     
     
@@ -5435,16 +5455,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 add relation to energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "energy transformation"@en
     
     SubClassOf: 
         OEO_00000419,
-        OEO_00000532 some OEO_00000150,
+        OEO_00010234 some OEO_00000150,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 some OEO_00000150,
+        OEO_00010235 some OEO_00000150,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
@@ -5605,11 +5629,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000446,
+        OEO_00010234 some OEO_00000446,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 some OEO_00000139,
+        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
     
     
@@ -5641,12 +5665,16 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
 delete has physical output relation:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "solar energy transformation"
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000384
+        OEO_00010234 some OEO_00000384
     
     
 Class: OEO_00020047
@@ -5654,7 +5682,11 @@ Class: OEO_00020047
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "solar thermal energy transformation"
     
     SubClassOf: 
@@ -5662,7 +5694,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00000533 some OEO_00000388,
+        OEO_00010235 some OEO_00000388,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
     
     
@@ -5671,7 +5703,11 @@ Class: OEO_00020048
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "photovoltaic energy transformation"
     
     SubClassOf: 
@@ -5679,7 +5715,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00000533 some OEO_00000139,
+        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
     
     
@@ -5720,16 +5756,20 @@ Class: OEO_00020054
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "nuclear energy transformation"
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000300,
+        OEO_00010234 some OEO_00000300,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 some OEO_00000207
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00020058
@@ -5752,12 +5792,16 @@ Class: OEO_00020059
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "geothermal heat transfer"
     
     SubClassOf: 
         OEO_00140101,
-        OEO_00000532 only OEO_00000191
+        OEO_00010234 only OEO_00000191
     
     
 Class: OEO_00020066
@@ -6487,11 +6531,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702"@en,
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000207,
+        OEO_00010234 some OEO_00000207,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 some OEO_00000139,
+        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
     
@@ -6569,12 +6613,16 @@ Class: OEO_00110004
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
         rdfs:label "hydro energy transformation"@en
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000218
+        OEO_00010234 some OEO_00000218
     
     
 Class: OEO_00110005
@@ -6582,7 +6630,11 @@ Class: OEO_00110005
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
         rdfs:label "hydroelectric energy transformation"@en
     
     SubClassOf: 
@@ -6590,7 +6642,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 some OEO_00000139
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00140000
@@ -7053,8 +7105,13 @@ Class: OEO_00140101
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
+
 subclass of energy transfer
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "heat transfer"@en
     
     SubClassOf: 
@@ -7062,11 +7119,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000532 only OEO_00000207,
+        OEO_00010234 only OEO_00000207,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00000533 only OEO_00000207
+        OEO_00010235 only OEO_00000207
     
     
 Class: OEO_00140102
@@ -7129,12 +7186,16 @@ Class: OEO_00140106
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "ambient thermal energy transfer"@en
     
     SubClassOf: 
         OEO_00140101,
-        OEO_00000532 some OEO_00000056,
+        OEO_00010234 some OEO_00000056,
         <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
@@ -7458,13 +7519,17 @@ Class: OEO_00240009
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "combined heat and power generation"
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000533 some OEO_00000139,
-        OEO_00000533 some OEO_00000207
+        OEO_00010235 some OEO_00000139,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00240010
@@ -7539,13 +7604,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
     
     EquivalentTo: 
         OEO_00020003
-         and (OEO_00000533 some OEO_00000139)
+         and (OEO_00010235 some OEO_00000139)
     
     SubClassOf: 
         OEO_00020003,
         OEO_00000500 some OEO_00240012,
         OEO_00000500 some OEO_00240013,
-        OEO_00000533 some OEO_00000139
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00240015

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -315,9 +315,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
 ObjectProperty: OEO_00000532
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity or energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "has physical input"
     
     SubPropertyOf: 
@@ -331,15 +335,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     Range: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 ObjectProperty: OEO_00000533
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity or energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "has physical output"
     
     SubPropertyOf: 
@@ -355,7 +363,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 ObjectProperty: OEO_00010234


### PR DESCRIPTION
Change `has energy input some energy` and `has energy output some energy` axioms for the following classes:
* `ambient thermal energy transfer`
* `combined heat and power generation`
* `electricity generation process`
* `energy transformation`
* `geothermal heat transfer`
* `heat transfer`
* `hydroelectric energy transformation`
* `hydro energy transformation`
* `marine current energy transformation`
* `marine tidal energy transformation`
* `marine wave energy transformation`
* `nuclear energy transformation`
* `photovoltaic energy transformation`
* `power-to-gas process`
* `power-to-methane process`
* `solar chemical energy transformation`
* `solar energy transformation`
* `solar-steam-electric process`
* `steam-electric process`
* `wind energy transformation`
* `water electrolysis process`

Restrict range of `has physical input` and `has physical output` to `material entity`.

Slightly adapt definition to match updated axioms:
* `has physical input`: _p has physical input c iff: p has input c, and c is a material entity ~or energy~_
* `has physical output`: _p has physical output c iff: p has output c, and c is a material entity ~or energy~_
* `power-to-methane process`: _A power-to-methane process is a power-to-gas process that has electrical energy **as energy input**, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation._

Closes #994