### PR TITLE
Change range of `has institution` to `organisational role` #1161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Here is a template for new release sections
 - energy transformation (#1182)
 - fuel (#1184)
 - fossil energy (#1185)
+- has institution (#1200)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -485,7 +485,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1042",
         OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
     
     Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000238
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     
 ObjectProperty: OEO_00000514

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -485,6 +485,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1042",
         OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
     
     Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     


### PR DESCRIPTION
## Summary of the discussion

The usage of `institution` as range in the axiom `has role some` defined for `has institution` caused inconsistencies, as `has role` required a `role` while `institution` is a `immaterial entity`.

## Type of change (see CHANGELOG.md)

### Changed

- Replace `institution` as range by `organisation role`

## Workflow checklist

### Automation

#1161 should remain open as there might be a more sophisticated solution following.

### PR-Assignee
- [x] An agreement has been reached
- [x] 🐙 Add yourself as `Assignee`
- [x] 🐙 Create a draft pull request
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add # to `term tracker item`
- [x] 🐙 All unit tests pass
- [x] 🐙 Publish pull request
- [x] 🐙 Add someone or a group (oeo-dev) as `Reviewer`

### PR-Reviewer
- [ ] 🐙 All unit tests pass
- [ ] 📙 All changes are in the correct OEO module
- [ ] 📙 Update of `changelog` has been done
- [ ] 📙 Correct entries in `term tracker item`
- [ ] 🐙 Provide feedback and show sufficient appreciation for the work done

### PR-Assignee
- [ ] 🐙 Show recognition for the review performed
- [ ] 🐙 Merge pull request
- [ ] 🐙 Delete branch
- [ ] 🐙 Close issue
