### PR TITLE
Update version number in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -114,7 +114,7 @@ authors:
 title: "Open Energy Ontology (OEO)"
 type: software
 license: CC0-1.0
-version: 1.9.0
+version: 1.10.1
 doi: 
-date-released: 2022-03-01
+date-released: 2022-06-14
 url: "https://github.com/OpenEnergyPlatform/ontology"


### PR DESCRIPTION
During the last two releases, CITATION.cff was not updated. This PR fixes this.

Maybe, there is a way to automatise this. But for the moment, I documented this update as a necessary step in the wiki: https://github.com/OpenEnergyPlatform/ontology/wiki/How-to-release-a-new-ontology-version