### PR TITLE
Add missing axioms at core energy-related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Here is a template for new release sections
 - software license (#1163)
 - photon, energy (#1165)
 - energy carrier (#1173)
+- transformation, energy transformation, energy carrier disposition, fuel role (#1178)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -378,6 +378,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         OEO_00240025
     
     
+ObjectProperty: OEO_00010121
+
+    
 ObjectProperty: OEO_00010234
 
     Annotations: 
@@ -877,7 +880,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00000331
     
     
 Class: OEO_00000003
@@ -5735,6 +5739,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -872,7 +872,11 @@ Class: OEO_00000001
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
         rdfs:label "fuel role",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -5725,7 +5729,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+add axiom relating to energy carrier
+input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
         rdfs:label "energy transformation"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6369,11 +6369,12 @@ Class: OEO_00030000
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "anthropogenic is an origin of portions of matter or energies created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "include \"or energies\"
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+include \"or energies\"
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "anthropogenic"
     
     SubClassOf: 
@@ -6436,7 +6437,6 @@ Class: OEO_00030004
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/397

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1105,7 +1105,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
         rdfs:label "energy carrier disposition"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00000206
@@ -1278,7 +1279,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
         rdfs:label "transformation"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
 Class: OEO_00000423

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1101,7 +1101,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
 move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
         rdfs:label "energy carrier disposition"
     
     SubClassOf: 
@@ -1275,7 +1279,11 @@ Class: OEO_00000419
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
         rdfs:label "transformation"
     
     SubClassOf: 


### PR DESCRIPTION
Add the following axioms as part of #1167:
* `'transformation' 'has input' some continuant'` and `'transformation' 'has output' some continuant'`, following the definition: _A transformation is a process that transforms **one or more inputs into at least one output**._
* `'energy transformation' 'has participant' some 'energy carrier'` as to me an energy transformation without any energy carrier does not make sense.
* `'fuel role' 'has bearer' 'portion of matter'` following the definition: _A fuel role is **a role of a portion of matter** that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work._
* `'energy carrier disposition' 'has bearer' some 'material entity'` following the definition: _An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy._

This PR also merges some duplicate term trackers, found in some `origin subclasses`.