### PR TITLE
import `programming language` #1132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Here is a template for new release sections
 ## [1.X.X] - 20XX-XX-XX
 
 ### Added
+- programming language (#1156)
 ### Changed
 - marine wave energy transformation, marine tidal energy transformation, marine current energy transformation (#1137)
 ### Removed

--- a/src/ontology/imports/iao-module.owl
+++ b/src/ontology/imports/iao-module.owl
@@ -138,7 +138,20 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">software</rdfs:label>
     </owl:Class>
     
+    <!-- http://purl.obolibrary.org/obo/IAO_0000025 -->
 
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <obo:IAO_0000111 xml:lang="en">programming language</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">R, Perl, Java</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">A language in which source code is written that is intended to be executed/run by a software interpreter. Programming languages are ways to write instructions that specify what to do, and sometimes, how to do it.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">person:Chris Stoeckert</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000058</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">programming language</rdfs:label>
+    </owl:Class>
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
 

--- a/src/ontology/imports/iao-module.owl
+++ b/src/ontology/imports/iao-module.owl
@@ -80,6 +80,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233"/>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -138,6 +144,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">software</rdfs:label>
     </owl:Class>
     
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000025 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000025">
@@ -150,8 +158,13 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">person:Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI_0000058</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <obo:IAO_0000233>import &apos;programming language&apos; manually
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1132
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1156</obo:IAO_0000233>
         <rdfs:label xml:lang="en">programming language</rdfs:label>
     </owl:Class>
+    
+
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
 


### PR DESCRIPTION
### Elements to be addressed

| Type    | Element                                             | Description    |
| ------- | --------------------------------------------------- | -------------- |
| `[__C]` | 'programming language' aka IAO_0000025 | manual import from IAO |

### Related discussions

This PR closes #1132

### Remarks

`term tracker item` is located in `iao-module`, too.
This will potentially reworked in #1154 