### PR TITLE
Fix `power capacity` axiom #1223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Here is a template for new release sections
 - is energy participant of, has energy participant (#1221)
 - has participant (#1225)
 - photovoltaic cell, solar thermal collector (#1228)
+- power capacity (#1235)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5713,7 +5713,11 @@ Class: OEO_00010257
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
+
+Fix 'quantity value of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
         rdfs:label "power capacity"@de
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5702,7 +5702,7 @@ Class: OEO_00010256
         <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "maximum value"@de
+        rdfs:label "maximum value"
     
     SubClassOf: 
         OEO_00000350
@@ -5718,7 +5718,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 Fix 'quantity value of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
-        rdfs:label "power capacity"@de
+        rdfs:label "power capacity"
     
     SubClassOf: 
         OEO_00010256,
@@ -5733,7 +5733,7 @@ Class: OEO_00010258
         <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
         <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
-        rdfs:label "bioenergy"@de
+        rdfs:label "bioenergy"
     
     EquivalentTo: 
         OEO_00000007
@@ -5749,7 +5749,7 @@ Class: OEO_00010259
         <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
-        rdfs:label "measurement device"@de
+        rdfs:label "measurement device"
     
     SubClassOf: 
         OEO_00000061

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -818,7 +818,8 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000024>    
+Class: <http://purl.obolibrary.org/obo/BFO_0000024>
+
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000027>
 
@@ -5717,7 +5718,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
     
     SubClassOf: 
         OEO_00010256,
-        OEO_00000334 or (OEO_00020056 some OEO_00000188),
+        OEO_00020056 some 
+            (OEO_00000188 or OEO_00000334),
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
     
     
@@ -6522,8 +6524,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
     
     SubClassOf: 
         OEO_00000061
-        
-
+    
+    
 Class: OEO_00020201
 
     


### PR DESCRIPTION
Change axiom to: `'power capacity' 'quantity value of' some (generator or 'power generating unit')` to fit the definition:
_A power capacity is a maximum value of a generator or power generating unit to generate power._

Closes #1223 

This PR additionally deletes some unwanted language labels.