### PR TITLE
Relabel `has institution` to `has organisation` #1161 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Here is a template for new release sections
 - measurement device (#1215)
 - parameterisation, model calibration (#1216)
 - scenario projection (#1217)
+- has institution -> has organisation (#1226)
 
 ### Changed
 - endogenous data, exogenous data (#1216)

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -476,7 +476,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain an
 improve definition:
 https://github.com/OpenEnergyPlatform/ontology/issues/1038
 https://github.com/OpenEnergyPlatform/ontology/pull/1042",
-        rdfs:label "has institution"
+        rdfs:label "has organisation"
     
     SubPropertyOf: 
         OEO_00140008

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -469,7 +469,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
 ObjectProperty: OEO_00000510
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the institution in which it was created."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -475,7 +475,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain an
 
 improve definition:
 https://github.com/OpenEnergyPlatform/ontology/issues/1038
-https://github.com/OpenEnergyPlatform/ontology/pull/1042",
+https://github.com/OpenEnergyPlatform/ontology/pull/1042
+
+Relabel to `has organisation`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
         rdfs:label "has organisation"
     
     SubPropertyOf: 


### PR DESCRIPTION
## Summary of the discussion

Relabeling the object-property adds a simplification to the ontology which allows to resolve inconsistencies without extending the ontology.
This is a follow-up of PR #1200 which only featured the inconsistency fix.

## Type of change (see CHANGELOG.md)

### Changed
- `has institution` -> `has organisation` (inkl. definition update)

## Workflow checklist

### Automation
Closes #1161

### PR-Assignee
- [x] An agreement has been reached
- [x] 🐙 Add yourself as `Assignee`
- [x] 🐙 Create a draft pull request
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add # to `term tracker item`
- [x] 🐙 All unit tests pass
- [x] 🐙 Publish pull request
- [x] 🐙 Add someone or a group (oeo-dev) as `Reviewer`

### PR-Reviewer
- [x] 📙 Spelling and grammar in the definition text are correct
- [x] 📙 Update of `changelog` has been done
- [x] 📙 Correct entries in `term tracker item`
- [x] 🐙 Provide feedback and show sufficient appreciation for the work done

### PR-Assignee
- [ ] 🐙 Show recognition for the review performed
- [ ] 🐙 Merge pull request
- [ ] 🐙 Delete branch
- [ ] 🐙 Close issue
