### PR TITLE
Fix classification of `software license` #1153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Here is a template for new release sections
 ### Changed
 - marine wave energy transformation, marine tidal energy transformation, marine current energy transformation (#1137)
 - has input, input of, has output, output of, participates in, has participant (#1138)
+- software license (#1163)
 ### Removed
 
 ## [1.10.0] - 2022-05-09

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -862,6 +862,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000017>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
     
@@ -1726,7 +1729,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
         rdfs:label "software license"
     
     SubClassOf: 
-        OEO_00020015
+        OEO_00020185
     
     
 Class: OEO_00030015
@@ -2065,8 +2068,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000017>
-
-
+    
+    
 Class: OEO_00140081
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1729,6 +1729,10 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
         rdfs:label "software license"
     
     SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
         OEO_00020185
     
     


### PR DESCRIPTION
## Summary of the discussion

`software license` aka OEO_00020187 was wrongly classified according to its definition. #1153

Remarks: 
Forgot capitalizing and appending issue number in commit message 1 + 2 (couldn't be edited without rewriting the repo-history)
I'll update my auto-formater, so I won't miss it in the future :)

I also copy-pasted the draft of the PR template in order to see how it works.
(Meaning, no automation involved. The template is still subject to review)

## Type of change

### Updated
- Move `software license` from `license` to `copyright license` #1153

## Workflow checklist

### Assignee
- [x] An agreement has been reached
- [x] 🐙 Add yourself as Assignee
- [x] 🐙 Create a draft pull request
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add # to term tracker item
- [x] 🐙 All unit tests pass
- [x] 🐙 Add someone or a group (oeo-dev) as Reviewer
- [x] 🐙 Publish pull request

### Reviewer
- [ ] ToDo: Add checklist for reviewer
- [ ] 🐙 All unit tests pass

### Assignee
- [ ] 🐙 Merge pull request
- [ ] 🐙 Delete branch
- [ ] 🐙 Close issue


**Automation**
Closes #1153
