### PR TITLE
bugfix general class axioms "combustible things"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Here is a template for new release sections
 - energy transformation (#1182)
 - fuel (#1184)
 - fossil energy (#1185)
+- general class axiom "combustible things" (#1195)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical-axioms.owl
+++ b/src/ontology/edits/oeo-physical-axioms.owl
@@ -95,6 +95,12 @@
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00000097 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00000097"/>
+    
+
+
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00000139 -->
 
     <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00000139"/>
@@ -150,7 +156,7 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000091"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00000151"/>
+                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00000097"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>


### PR DESCRIPTION
changed general class axiom according to #1195:
involved `combustible energy carrier disposition` instead of just `energy carrier disposition`

closes #1195