### PR TITLE
Update definition and axiom of `fossil energy` #1172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Here is a template for new release sections
 - transformation, energy transformation, energy carrier disposition, fuel role (#1178)
 - fossil (#1181)
 - energy transformation (#1182)
+- fossil energy (#1185)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6356,7 +6356,11 @@ Class: OEO_00020149
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Update definition and axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1172
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
         rdfs:label "fossil energy"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6354,7 +6354,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
 Class: OEO_00020149
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
         rdfs:label "fossil energy"
@@ -6362,7 +6362,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
     EquivalentTo: 
         OEO_00000007
          and (OEO_00000530 some OEO_00020147)
-         and (OEO_00000530 some OEO_00030002)
+         and (OEO_00010121 some OEO_00000014)
     
     SubClassOf: 
         OEO_00000007


### PR DESCRIPTION
Update definition to: _Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin._

Update axiom: `'fossil energy' 'Equivalent To' 'chemical energy' and ('has origin' some conventional) and ('has bearer' some 'fossil combustion fuel')`

Closes #1172