### PR TITLE
add secondary energy carrier disposition to some classes #1222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Here is a template for new release sections
 - public transport, private transport, vehicle (#1234)
 - power capacity (#1235)
 - jet fuel (#1237)
-- charcoal, synthetic fuel, gas diesel oil, manufactured coal based gas, syngas, gasoline, kerosene, staem, compressed air (#1243)
+- charcoal, synthetic fuel, gas diesel oil, manufactured coal based gas, syngas, gasoline, kerosene, staem, compressed air, pumped water (#1243)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Here is a template for new release sections
 - public transport, private transport, vehicle (#1234)
 - power capacity (#1235)
 - jet fuel (#1237)
+- charcoal, synthetic fuel, gas diesel oil, manufactured coal based gas, syngas, gasoline, kerosene, staem, compressed air (#1243)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3368,12 +3368,17 @@ Class: OEO_00000345
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
+
+add secondary energy carrier disposition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "pumped water"
     
     SubClassOf: 
         OEO_00110000,
-        OEO_00000501 some OEO_00000399
+        OEO_00000501 some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
     
     
 Class: OEO_00000348

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2886,7 +2886,10 @@ Class: OEO_00000263
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "manufactured coal based gas"
     
     SubClassOf: 
@@ -2894,6 +2897,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000182
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2737,7 +2737,11 @@ Kerosene is widely used to power jet engines of aircraft (jet fuel) and some roc
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024",
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "kerosene"
     
     SubClassOf: 
@@ -2746,6 +2750,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000256
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2278,7 +2278,11 @@ Class: OEO_00000181
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024",
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "gas diesel oil"
     
     SubClassOf: 
@@ -2287,6 +2291,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1024",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000256
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7882,14 +7882,19 @@ Class: OEO_00140160
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
 
 add axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "syngas"@en
     
     SubClassOf: 
@@ -7898,6 +7903,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000182
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7120,11 +7120,16 @@ Class: OEO_00110001
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
         rdfs:label "steam"@en
     
     SubClassOf: 
         OEO_00000441,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000531 value OEO_00000182
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2311,7 +2311,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1024
 
 relabel and add axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "gasoline"
     
     SubClassOf: 
@@ -2320,6 +2324,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000256
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1980,10 +1980,14 @@ Class: OEO_00000102
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "compressed air"
     
     SubClassOf: 
-        OEO_00000054
+        OEO_00000054,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
     
     
 Class: OEO_00000115

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1867,6 +1867,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
         OEO_00000529 value OEO_00000390
     
     
@@ -4301,6 +4302,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
     
 Class: OEO_00010023
 
+    
 Class: OEO_00010024
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1855,7 +1855,10 @@ Class: OEO_00000084
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "charcoal",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -4167,7 +4170,11 @@ Class: OEO_00010017
         <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
         <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "synthetic fuel"
     
     EquivalentTo: 
@@ -4180,7 +4187,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
         OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
     
     
 Class: OEO_00010018


### PR DESCRIPTION
closes #1222 

add axiom `'has disposition' some 'secondary energy carrier disposition'` to:
- charcoal
- synthetic fuel
- gas diesel oil
- manufactured coal based gas
- syngas
- gasoline
- kerosene
- steam
- compressed air
- pumped water (#1174)