### PR TITLE
Make `capacity factor` a subclass of `fraction value` #1144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Here is a template for new release sections
 - energy system (#1123)
 - trades / is traded at, good, good role (#1127)
 - traction motor -> electric traction motor (#1135)
+- capacity factor (#1144)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7884,7 +7884,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00240016
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
@@ -7892,7 +7892,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946",
         rdfs:label "net capacity factor"
     
     SubClassOf: 
-        OEO_00000350
+        OEO_00140127
     
     
 Class: OEO_00240018

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7888,7 +7888,11 @@ Class: OEO_00240016
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
+
+make subclass of 'fraction value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
         rdfs:label "net capacity factor"
     
     SubClassOf: 


### PR DESCRIPTION
Make `capacity factor` a subclass of `fraction value` and redefine to:
_A net capacity factor is a fraction **value** that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step._

Closes #1144 