### PR TITLE
Add classes `heat generation process` and `combustion thermal energy transformation` #1045

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Here is a template for new release sections
 - slope, surface azimuth angle (#1112)
 - potential (#1102)
 - information input/output of (#1113)
+- heat generation, combustion thermal energy transformation (#1130)
 
 ### Changed
 - has bearer, bearer of, is defined by, process attribute of (#985)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -689,6 +689,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
             (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032)))
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
+        rdfs:label "heat generation process"@en
+    
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000207)
+    
+    SubClassOf: 
+        OEO_00020003
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010249>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion thermal energy transformation is an energy transformation that converts chemical energy of a combustion fuel into thermal energy.",
+        rdfs:label "combustion thermal energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00000532 some OEO_00000099,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000207,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038
+    
+    
 Class: <http://opennergy-plattform.org/ontology/oeo/OEO_00290002>
 
     Annotations: 
@@ -7852,20 +7880,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
     
     
-
-Class: OEO_00290001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
-        rdfs:label "slope"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
-
 Class: OEO_00240026
 
     Annotations: 
@@ -8003,6 +8017,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
     
     SubClassOf: 
         OEO_00000350
+    
+    
+Class: OEO_00290001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
+        rdfs:label "slope"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -693,6 +693,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
         rdfs:label "heat generation process"@en
     
     EquivalentTo: 
@@ -707,6 +709,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010249>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion thermal energy transformation is an energy transformation that converts chemical energy of a combustion fuel into thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
         rdfs:label "combustion thermal energy transformation"@en
     
     SubClassOf: 


### PR DESCRIPTION
Adds:
* `heat generation process`: _A heat generation process is an energy transformation that has thermal energy as energy output._
* `combustion thermal energy transformation`: _A combustion thermal energy transformation is an energy transformation that converts chemical energy of a combustion fuel into thermal energy._

Solves #1045 only partially, as the axiom `'heat generation process' causes some emission` cannot be implemented yet. Depends on further imports from RO are needed for this.