### PR TITLE
Add editor note on `water` #1081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - license (#1063)
 - is energy participant of and subrelations (#1057)
 - acronym (#1075)
+- water (#1099)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3641,6 +3641,10 @@ Class: OEO_00000441
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
         
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
+        
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3643,7 +3643,7 @@ Class: OEO_00000441
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"


### PR DESCRIPTION
_We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons._

Closes #1081