### PR TITLE
Add `scenario projection` #970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Here is a template for new release sections
 
 ### Added
 - combustion thermal energy transformation (#1210)
+- scenario projection (#1217)
 
 ### Changed
 ### Removed

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1057,7 +1057,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
 Class: OEO_00010262
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculations based on a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
 (Intentional: a research question is basis for the projection to be done)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1082,8 +1082,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00140024,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00030029
-
-
+    
+    
 Class: OEO_00010262
 
     Annotations: 
@@ -1099,8 +1099,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
-
-
+    
+    
 Class: OEO_00020011
 
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1054,6 +1054,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
     
     
+Class: OEO_00010262
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculations based on a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
+(Intentional: a research question is basis for the projection to be done)",
+        rdfs:label "scenario projection"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
+    
+    
 Class: OEO_00020011
 
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1060,6 +1060,8 @@ Class: OEO_00010262
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculations based on a scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
 (Intentional: a research question is basis for the projection to be done)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
         rdfs:label "scenario projection"@de
     
     SubClassOf: 


### PR DESCRIPTION
Definition: _A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculations based on a scenario._

Closes #970