### PR TITLE
Add axioms for photovoltaic #1074

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ Here is a template for new release sections
 - measurement device (#1215)
 - parameterisation, model calibration (#1216)
 - scenario projection (#1217)
+- tangential proper part, surface, solar radiation receiving surface (#1209)
+- solar receiving object (#1228)
 
 ### Changed
 - endogenous data, exogenous data (#1216)
 - origin, portion of matter (#1218)
 - pv cell -> photovoltaic cell (#1220)
+- photovoltaic cell, solar thermal collector (#1228)
 
 ### Removed
 
@@ -34,7 +37,6 @@ Here is a template for new release sections
 - fissile material entity (#1190, #1196)
 - realized in (#1197)
 - frequency control and subclasses primary control, secondary control, tertiary control (#1202)
-- tangential proper part, surface, solar radiation receiving surface (#1209)
 
 ### Changed
 - marine wave energy transformation, marine tidal energy transformation, marine current energy transformation (#1137)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1349,7 +1349,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 Add axiom to 'has part some solar radiation receiving surface'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228"
 
 Update definition, label and axioms, add alternative terms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3485,7 +3485,10 @@ Class: OEO_00000387
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
         rdfs:label "solar thermal collector"
     
     SubClassOf: 
@@ -3498,6 +3501,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         OEO_00010235 some OEO_00000388,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6500,6 +6500,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
         OEO_00020198
     
     
+Class: OEO_00020200
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+        rdfs:label "solar receiving object"
+    
+    EquivalentTo: 
+        OEO_00000061
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199)
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1347,6 +1347,10 @@ Class: OEO_00000032
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
+Add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+
 Update definition, label and axioms, add alternative terms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
@@ -1359,6 +1363,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         OEO_00010234 some OEO_00000384,
         OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1349,7 +1349,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 Add axiom to 'has part some solar radiation receiving surface'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
 
 Update definition, label and axioms, add alternative terms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152


### PR DESCRIPTION
⚠: 
This PR contains a merge which will disappear as soon #1227 is done.
The **review and merge** of PR #1227 is a mandatory prerequisite for this PR.

## Summary of the discussion

This is a **partial replacement** of PR #1209 . 
Changes done in #1209 where cherry-picked and selectively added.

## Type of change (see CHANGELOG.md)

### Added

- eqiv. class: `solar receiving object`
- axiom:  `solar thermal collector` `has part` `some` `solar radiation receiving surface`
- aciom: `photovoltaic cell` `has part` `some` `solar radiation receiving surface`

## Workflow checklist

### Automation

Closes #1074

### PR-Assignee
- [x] An agreement has been reached
- [x] 🐙 Add yourself as `Assignee`
- [x] 🐙 Create a draft pull request
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add # to `term tracker item`
- [x] 🐙 All unit tests pass
- [x] 🐙 Publish pull request
- [x] 🐙 Add someone or a group (oeo-dev) as `Reviewer`

### PR-Reviewer
- [ ] 📙 Class name fits the concept
- [ ] 📙 The classification according to the BFO is correct
- [ ] 📙 Axioms have been added and reflect the definition
- [ ] 📙 Spelling and grammar in the definition text are correct
- [ ] 📙 All changes are in the correct OEO module
- [ ] 📙 Update of `changelog` has been done
- [ ] 📙 Correct entries in `term tracker item`
- [ ] 🐙 Provide feedback and show sufficient appreciation for the work done

### PR-Assignee
- [ ] 🐙 Show recognition for the review performed
- [ ] 🐙 Merge pull request
- [ ] 🐙 Delete branch
- [ ] 🐙 Close issue