### PR TITLE
Add range axiom for `has participant` #1157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Here is a template for new release sections
 - endogenous data, exogenous data (#1216)
 - origin, portion of matter (#1218)
 - pv cell -> photovoltaic cell (#1220)
+- has participant (#1225)
 
 ### Removed
 

--- a/src/ontology/imports/ro-module.owl
+++ b/src/ontology/imports/ro-module.owl
@@ -397,6 +397,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1138</obo:IAO_
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
         <obo:IAO_0000111 xml:lang="en">has participant</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">this blood coagulation has participant this blood clot</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">this investigation has participant this investigator</obo:IAO_0000112>
@@ -985,6 +986,12 @@ Each of these 3 primitives can be composed to yield a cross-product of different
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
     
 
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -112,7 +112,11 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "make inverse of participates in
 issue https://github.com/OpenEnergyPlatform/ontology/issues/979
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086"
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086
+
+Add range axiom for `has participant`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1157
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225"
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001015>


### PR DESCRIPTION
## Summary of the discussion

`range` for `has participant` has to be added, based on the properties definition.

## Type of change (see CHANGELOG.md)

### Changed
- insert `continuant` as `range`

## Workflow checklist

### Automation
Closes #1157 

### PR-Assignee
- [x] An agreement has been reached
- [x] 🐙 Add yourself as `Assignee`
- [x] 🐙 Create a draft pull request
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add # to `term tracker item`
- [x] 🐙 All unit tests pass
- [x] 🐙 Publish pull request
- [x] 🐙 Add someone or a group (oeo-dev) as `Reviewer`

### PR-Reviewer
- [ ] 📙 Axioms have been added and reflect the definition
- [ ] 📙 Spelling and grammar in the definition text are correct
- [ ] 📙 Update of `changelog` has been done
- [ ] 📙 Correct entries in `term tracker item`
- [ ] 🐙 Provide feedback and show sufficient appreciation for the work done

### PR-Assignee
- [ ] 🐙 Show recognition for the review performed
- [ ] 🐙 Merge pull request
- [ ] 🐙 Delete branch
- [ ] 🐙 Close issue