### PR TITLE
Add annotations for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
-- added annotations for which modules classes and individuals belong to (#870)
+- added annotations for which modules classes and individuals belong to (#1252)
 
 ## [1.11.0] - 2022-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 
+### Changed
+- added annotations for which modules classes and individuals belong to (#870)
+
 ## [1.11.0] - 2022-07-04
 
 ### Added

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1,7 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
-Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: obda: <https://w3id.org/obda/vocabulary#>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -19,6 +16,21 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)"
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140170>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
+        rdfs:label "has documentation quality"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -42,18 +54,6 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
     
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
-    
-AnnotationProperty: OEO_00140170
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
-        rdfs:label "has documentation quality"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
     
 AnnotationProperty: dc:contributor
 
@@ -82,6 +82,147 @@ Datatype: xsd:integer
 Datatype: xsd:string
 
     
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function or objective variable."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "correct spelling optimisation and add range 'objective variable'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "has objective"
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000304> or <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000512>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function."@en,
+        rdfs:label "has objective function"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000513>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective variable."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add range 'objective variable'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "has objective variable"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000515>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000516>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000517>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
+        rdfs:label "has constraint"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140094>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140095>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
+        rdfs:label "has typical computation time"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140096>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
+        rdfs:label "has typical computation hardware"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
+    
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     
@@ -103,152 +244,1448 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
 
     
-ObjectProperty: OEO_00000503
-
-    
-ObjectProperty: OEO_00000511
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function or objective variable."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "correct spelling optimisation and add range 'objective variable'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "has objective"
-    
-    Domain: 
-        OEO_00000313
-    
-    Range: 
-        OEO_00000304 or OEO_00240004
-    
-    
-ObjectProperty: OEO_00000512
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function."@en,
-        rdfs:label "has objective function"
-    
-    SubPropertyOf: 
-        OEO_00000511
-    
-    Domain: 
-        OEO_00000313
-    
-    Range: 
-        OEO_00000304
-    
-    
-ObjectProperty: OEO_00000513
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective variable."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add range 'objective variable'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "has objective variable"
-    
-    SubPropertyOf: 
-        OEO_00000511
-    
-    Domain: 
-        OEO_00000313
-    
-    Range: 
-        OEO_00240004
-    
-    
-ObjectProperty: OEO_00000514
-
-    
-ObjectProperty: OEO_00000515
-
-    
-ObjectProperty: OEO_00000516
-
-    
-ObjectProperty: OEO_00000517
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
-        rdfs:label "has constraint"
-    
-    SubPropertyOf: 
-        OEO_00140093
-    
-    Domain: 
-        OEO_00000419
-    
-    Range: 
-        OEO_00000104
-    
-    
-ObjectProperty: OEO_00000522
-
-    Domain: 
-        OEO_00020011
-    
-    
-ObjectProperty: OEO_00020056
-
-    
-ObjectProperty: OEO_00040010
-
-    
-ObjectProperty: OEO_00140002
-
-    
-ObjectProperty: OEO_00140093
-
-    
-ObjectProperty: OEO_00140094
-
-    
-ObjectProperty: OEO_00140095
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
-        rdfs:label "has typical computation time"@en
-    
-    SubPropertyOf: 
-        OEO_00140002
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
-    
-    Range: 
-        OEO_00030035
-    
-    
-ObjectProperty: OEO_00140096
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
-        rdfs:label "has typical computation hardware"@en
-    
-    SubPropertyOf: 
-        OEO_00000503
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
-        OEO_00000206
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: OEO_00140178
+DataProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140178>
 
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000048>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
+        rdfs:label "acronym"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010247>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000059>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
+        rdfs:label "API"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000202>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000063>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
+        rdfs:label "assumption"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
+        rdfs:label "boolean variable"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000085>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
+        rdfs:label "citation reference"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000353>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000090>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
+        rdfs:label "code documentation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000091>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
+        rdfs:label "code source"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
+        rdfs:label "constraint"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000118>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
+        rdfs:label "database"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
+        rdfs:label "data descriptor"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
+        rdfs:label "data format"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000312>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000122>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
+        rdfs:label "data postprocessing"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000123>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
+        rdfs:label "data preprocessing"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
+        rdfs:comment "data processing is a transformation in which a data item gets transformed.",
+        rdfs:label "data processing"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000125>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
+        rdfs:label "data processing software"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000133>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
+source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
+        rdfs:label "DOI"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000028>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000149>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
+        rdfs:label "empirical dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000403>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000161>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
+        rdfs:label "external optimiser"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000162>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
+        rdfs:comment "this entity is general and not specific to the OEP factsheets.",
+        rdfs:label "factsheet"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000172>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
+        rdfs:label "framework factsheet"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000202>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is a software interface allowing users to communicate with a software application through a graphical window.",
+        rdfs:label "GUI"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000059>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000228>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
+        rdfs:label "installation guide"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
+        rdfs:label "software interface"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000276>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
+        rdfs:label "model component"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000277>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
+        rdfs:label "model factsheet"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000279>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
+        pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
+        rdfs:label "modelling software"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
+        rdfs:label "modus"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
+        rdfs:label "objective function"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000312>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
+        rdfs:label "open source"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000378>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
+        rdfs:label "optimisation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000370>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000314>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
+        rdfs:label "optimisation model"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000327>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
+        rdfs:label "plotting"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000328>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
+        rdfs:label "political assumption"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000339>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
+        rdfs:label "program parameter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000340>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000353>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
+        rdfs:label "reference"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000365>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
+        rdfs:label "scenario factsheet"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000370>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
+        rdfs:label "simulation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000371>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
+        rdfs:label "simulation model"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000304>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000372>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "single node model"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000378>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
+        rdfs:label "software descriptor"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
+        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
+        rdfs:label "software documentation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
+        rdfs:label "software framework"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
+        rdfs:label "solver"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000403>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
+        rdfs:label "synthetic dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000149>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000408>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
+        rdfs:label "test dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000432>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
+        rdfs:label "user documentation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
+        rdfs:label "variable"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010051>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
+        rdfs:label "sensitivity analysis"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010213>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
+        rdfs:label "emission constraint"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010233>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
+        rdfs:label "forecast error"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010247>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
+        rdfs:label "abbreviation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000028>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000300>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010255>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
+        rdfs:label "nationally determined contribution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020093>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010260>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "parameterisation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002233> some <http://openenergy-platform.org/ontology/oeo/OEO_00000063>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010261>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "model calibration"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00140024>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010262>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
+(Intentional: a research question is basis for the projection to be done)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
+        rdfs:label "scenario projection"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00020013>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000522> some <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020013>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/536
+
+add alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "output data"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model descriptor"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+fix typo of label
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
+        rdfs:label "analytical approach"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+        rdfs:label "methodical focus"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "primary modelling purpose"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020022>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model documentation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020032>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "study region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020033>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "subregion"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion of a study region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "study subregion"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "considered region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020036>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a spatial region that interacts with a study region. It is part of a considered region, but not a study region.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "interacting region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "analysis scope"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020032>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020089>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
+        rdfs:label "typical period"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020090>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "typical year"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020091>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020091>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "typical day"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000033>)
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020090>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020093>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
+        rdfs:label "target description"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020097>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario year"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020098>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020098>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario horizon"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020097>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020099>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "meteorological year"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020100>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "weather time series"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020101>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario time series"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020166>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+        rdfs:label "methodology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "climate scenario"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "economic scenario"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "emission scenario"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030010>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "energy scenario"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030031>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030032>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030033>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time step"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>,
+        ((<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030031>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030032>)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140043>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140044>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "time series",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030032>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030033> or <http://purl.obolibrary.org/obo/BFO_0000148>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "validation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140025>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "cross-checking against other models"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140026>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "checking against measurements"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140027>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "checking against empirical data"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140043>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time stamp"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time stamp alignment"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `'is about' some 'typical period'`:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
+        rdfs:label "aggregation type"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020089>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140098>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
+        rdfs:label "quality control flag"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140099>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
+        rdfs:label "goal description"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140138>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "generation time series"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140139>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "yield profile"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140138>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140161>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
+https://github.com/OpenEnergyPlatform/ontology/pull/808",
+        rdfs:label "cooperative programming"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
+        rdfs:label "uncertainty approach"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "objective variable"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010250>
 
@@ -259,8 +1696,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131",
         rdfs:label "study factsheet"@en
     
     SubClassOf: 
-        OEO_00000162,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020011
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010251>
@@ -285,8 +1722,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131",
         rdfs:label "scenario study"@en
     
     SubClassOf: 
-        OEO_00020011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -388,1681 +1825,380 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Class: OEO_00000048
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000049>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
-        rdfs:label "acronym"
-    
-    SubClassOf: 
-        OEO_00010247
-    
-    
-Class: OEO_00000059
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
-        rdfs:label "API"
-    
-    SubClassOf: 
-        OEO_00000239
-    
-    DisjointWith: 
-        OEO_00000202
-    
-    
-Class: OEO_00000063
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
-        rdfs:label "assumption"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000364
-    
-    
-Class: OEO_00000078
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
-        rdfs:label "boolean variable"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    DisjointWith: 
-        OEO_00240004
-    
-    
-Class: OEO_00000085
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
-        rdfs:label "citation reference"
-    
-    SubClassOf: 
-        OEO_00000353
-    
-    
-Class: OEO_00000090
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
-        rdfs:label "code documentation"
-    
-    SubClassOf: 
-        OEO_00000380
-    
-    
-Class: OEO_00000091
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
-        rdfs:label "code source"
-    
-    SubClassOf: 
-        OEO_00000119
-    
-    
-Class: OEO_00000104
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
-        rdfs:label "constraint"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000118
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
-        rdfs:label "database"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
-    
-    
-Class: OEO_00000119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
-        rdfs:label "data descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000120
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
-        rdfs:label "data format"
-    
-    SubClassOf: 
-        OEO_00000119
-    
-    DisjointWith: 
-        OEO_00000312
-    
-    
-Class: OEO_00000122
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
-        rdfs:label "data postprocessing"
-    
-    SubClassOf: 
-        OEO_00000124
-    
-    
-Class: OEO_00000123
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
-        rdfs:label "data preprocessing"
-    
-    SubClassOf: 
-        OEO_00000124
-    
-    
-Class: OEO_00000124
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
-        rdfs:comment "data processing is a transformation in which a data item gets transformed.",
-        rdfs:label "data processing"
-    
-    SubClassOf: 
-        OEO_00000419,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
-    
-    
-Class: OEO_00000125
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
-        rdfs:label "data processing software"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000133
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
-source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
-        rdfs:label "DOI"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000028>
-    
-    
-Class: OEO_00000149
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
-        rdfs:label "empirical dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000403
-    
-    
-Class: OEO_00000161
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
-        rdfs:label "external optimiser"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000162
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
-        rdfs:comment "this entity is general and not specific to the OEP factsheets.",
-        rdfs:label "factsheet"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: OEO_00000172
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
-        rdfs:label "framework factsheet"
-    
-    SubClassOf: 
-        OEO_00000162,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000382
-    
-    
-Class: OEO_00000199
-
-    
-Class: OEO_00000202
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is a software interface allowing users to communicate with a software application through a graphical window.",
-        rdfs:label "GUI"
-    
-    SubClassOf: 
-        OEO_00000239
-    
-    DisjointWith: 
-        OEO_00000059
-    
-    
-Class: OEO_00000206
-
-    
-Class: OEO_00000228
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
-        rdfs:label "installation guide"
-    
-    SubClassOf: 
-        OEO_00000380
-    
-    
-Class: OEO_00000239
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
-        rdfs:label "software interface"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000274
-
-    
-Class: OEO_00000275
-
-    
-Class: OEO_00000276
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
-        rdfs:label "model component"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000274
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: OEO_00000277
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
-        rdfs:label "model factsheet"
-    
-    SubClassOf: 
-        OEO_00000162
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    
-Class: OEO_00000279
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
-        pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
-        rdfs:label "modelling software"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000281
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
-        rdfs:label "modus"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000304
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
-        rdfs:label "objective function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000312
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
-        rdfs:label "open source"
-    
-    SubClassOf: 
-        OEO_00000378
-    
-    DisjointWith: 
-        OEO_00000120
-    
-    
-Class: OEO_00000313
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
-        rdfs:label "optimisation"
-    
-    SubClassOf: 
-        OEO_00000275
-    
-    DisjointWith: 
-        OEO_00000370
-    
-    
-Class: OEO_00000314
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
-        rdfs:label "optimisation model"
-    
-    SubClassOf: 
-        OEO_00000274,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304
-    
-    
-Class: OEO_00000327
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
-        rdfs:label "plotting"
-    
-    SubClassOf: 
-        OEO_00000124
-    
-    
-Class: OEO_00000328
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
-        rdfs:label "political assumption"
-    
-    SubClassOf: 
-        OEO_00000063
-    
-    
-Class: OEO_00000339
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
-        rdfs:label "program parameter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000340
-
-    
-Class: OEO_00000350
-
-    
-Class: OEO_00000353
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
-        rdfs:label "reference"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000364
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
-    
-    
-Class: OEO_00000365
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
-        rdfs:label "scenario factsheet"
-    
-    SubClassOf: 
-        OEO_00000162,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000364
-    
-    
-Class: OEO_00000367
-
-    
-Class: OEO_00000370
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
-        rdfs:label "simulation"
-    
-    SubClassOf: 
-        OEO_00000275
-    
-    DisjointWith: 
-        OEO_00000313
-    
-    
-Class: OEO_00000371
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
-        rdfs:label "simulation model"
-    
-    SubClassOf: 
-        OEO_00000274,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304)
-    
-    
-Class: OEO_00000372
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "single node model"
-    
-    SubClassOf: 
-        OEO_00000274
-    
-    
-Class: OEO_00000378
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
-        rdfs:label "software descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000380
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
-        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
-        rdfs:label "software documentation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: OEO_00000382
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
-        rdfs:label "software framework"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000392
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
-        rdfs:label "solver"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: OEO_00000403
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
-        rdfs:label "synthetic dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000149
-    
-    
-Class: OEO_00000408
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
-        rdfs:label "test dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    
-Class: OEO_00000419
-
-    
-Class: OEO_00000432
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
-        rdfs:label "user documentation"
-    
-    SubClassOf: 
-        OEO_00000380
-    
-    
-Class: OEO_00000435
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
-        rdfs:label "variable"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00010051
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
-        rdfs:label "sensitivity analysis"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00010213
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
-        rdfs:label "emission constraint"@en
-    
-    SubClassOf: 
-        OEO_00000104
-    
-    
-Class: OEO_00010233
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
-        rdfs:label "forecast error"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00010247
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
-        rdfs:label "abbreviation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000028>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000300>
-    
-    
-Class: OEO_00010255
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
-        rdfs:label "nationally determined contribution"
-    
-    SubClassOf: 
-        OEO_00020093,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
-    
-    
-Class: OEO_00010260
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "parameterisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00000063,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00030029
-    
-    
-Class: OEO_00010261
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "model calibration"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00140024,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00030029
-    
-    
-Class: OEO_00010262
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
-(Intentional: a research question is basis for the projection to be done)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
-        rdfs:label "scenario projection"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
-    
-    
-Class: OEO_00020011
-
-    SubClassOf: 
-        OEO_00000522 some OEO_00020072
-    
-    
-Class: OEO_00020012
-
-    
-Class: OEO_00020013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/536
-
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "output data"
-    
-    SubClassOf: 
-        OEO_00030030
-    
-    
-Class: OEO_00020016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    
-Class: OEO_00020017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-fix typo of label
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
-        rdfs:label "analytical approach"@en
-    
-    SubClassOf: 
-        OEO_00020016
-    
-    
-Class: OEO_00020018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
-    
-    
-Class: OEO_00020019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "primary modelling purpose"@en
-    
-    SubClassOf: 
-        OEO_00020016
-    
-    
-Class: OEO_00020022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model documentation"@en
-    
-    SubClassOf: 
-        OEO_00020016
-    
-    
-Class: OEO_00020032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: OEO_00020033
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "subregion"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: OEO_00020034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion of a study region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study subregion"
-    
-    SubClassOf: 
-        OEO_00020033
-    
-    
-Class: OEO_00020035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "considered region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: OEO_00020036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a spatial region that interacts with a study region. It is part of a considered region, but not a study region.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "interacting region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: OEO_00020072
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "analysis scope"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032
-    
-    
-Class: OEO_00020089
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
-        rdfs:label "typical period"
-    
-    SubClassOf: 
-        OEO_00030034,
-        OEO_00000503 some OEO_00140068
-    
-    
-Class: OEO_00020090
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
-add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "typical year"
-    
-    SubClassOf: 
-        OEO_00020089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
-    
-    DisjointWith: 
-        OEO_00020091
-    
-    
-Class: OEO_00020091
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
-add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "typical day"
-    
-    SubClassOf: 
-        OEO_00020089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000033>)
-             and (OEO_00140178 value 1))
-    
-    DisjointWith: 
-        OEO_00020090
-    
-    
-Class: OEO_00020093
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
-        rdfs:label "target description"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00020097
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario year"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
-    
-    
-Class: OEO_00020098
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario horizon"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
-    
-    
-Class: OEO_00020099
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "meteorological year"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
-    
-    
-Class: OEO_00020100
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "weather time series"
-    
-    SubClassOf: 
-        OEO_00030034,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020099
-    
-    
-Class: OEO_00020101
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario time series"
-    
-    SubClassOf: 
-        OEO_00030034,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
-    
-    
-Class: OEO_00020166
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
-    
-    
-Class: OEO_00030007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "climate scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
-    
-Class: OEO_00030008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "economic scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
-    
-Class: OEO_00030009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "emission scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
-    
-Class: OEO_00030010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "energy scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
-    
-Class: OEO_00030029
-
-    
-Class: OEO_00030030
-
-    
-Class: OEO_00030031
-
-    
-Class: OEO_00030032
-
-    
-Class: OEO_00030033
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time step"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>,
-        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
-    
-    
-Class: OEO_00030034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "time series",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
-    
-    
-Class: OEO_00030035
-
-    
-Class: OEO_00140024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "validation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "cross-checking against other models"@en
-    
-    SubClassOf: 
-        OEO_00140024
-    
-    
-Class: OEO_00140026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "checking against measurements"@en
-    
-    SubClassOf: 
-        OEO_00140024
-    
-    
-Class: OEO_00140027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "checking against empirical data"@en
-    
-    SubClassOf: 
-        OEO_00140024
-    
-    
-Class: OEO_00140043
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time stamp"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: OEO_00140044
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time stamp alignment"@en
-    
-    SubClassOf: 
-        OEO_00000119
-    
-    
-Class: OEO_00140068
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `'is about' some 'typical period'`:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
-        rdfs:label "aggregation type"@en
-    
-    SubClassOf: 
-        OEO_00000119,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020089
-    
-    
-Class: OEO_00140098
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
-        rdfs:label "quality control flag"@en
-    
-    SubClassOf: 
-        OEO_00000119,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    
-Class: OEO_00140099
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
-        rdfs:label "goal description"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00140138
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "generation time series"@en
-    
-    SubClassOf: 
-        OEO_00030034
-    
-    
-Class: OEO_00140139
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "yield profile"@en
-    
-    SubClassOf: 
-        OEO_00140138
-    
-    
-Class: OEO_00140161
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
-https://github.com/OpenEnergyPlatform/ontology/pull/808",
-        rdfs:label "cooperative programming"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140167
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
-        rdfs:label "uncertainty approach"@en
-    
-    SubClassOf: 
-        OEO_00020016
-    
-    
-Class: OEO_00240004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "objective variable"
-    
-    SubClassOf: 
-        OEO_00000435
-    
-    DisjointWith: 
-        OEO_00000078
-    
-    
-Individual: OEO_00000049
-
-    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "active"
     
     Types: 
-        OEO_00000281
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
     
     
-Individual: OEO_00000081
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000081>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "c++"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000092
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000092>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "coin- or_cbc"
     
     Types: 
-        OEO_00000392
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
     
     
-Individual: OEO_00000114
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000114>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "cplex"
     
     Types: 
-        OEO_00000392
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
     
     
-Individual: OEO_00000116
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000116>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "csv"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000121
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000121>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "data frame"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000130
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000130>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "dict"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000163
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000163>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "false"
     
     Types: 
-        OEO_00000078
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
     
     
-Individual: OEO_00000170
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000170>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "fortran"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000180
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000180>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gams"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000187
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000187>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gdx"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000195
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000195>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "glpk"
     
     Types: 
-        OEO_00000392
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
     
     
-Individual: OEO_00000196
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000196>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gnu"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000203
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000203>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gurobi"
     
     Types: 
-        OEO_00000392
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
     
     
-Individual: OEO_00000225
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000225>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "inactive"
     
     Types: 
-        OEO_00000281
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
     
     
-Individual: OEO_00000244
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000244>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "java"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000266
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000266>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "math prog"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000267
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000267>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "matlab"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000280
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000280>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "modelica"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000285
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000285>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "mosek"
     
     Types: 
-        OEO_00000392
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
     
     
-Individual: OEO_00000287
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000287>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ms_ excel"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000288
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000288>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "vba"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000319
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000319>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "passive"
     
     Types: 
-        OEO_00000281
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
     
     
-Individual: OEO_00000325
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000325>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "php"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000349
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000349>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "python"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000351
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000351>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "r"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000362
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000362>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ruby"
     
     Types: 
-        OEO_00000382
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
     
     
-Individual: OEO_00000424
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000424>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "true"
     
     Types: 
-        OEO_00000078
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
     
     
-Individual: OEO_00000426
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000426>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "txt"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000450
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000450>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xlsx"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00000451
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000451>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xml"
     
     Types: 
-        OEO_00000120
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
     
     
-Individual: OEO_00020023
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020023>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "top down"@en
     
     Types: 
-        OEO_00020017
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
     
     
-Individual: OEO_00020024
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020024>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "bottom up"@en
     
     Types: 
-        OEO_00020017
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
     
     
-Individual: OEO_00020026
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020026>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "hybrid"@en
     
     Types: 
-        OEO_00020017
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
     
     
-Individual: OEO_00020027
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020027>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "spreadsheet"@en
     
     Types: 
-        OEO_00020018
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
     
     
-Individual: OEO_00020028
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020028>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "monte carlo"@en
     
     Types: 
-        OEO_00020018
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
     
     
-Individual: OEO_00020029
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020029>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "econometric"@en
     
     Types: 
-        OEO_00020018
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
     
     
-Individual: OEO_00140045
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140045>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2070,12 +2206,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "start alignment"@en
     
     Types: 
-        OEO_00140044
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
     
     
-Individual: OEO_00140046
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140046>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "center alignment",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
@@ -2084,12 +2221,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "middle alignment"@en
     
     Types: 
-        OEO_00140044
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
     
     
-Individual: OEO_00140047
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140047>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2097,88 +2235,95 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "end alignment"@en
     
     Types: 
-        OEO_00140044
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
     
     
-Individual: OEO_00140069
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140069>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "value measured at or modelled for exactly one 0-dim temporal region, referenced by a time stamp, e.g. to represent a time step in a time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "instantaneous"@en
     
     Types: 
-        OEO_00140068
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
     
     
-Individual: OEO_00140070
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140070>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "sum or integral of values, e.g. within a time step or a spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "integral"@en
     
     Types: 
-        OEO_00140068
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
     
     
-Individual: OEO_00140071
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140071>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "average value calculated by arithmetic mean over a set of data values, e.g. within a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "arithmetic mean"@en
     
     Types: 
-        OEO_00140068
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
     
     
-Individual: OEO_00140072
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140072>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "minimum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "minimum"@en
     
     Types: 
-        OEO_00140068
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
     
     
-Individual: OEO_00140073
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140073>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "maximum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "maximum"@en
     
     Types: 
-        OEO_00140068
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
     
     
-Individual: OEO_00140168
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140168>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "stochastic"@en
     
     Types: 
-        OEO_00140167
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
     
     
-Individual: OEO_00140169
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140169>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "deterministic"@en
     
     Types: 
-        OEO_00140167
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1,3 +1,4 @@
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -7,7 +8,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model/>
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model.omn>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
 
@@ -16,21 +17,6 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Modelling module)"
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140170>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
-        rdfs:label "has documentation quality"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
-
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -53,6 +39,21 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
 AnnotationProperty: <http://purl.org/dc/terms/title>
+
+    
+AnnotationProperty: OEO_00140170
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
+        rdfs:label "has documentation quality"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+AnnotationProperty: OEO_00269001
 
     
 AnnotationProperty: dc:contributor
@@ -82,147 +83,6 @@ Datatype: xsd:integer
 Datatype: xsd:string
 
     
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function or objective variable."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "correct spelling optimisation and add range 'objective variable'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "has objective"
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000304> or <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000512>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function."@en,
-        rdfs:label "has objective function"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000513>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective variable."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add range 'objective variable'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "has objective variable"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000511>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000515>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000516>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000517>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
-        rdfs:label "has constraint"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140094>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140095>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
-        rdfs:label "has typical computation time"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140096>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
-        rdfs:label "has typical computation hardware"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
-    
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     
@@ -244,1448 +104,152 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
 
     
+ObjectProperty: OEO_00000503
+
+    
+ObjectProperty: OEO_00000511
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function or objective variable."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "correct spelling optimisation and add range 'objective variable'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "has objective"
+    
+    Domain: 
+        OEO_00000313
+    
+    Range: 
+        OEO_00000304 or OEO_00240004
+    
+    
+ObjectProperty: OEO_00000512
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective function."@en,
+        rdfs:label "has objective function"
+    
+    SubPropertyOf: 
+        OEO_00000511
+    
+    Domain: 
+        OEO_00000313
+    
+    Range: 
+        OEO_00000304
+    
+    
+ObjectProperty: OEO_00000513
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an optimisation and its objective variable."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add range 'objective variable'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "has objective variable"
+    
+    SubPropertyOf: 
+        OEO_00000511
+    
+    Domain: 
+        OEO_00000313
+    
+    Range: 
+        OEO_00240004
+    
+    
+ObjectProperty: OEO_00000514
+
+    
+ObjectProperty: OEO_00000515
+
+    
+ObjectProperty: OEO_00000516
+
+    
+ObjectProperty: OEO_00000517
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a transformation and the constraints it has to fulfill."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716",
+        rdfs:label "has constraint"
+    
+    SubPropertyOf: 
+        OEO_00140093
+    
+    Domain: 
+        OEO_00000419
+    
+    Range: 
+        OEO_00000104
+    
+    
+ObjectProperty: OEO_00000522
+
+    Domain: 
+        OEO_00020011
+    
+    
+ObjectProperty: OEO_00020056
+
+    
+ObjectProperty: OEO_00040010
+
+    
+ObjectProperty: OEO_00140002
+
+    
+ObjectProperty: OEO_00140093
+
+    
+ObjectProperty: OEO_00140094
+
+    
+ObjectProperty: OEO_00140095
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical duration of its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
+        rdfs:label "has typical computation time"@en
+    
+    SubPropertyOf: 
+        OEO_00140002
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        OEO_00030035
+    
+    
+ObjectProperty: OEO_00140096
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an algorithm or a software and the typical hardware used for its execution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/723",
+        rdfs:label "has typical computation hardware"@en
+    
+    SubPropertyOf: 
+        OEO_00000503
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000010> or <http://purl.obolibrary.org/obo/IAO_0000064>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
+        OEO_00000206
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140178>
+DataProperty: OEO_00140178
 
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000048>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
-        rdfs:label "acronym"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010247>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000059>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
-        rdfs:label "API"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000202>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000063>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
-        rdfs:label "assumption"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
-        rdfs:label "boolean variable"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000085>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
-        rdfs:label "citation reference"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000353>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000090>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
-        rdfs:label "code documentation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000091>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
-        rdfs:label "code source"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
-        rdfs:label "constraint"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000118>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
-        rdfs:label "database"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
-        rdfs:label "data descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
-        rdfs:label "data format"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000312>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000122>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
-        rdfs:label "data postprocessing"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000123>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
-        rdfs:label "data preprocessing"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
-        rdfs:comment "data processing is a transformation in which a data item gets transformed.",
-        rdfs:label "data processing"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000125>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
-        rdfs:label "data processing software"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000133>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
-source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
-        rdfs:label "DOI"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000028>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000149>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
-        rdfs:label "empirical dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000403>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000161>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
-        rdfs:label "external optimiser"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000162>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
-        rdfs:comment "this entity is general and not specific to the OEP factsheets.",
-        rdfs:label "factsheet"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000172>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
-        rdfs:label "framework factsheet"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000202>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is a software interface allowing users to communicate with a software application through a graphical window.",
-        rdfs:label "GUI"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000059>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000228>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
-        rdfs:label "installation guide"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000239>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
-        rdfs:label "software interface"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000276>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
-        rdfs:label "model component"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000277>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
-        rdfs:label "model factsheet"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000279>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
-        pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
-        rdfs:label "modelling software"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
-        rdfs:label "modus"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
-        rdfs:label "objective function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000312>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
-        rdfs:label "open source"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000378>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
-        rdfs:label "optimisation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000370>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000314>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
-        rdfs:label "optimisation model"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000304>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000327>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
-        rdfs:label "plotting"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000124>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000328>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
-        rdfs:label "political assumption"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000339>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
-        rdfs:label "program parameter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000340>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000353>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
-        rdfs:label "reference"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000365>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
-        rdfs:label "scenario factsheet"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000370>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
-        rdfs:label "simulation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000313>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000371>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
-        rdfs:label "simulation model"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000304>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000372>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "single node model"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000378>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
-        rdfs:label "software descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
-        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
-        rdfs:label "software documentation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
-        rdfs:label "software framework"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
-        rdfs:label "solver"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000403>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
-        rdfs:label "synthetic dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000149>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000408>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
-        rdfs:label "test dataset"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000432>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
-        rdfs:label "user documentation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000380>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
-        rdfs:label "variable"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010051>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
-        rdfs:label "sensitivity analysis"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010213>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
-        rdfs:label "emission constraint"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010233>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
-        rdfs:label "forecast error"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010247>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
-        rdfs:label "abbreviation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000028>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000300>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010255>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
-        rdfs:label "nationally determined contribution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020093>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010260>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "parameterisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002233> some <http://openenergy-platform.org/ontology/oeo/OEO_00000063>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010261>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "model calibration"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00140024>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010262>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
-(Intentional: a research question is basis for the projection to be done)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
-        rdfs:label "scenario projection"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00020013>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000522> some <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020013>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/536
-
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "output data"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-fix typo of label
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
-        rdfs:label "analytical approach"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "primary modelling purpose"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020022>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
-        rdfs:label "model documentation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020032>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020033>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "subregion"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion of a study region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study subregion"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "considered region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020036>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a spatial region that interacts with a study region. It is part of a considered region, but not a study region.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "interacting region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "analysis scope"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020032>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020089>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
-        rdfs:label "typical period"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020090>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
-add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "typical year"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020091>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020091>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
-add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "typical day"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000033>)
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020090>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020093>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
-        rdfs:label "target description"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020097>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario year"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020098>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020098>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario horizon"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020097>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020099>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "meteorological year"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00140178> value 1))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020100>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "weather time series"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020101>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario time series"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020166>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "climate scenario"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "economic scenario"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "emission scenario"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030010>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
-        rdfs:label "energy scenario"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030031>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030032>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030033>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time step"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>,
-        ((<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030031>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030032>)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140043>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140044>))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "time series",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030032>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00030033> or <http://purl.obolibrary.org/obo/BFO_0000148>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "validation"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140025>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "cross-checking against other models"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140026>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "checking against measurements"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140027>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
-        rdfs:label "checking against empirical data"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140043>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time stamp"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
-        rdfs:label "time stamp alignment"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `'is about' some 'typical period'`:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
-        rdfs:label "aggregation type"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020089>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140098>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
-        rdfs:label "quality control flag"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000119>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140099>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
-        rdfs:label "goal description"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140138>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "generation time series"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140139>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "yield profile"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140138>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140161>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
-https://github.com/OpenEnergyPlatform/ontology/pull/808",
-        rdfs:label "cooperative programming"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
-        rdfs:label "uncertainty approach"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
-        rdfs:label "objective variable"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000435>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
-    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010250>
 
@@ -1696,8 +260,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131",
         rdfs:label "study factsheet"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000162>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+        OEO_00000162,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020011
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010251>
@@ -1722,8 +286,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131",
         rdfs:label "scenario study"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+        OEO_00020011,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -1825,380 +389,1817 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
         <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000049>
+Class: OEO_00000048
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
+        rdfs:label "acronym"
+    
+    SubClassOf: 
+        OEO_00010247
+    
+    
+Class: OEO_00000059
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
+        rdfs:label "API"
+    
+    SubClassOf: 
+        OEO_00000239
+    
+    DisjointWith: 
+        OEO_00000202
+    
+    
+Class: OEO_00000063
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
+        rdfs:label "assumption"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000364
+    
+    
+Class: OEO_00000078
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
+        rdfs:label "boolean variable"
+    
+    SubClassOf: 
+        OEO_00000435
+    
+    DisjointWith: 
+        OEO_00240004
+    
+    
+Class: OEO_00000085
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
+        rdfs:label "citation reference"
+    
+    SubClassOf: 
+        OEO_00000353
+    
+    
+Class: OEO_00000090
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
+        rdfs:label "code documentation"
+    
+    SubClassOf: 
+        OEO_00000380
+    
+    
+Class: OEO_00000091
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
+        rdfs:label "code source"
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    
+Class: OEO_00000104
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
+        rdfs:label "constraint"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000118
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
+        rdfs:label "database"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: OEO_00000119
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
+        rdfs:label "data descriptor"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000120
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
+        rdfs:label "data format"
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    DisjointWith: 
+        OEO_00000312
+    
+    
+Class: OEO_00000122
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
+        rdfs:label "data postprocessing"
+    
+    SubClassOf: 
+        OEO_00000124
+    
+    
+Class: OEO_00000123
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
+        rdfs:label "data preprocessing"
+    
+    SubClassOf: 
+        OEO_00000124
+    
+    
+Class: OEO_00000124
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
+        rdfs:comment "data processing is a transformation in which a data item gets transformed.",
+        rdfs:label "data processing"
+    
+    SubClassOf: 
+        OEO_00000419,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: OEO_00000125
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
+        rdfs:label "data processing software"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000133
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
+source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
+        rdfs:label "DOI"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000028>
+    
+    
+Class: OEO_00000149
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
+        rdfs:label "empirical dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        OEO_00000403
+    
+    
+Class: OEO_00000161
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
+        rdfs:label "external optimiser"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000162
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
+        rdfs:comment "this entity is general and not specific to the OEP factsheets.",
+        rdfs:label "factsheet"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: OEO_00000172
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
+        rdfs:label "framework factsheet"
+    
+    SubClassOf: 
+        OEO_00000162,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000382
+    
+    
+Class: OEO_00000199
+
+    
+Class: OEO_00000202
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is a software interface allowing users to communicate with a software application through a graphical window.",
+        rdfs:label "GUI"
+    
+    SubClassOf: 
+        OEO_00000239
+    
+    DisjointWith: 
+        OEO_00000059
+    
+    
+Class: OEO_00000206
+
+    
+Class: OEO_00000228
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
+        rdfs:label "installation guide"
+    
+    SubClassOf: 
+        OEO_00000380
+    
+    
+Class: OEO_00000239
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
+        rdfs:label "software interface"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000274
+
+    
+Class: OEO_00000275
+
+    
+Class: OEO_00000276
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
+        rdfs:label "model component"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000274
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: OEO_00000277
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
+        rdfs:label "model factsheet"
+    
+    SubClassOf: 
+        OEO_00000162
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    
+Class: OEO_00000279
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
+        pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
+        rdfs:label "modelling software"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000281
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
+        rdfs:label "modus"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000304
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
+        rdfs:label "objective function"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000312
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
+        rdfs:label "open source"
+    
+    SubClassOf: 
+        OEO_00000378
+    
+    DisjointWith: 
+        OEO_00000120
+    
+    
+Class: OEO_00000313
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
+        rdfs:label "optimisation"
+    
+    SubClassOf: 
+        OEO_00000275
+    
+    DisjointWith: 
+        OEO_00000370
+    
+    
+Class: OEO_00000314
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
+        rdfs:label "optimisation model"
+    
+    SubClassOf: 
+        OEO_00000274,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304
+    
+    
+Class: OEO_00000327
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
+        rdfs:label "plotting"
+    
+    SubClassOf: 
+        OEO_00000124
+    
+    
+Class: OEO_00000328
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
+        rdfs:label "political assumption"
+    
+    SubClassOf: 
+        OEO_00000063
+    
+    
+Class: OEO_00000339
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
+        rdfs:label "program parameter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000340
+
+    
+Class: OEO_00000350
+
+    
+Class: OEO_00000353
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
+        rdfs:label "reference"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000364
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
+    
+    
+Class: OEO_00000365
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
+        rdfs:label "scenario factsheet"
+    
+    SubClassOf: 
+        OEO_00000162,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000364
+    
+    
+Class: OEO_00000367
+
+    
+Class: OEO_00000370
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
+        rdfs:label "simulation"
+    
+    SubClassOf: 
+        OEO_00000275
+    
+    DisjointWith: 
+        OEO_00000313
+    
+    
+Class: OEO_00000371
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
+        rdfs:label "simulation model"
+    
+    SubClassOf: 
+        OEO_00000274,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304)
+    
+    
+Class: OEO_00000372
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "single node model"
+    
+    SubClassOf: 
+        OEO_00000274
+    
+    
+Class: OEO_00000378
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
+        rdfs:label "software descriptor"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000380
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
+        rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
+        rdfs:label "software documentation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: OEO_00000382
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
+        rdfs:label "software framework"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000392
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
+        rdfs:label "solver"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000403
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
+        rdfs:label "synthetic dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        OEO_00000149
+    
+    
+Class: OEO_00000408
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
+        rdfs:label "test dataset"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+Class: OEO_00000419
+
+    
+Class: OEO_00000432
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
+        rdfs:label "user documentation"
+    
+    SubClassOf: 
+        OEO_00000380
+    
+    
+Class: OEO_00000435
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
+        rdfs:label "variable"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00010051
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
+        rdfs:label "sensitivity analysis"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00010213
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
+        rdfs:label "emission constraint"@en
+    
+    SubClassOf: 
+        OEO_00000104
+    
+    
+Class: OEO_00010233
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
+        rdfs:label "forecast error"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00010247
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
+        rdfs:label "abbreviation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000028>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000300>
+    
+    
+Class: OEO_00010255
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
+        rdfs:label "nationally determined contribution"
+    
+    SubClassOf: 
+        OEO_00020093,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
+    
+    
+Class: OEO_00010260
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "parameterisation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002233> some OEO_00000063,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00030029
+    
+    
+Class: OEO_00010261
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "model calibration"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00140024,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00030029
+    
+    
+Class: OEO_00010262
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
+(Intentional: a research question is basis for the projection to be done)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
+        rdfs:label "scenario projection"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
+    
+    
+Class: OEO_00020011
+
+    SubClassOf: 
+        OEO_00000522 some OEO_00020072
+    
+    
+Class: OEO_00020012
+
+    
+Class: OEO_00020013
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/536
+
+add alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "output data"
+    
+    SubClassOf: 
+        OEO_00030030
+    
+    
+Class: OEO_00020016
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model descriptor"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    
+Class: OEO_00020017
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+fix typo of label
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
+        rdfs:label "analytical approach"@en
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020018
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+        rdfs:label "methodical focus"@en
+    
+    SubClassOf: 
+        OEO_00020016,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
+    
+    
+Class: OEO_00020019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "primary modelling purpose"@en
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020022
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+        rdfs:label "model documentation"@en
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00020032
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "study region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00020033
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "subregion"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00020034
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion of a study region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "study subregion"
+    
+    SubClassOf: 
+        OEO_00020033
+    
+    
+Class: OEO_00020035
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "considered region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00020036
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a spatial region that interacts with a study region. It is part of a considered region, but not a study region.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "interacting region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00020072
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "analysis scope"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032
+    
+    
+Class: OEO_00020089
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
+        rdfs:label "typical period"
+    
+    SubClassOf: 
+        OEO_00030034,
+        OEO_00000503 some OEO_00140068
+    
+    
+Class: OEO_00020090
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "typical year"
+    
+    SubClassOf: 
+        OEO_00020089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
+    
+    DisjointWith: 
+        OEO_00020091
+    
+    
+Class: OEO_00020091
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
+add axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "typical day"
+    
+    SubClassOf: 
+        OEO_00020089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000033>)
+             and (OEO_00140178 value 1))
+    
+    DisjointWith: 
+        OEO_00020090
+    
+    
+Class: OEO_00020093
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
+        rdfs:label "target description"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00020097
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario year"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
+    
+    
+Class: OEO_00020098
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario horizon"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
+    
+    
+Class: OEO_00020099
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "meteorological year"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
+    
+    
+Class: OEO_00020100
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "weather time series"
+    
+    SubClassOf: 
+        OEO_00030034,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020099
+    
+    
+Class: OEO_00020101
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
+        rdfs:label "scenario time series"
+    
+    SubClassOf: 
+        OEO_00030034,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
+    
+    
+Class: OEO_00020166
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+        rdfs:label "methodology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
+    
+    
+Class: OEO_00030007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "climate scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
+Class: OEO_00030008
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "economic scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
+Class: OEO_00030009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "emission scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
+Class: OEO_00030010
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+        rdfs:label "energy scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
+Class: OEO_00030029
+
+    
+Class: OEO_00030030
+
+    
+Class: OEO_00030031
+
+    
+Class: OEO_00030032
+
+    
+Class: OEO_00030033
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time step"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>,
+        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
+    
+    
+Class: OEO_00030034
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "time series",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
+    
+    
+Class: OEO_00030035
+
+    
+Class: OEO_00140024
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "validation"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140025
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "cross-checking against other models"@en
+    
+    SubClassOf: 
+        OEO_00140024
+    
+    
+Class: OEO_00140026
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "checking against measurements"@en
+    
+    SubClassOf: 
+        OEO_00140024
+    
+    
+Class: OEO_00140027
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
+        rdfs:label "checking against empirical data"@en
+    
+    SubClassOf: 
+        OEO_00140024
+    
+    
+Class: OEO_00140043
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time stamp"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00140044
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
+        rdfs:label "time stamp alignment"@en
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    
+Class: OEO_00140068
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `'is about' some 'typical period'`:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/880
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/883
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
+        rdfs:label "aggregation type"@en
+    
+    SubClassOf: 
+        OEO_00000119,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020089
+    
+    
+Class: OEO_00140098
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
+        rdfs:label "quality control flag"@en
+    
+    SubClassOf: 
+        OEO_00000119,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+Class: OEO_00140099
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
+        rdfs:label "goal description"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00140138
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "generation time series"@en
+    
+    SubClassOf: 
+        OEO_00030034
+    
+    
+Class: OEO_00140139
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "yield profile"@en
+    
+    SubClassOf: 
+        OEO_00140138
+    
+    
+Class: OEO_00140161
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
+https://github.com/OpenEnergyPlatform/ontology/pull/808",
+        rdfs:label "cooperative programming"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140167
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
+        rdfs:label "uncertainty approach"@en
+    
+    SubClassOf: 
+        OEO_00020016
+    
+    
+Class: OEO_00240004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
+        rdfs:label "objective variable"
+    
+    SubClassOf: 
+        OEO_00000435
+    
+    DisjointWith: 
+        OEO_00000078
+    
+    
+Individual: OEO_00000049
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "active"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
+        OEO_00000281
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000081>
+Individual: OEO_00000081
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "c++"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000092>
+Individual: OEO_00000092
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "coin- or_cbc"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+        OEO_00000392
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000114>
+Individual: OEO_00000114
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "cplex"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+        OEO_00000392
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000116>
+Individual: OEO_00000116
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "csv"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000121>
+Individual: OEO_00000121
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "data frame"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000130>
+Individual: OEO_00000130
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "dict"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000163>
+Individual: OEO_00000163
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "false"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
+        OEO_00000078
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000170>
+Individual: OEO_00000170
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "fortran"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000180>
+Individual: OEO_00000180
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gams"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000187>
+Individual: OEO_00000187
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gdx"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000195>
+Individual: OEO_00000195
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "glpk"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+        OEO_00000392
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000196>
+Individual: OEO_00000196
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gnu"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000203>
+Individual: OEO_00000203
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gurobi"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+        OEO_00000392
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000225>
+Individual: OEO_00000225
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "inactive"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
+        OEO_00000281
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000244>
+Individual: OEO_00000244
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "java"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000266>
+Individual: OEO_00000266
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "math prog"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000267>
+Individual: OEO_00000267
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "matlab"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000280>
+Individual: OEO_00000280
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "modelica"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000285>
+Individual: OEO_00000285
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "mosek"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000392>
+        OEO_00000392
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000287>
+Individual: OEO_00000287
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ms_ excel"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000288>
+Individual: OEO_00000288
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "vba"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000319>
+Individual: OEO_00000319
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "passive"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000281>
+        OEO_00000281
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000325>
+Individual: OEO_00000325
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "php"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000349>
+Individual: OEO_00000349
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "python"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000351>
+Individual: OEO_00000351
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "r"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000362>
+Individual: OEO_00000362
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ruby"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000382>
+        OEO_00000382
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000424>
+Individual: OEO_00000424
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "true"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000078>
+        OEO_00000078
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000426>
+Individual: OEO_00000426
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "txt"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000450>
+Individual: OEO_00000450
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xlsx"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000451>
+Individual: OEO_00000451
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xml"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000120>
+        OEO_00000120
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020023>
+Individual: OEO_00020023
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "top down"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
+        OEO_00020017
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020024>
+Individual: OEO_00020024
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "bottom up"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
+        OEO_00020017
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020026>
+Individual: OEO_00020026
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "hybrid"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020017>
+        OEO_00020017
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020027>
+Individual: OEO_00020027
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "spreadsheet"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
+        OEO_00020018
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020028>
+Individual: OEO_00020028
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "monte carlo"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
+        OEO_00020018
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020029>
+Individual: OEO_00020029
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "econometric"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
+        OEO_00020018
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140045>
+Individual: OEO_00140045
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2206,13 +2207,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "start alignment"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
+        OEO_00140044
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140046>
+Individual: OEO_00140046
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "center alignment",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
@@ -2221,13 +2222,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "middle alignment"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
+        OEO_00140044
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140047>
+Individual: OEO_00140047
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2235,95 +2236,95 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
         rdfs:label "end alignment"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140044>
+        OEO_00140044
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140069>
+Individual: OEO_00140069
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "value measured at or modelled for exactly one 0-dim temporal region, referenced by a time stamp, e.g. to represent a time step in a time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "instantaneous"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+        OEO_00140068
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140070>
+Individual: OEO_00140070
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "sum or integral of values, e.g. within a time step or a spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "integral"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+        OEO_00140068
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140071>
+Individual: OEO_00140071
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "average value calculated by arithmetic mean over a set of data values, e.g. within a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "arithmetic mean"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+        OEO_00140068
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140072>
+Individual: OEO_00140072
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "minimum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "minimum"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+        OEO_00140068
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140073>
+Individual: OEO_00140073
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "maximum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
         rdfs:label "maximum"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140068>
+        OEO_00140068
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140168>
+Individual: OEO_00140168
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "stochastic"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
+        OEO_00140167
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00140169>
+Individual: OEO_00140169
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "deterministic"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140167>
+        OEO_00140167
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -8,7 +8,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model.omn>
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-model/>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -41,6 +41,9 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
+AnnotationProperty: OEO_00040001
+
+    
 AnnotationProperty: OEO_00140170
 
     Annotations: 
@@ -52,9 +55,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
     Domain: 
         <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
     
-    
-AnnotationProperty: OEO_00269001
-
     
 AnnotationProperty: dc:contributor
 
@@ -392,7 +392,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
 Class: OEO_00000048
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
@@ -406,7 +406,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
 Class: OEO_00000059
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
         rdfs:label "API"
     
@@ -420,7 +420,7 @@ Class: OEO_00000059
 Class: OEO_00000063
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
@@ -434,7 +434,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
 Class: OEO_00000078
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that can only be true or false."@en,
         rdfs:label "boolean variable"
     
@@ -448,7 +448,7 @@ Class: OEO_00000078
 Class: OEO_00000085
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from."^^xsd:string,
         rdfs:label "citation reference"
     
@@ -459,7 +459,7 @@ Class: OEO_00000085
 Class: OEO_00000090
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code."^^xsd:string,
         rdfs:label "code documentation"
     
@@ -470,7 +470,7 @@ Class: OEO_00000090
 Class: OEO_00000091
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code."^^xsd:string,
         rdfs:label "code source"
     
@@ -481,7 +481,7 @@ Class: OEO_00000091
 Class: OEO_00000104
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fullfilled within a calculation."@en,
         rdfs:label "constraint"
@@ -493,7 +493,7 @@ Class: OEO_00000104
 Class: OEO_00000118
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
@@ -507,7 +507,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
 Class: OEO_00000119
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data."^^xsd:string,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
@@ -521,7 +521,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
 Class: OEO_00000120
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that describes in which format the data is encoded."^^xsd:string,
         rdfs:label "data format"
     
@@ -535,7 +535,7 @@ Class: OEO_00000120
 Class: OEO_00000122
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation."^^xsd:string,
         rdfs:label "data postprocessing"
     
@@ -546,7 +546,7 @@ Class: OEO_00000122
 Class: OEO_00000123
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation."^^xsd:string,
         rdfs:label "data preprocessing"
     
@@ -557,7 +557,7 @@ Class: OEO_00000123
 Class: OEO_00000124
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
         rdfs:comment "data processing is a transformation in which a data item gets transformed.",
@@ -571,7 +571,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
 Class: OEO_00000125
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing."^^xsd:string,
         rdfs:label "data processing software"
     
@@ -582,7 +582,7 @@ Class: OEO_00000125
 Class: OEO_00000133
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
 source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
@@ -595,7 +595,7 @@ source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
 Class: OEO_00000149
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical dataset is a dataset that is optained from observations in the real world."@en,
         rdfs:label "empirical dataset"
@@ -610,7 +610,7 @@ Class: OEO_00000149
 Class: OEO_00000161
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
         rdfs:label "external optimiser"
@@ -622,7 +622,7 @@ Class: OEO_00000161
 Class: OEO_00000162
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
@@ -636,7 +636,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
 Class: OEO_00000172
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
@@ -654,7 +654,7 @@ Class: OEO_00000199
 Class: OEO_00000202
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface)  is a software interface allowing users to communicate with a software application through a graphical window.",
         rdfs:label "GUI"
     
@@ -671,7 +671,7 @@ Class: OEO_00000206
 Class: OEO_00000228
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software."^^xsd:string,
         rdfs:label "installation guide"
     
@@ -682,7 +682,7 @@ Class: OEO_00000228
 Class: OEO_00000239
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
         rdfs:label "software interface"
     
@@ -699,7 +699,7 @@ Class: OEO_00000275
 Class: OEO_00000276
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
         rdfs:label "model component"
@@ -714,7 +714,7 @@ Class: OEO_00000276
 Class: OEO_00000277
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
@@ -733,7 +733,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
 Class: OEO_00000279
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
@@ -747,7 +747,7 @@ Class: OEO_00000279
 Class: OEO_00000281
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive."^^xsd:string,
         rdfs:label "modus"
     
@@ -758,7 +758,7 @@ Class: OEO_00000281
 Class: OEO_00000304
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
@@ -771,7 +771,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
 Class: OEO_00000312
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed."^^xsd:string,
         rdfs:label "open source"
     
@@ -785,7 +785,7 @@ Class: OEO_00000312
 Class: OEO_00000313
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
         rdfs:label "optimisation"
@@ -800,7 +800,7 @@ Class: OEO_00000313
 Class: OEO_00000314
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
         rdfs:label "optimisation model"
@@ -816,7 +816,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000327
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram."^^xsd:string,
         rdfs:label "plotting"
     
@@ -827,7 +827,7 @@ Class: OEO_00000327
 Class: OEO_00000328
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
         rdfs:label "political assumption"
     
@@ -838,7 +838,7 @@ Class: OEO_00000328
 Class: OEO_00000339
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable that influences the output of  a calculation in the program but has no meaning outside of the program."@en,
         rdfs:label "program parameter"
@@ -856,7 +856,7 @@ Class: OEO_00000350
 Class: OEO_00000353
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address."^^xsd:string,
         rdfs:label "reference"
     
@@ -867,7 +867,7 @@ Class: OEO_00000353
 Class: OEO_00000364
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
@@ -883,7 +883,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
 Class: OEO_00000365
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
@@ -901,7 +901,7 @@ Class: OEO_00000367
 Class: OEO_00000370
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
         rdfs:label "simulation"
     
@@ -915,7 +915,7 @@ Class: OEO_00000370
 Class: OEO_00000371
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
         rdfs:label "simulation model"
     
@@ -930,7 +930,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000372
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
@@ -943,7 +943,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
 Class: OEO_00000378
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software."^^xsd:string,
         rdfs:label "software descriptor"
     
@@ -954,7 +954,7 @@ Class: OEO_00000378
 Class: OEO_00000380
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
         rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
@@ -967,7 +967,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
 Class: OEO_00000382
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
@@ -980,7 +980,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
 Class: OEO_00000392
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
         rdfs:label "solver"
     
@@ -991,7 +991,7 @@ Class: OEO_00000392
 Class: OEO_00000403
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic dataset is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real world dataset."@en,
         rdfs:label "synthetic dataset"
@@ -1006,7 +1006,7 @@ Class: OEO_00000403
 Class: OEO_00000408
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A test dataset is a data set used for testing."^^xsd:string,
         rdfs:label "test dataset"
     
@@ -1020,7 +1020,7 @@ Class: OEO_00000419
 Class: OEO_00000432
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software."^^xsd:string,
         rdfs:label "user documentation"
     
@@ -1031,7 +1031,7 @@ Class: OEO_00000432
 Class: OEO_00000435
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
         rdfs:label "variable"
     
@@ -1042,7 +1042,7 @@ Class: OEO_00000435
 Class: OEO_00010051
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
@@ -1055,7 +1055,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
 Class: OEO_00010213
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
@@ -1069,7 +1069,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
 Class: OEO_00010233
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
@@ -1082,7 +1082,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
 Class: OEO_00010247
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
@@ -1096,7 +1096,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
 Class: OEO_00010255
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
@@ -1111,7 +1111,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1151",
 Class: OEO_00010260
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
@@ -1127,7 +1127,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00010261
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
@@ -1143,7 +1143,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00010262
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
 (Intentional: a research question is basis for the projection to be done)",
@@ -1170,7 +1170,7 @@ Class: OEO_00020012
 Class: OEO_00020013
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
@@ -1187,7 +1187,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
 Class: OEO_00020016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
@@ -1201,7 +1201,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
@@ -1216,7 +1216,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
 Class: OEO_00020018
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
@@ -1233,7 +1233,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
 Class: OEO_00020019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
@@ -1247,7 +1247,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020022
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
@@ -1260,7 +1260,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020032
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1277,7 +1277,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020033
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
@@ -1290,7 +1290,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1307,7 +1307,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1324,7 +1324,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020036
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1342,7 +1342,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020072
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
@@ -1357,7 +1357,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
 Class: OEO_00020089
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
@@ -1376,7 +1376,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
 Class: OEO_00020090
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
@@ -1398,7 +1398,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020091
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
@@ -1420,7 +1420,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020093
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
@@ -1433,7 +1433,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
 Class: OEO_00020097
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -1451,7 +1451,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020098
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -1468,7 +1468,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020099
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -1485,7 +1485,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020100
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
@@ -1500,7 +1500,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020101
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -1514,7 +1514,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020166
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
@@ -1528,7 +1528,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
 Class: OEO_00030007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
@@ -1541,7 +1541,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
 Class: OEO_00030008
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
@@ -1554,7 +1554,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
 Class: OEO_00030009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
@@ -1567,7 +1567,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
 Class: OEO_00030010
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
@@ -1592,7 +1592,7 @@ Class: OEO_00030032
 Class: OEO_00030033
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an endtime and thus a finite duration.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
@@ -1610,7 +1610,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Class: OEO_00030034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
@@ -1635,7 +1635,7 @@ Class: OEO_00030035
 Class: OEO_00140024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -1648,7 +1648,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140025
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -1661,7 +1661,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -1674,7 +1674,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -1687,7 +1687,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140043
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
@@ -1700,7 +1700,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Class: OEO_00140044
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
@@ -1713,7 +1713,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Class: OEO_00140068
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
         <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
@@ -1733,7 +1733,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Class: OEO_00140098
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
@@ -1747,7 +1747,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
 Class: OEO_00140099
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
@@ -1760,7 +1760,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
 Class: OEO_00140138
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1773,7 +1773,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140139
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1786,7 +1786,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140161
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
@@ -1800,7 +1800,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/808",
 Class: OEO_00140167
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
@@ -1813,7 +1813,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
 Class: OEO_00240004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
@@ -1829,7 +1829,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
 Individual: OEO_00000049
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "active"
     
     Types: 
@@ -1839,7 +1839,7 @@ Individual: OEO_00000049
 Individual: OEO_00000081
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "c++"
     
     Types: 
@@ -1849,7 +1849,7 @@ Individual: OEO_00000081
 Individual: OEO_00000092
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "coin- or_cbc"
     
     Types: 
@@ -1859,7 +1859,7 @@ Individual: OEO_00000092
 Individual: OEO_00000114
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "cplex"
     
     Types: 
@@ -1869,7 +1869,7 @@ Individual: OEO_00000114
 Individual: OEO_00000116
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "csv"
     
     Types: 
@@ -1879,7 +1879,7 @@ Individual: OEO_00000116
 Individual: OEO_00000121
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "data frame"
     
     Types: 
@@ -1889,7 +1889,7 @@ Individual: OEO_00000121
 Individual: OEO_00000130
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "dict"
     
     Types: 
@@ -1899,7 +1899,7 @@ Individual: OEO_00000130
 Individual: OEO_00000163
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "false"
     
     Types: 
@@ -1909,7 +1909,7 @@ Individual: OEO_00000163
 Individual: OEO_00000170
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "fortran"
     
     Types: 
@@ -1919,7 +1919,7 @@ Individual: OEO_00000170
 Individual: OEO_00000180
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gams"
     
     Types: 
@@ -1929,7 +1929,7 @@ Individual: OEO_00000180
 Individual: OEO_00000187
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gdx"
     
     Types: 
@@ -1939,7 +1939,7 @@ Individual: OEO_00000187
 Individual: OEO_00000195
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "glpk"
     
     Types: 
@@ -1949,7 +1949,7 @@ Individual: OEO_00000195
 Individual: OEO_00000196
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gnu"
     
     Types: 
@@ -1959,7 +1959,7 @@ Individual: OEO_00000196
 Individual: OEO_00000203
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "gurobi"
     
     Types: 
@@ -1969,7 +1969,7 @@ Individual: OEO_00000203
 Individual: OEO_00000225
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "inactive"
     
     Types: 
@@ -1979,7 +1979,7 @@ Individual: OEO_00000225
 Individual: OEO_00000244
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "java"
     
     Types: 
@@ -1989,7 +1989,7 @@ Individual: OEO_00000244
 Individual: OEO_00000266
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "math prog"
     
     Types: 
@@ -1999,7 +1999,7 @@ Individual: OEO_00000266
 Individual: OEO_00000267
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "matlab"
     
     Types: 
@@ -2009,7 +2009,7 @@ Individual: OEO_00000267
 Individual: OEO_00000280
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "modelica"
     
     Types: 
@@ -2019,7 +2019,7 @@ Individual: OEO_00000280
 Individual: OEO_00000285
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "mosek"
     
     Types: 
@@ -2029,7 +2029,7 @@ Individual: OEO_00000285
 Individual: OEO_00000287
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ms_ excel"
     
     Types: 
@@ -2039,7 +2039,7 @@ Individual: OEO_00000287
 Individual: OEO_00000288
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "vba"
     
     Types: 
@@ -2049,7 +2049,7 @@ Individual: OEO_00000288
 Individual: OEO_00000319
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "passive"
     
     Types: 
@@ -2059,7 +2059,7 @@ Individual: OEO_00000319
 Individual: OEO_00000325
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "php"
     
     Types: 
@@ -2069,7 +2069,7 @@ Individual: OEO_00000325
 Individual: OEO_00000349
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "python"
     
     Types: 
@@ -2079,7 +2079,7 @@ Individual: OEO_00000349
 Individual: OEO_00000351
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "r"
     
     Types: 
@@ -2089,7 +2089,7 @@ Individual: OEO_00000351
 Individual: OEO_00000362
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "ruby"
     
     Types: 
@@ -2099,7 +2099,7 @@ Individual: OEO_00000362
 Individual: OEO_00000424
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "true"
     
     Types: 
@@ -2109,7 +2109,7 @@ Individual: OEO_00000424
 Individual: OEO_00000426
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "txt"
     
     Types: 
@@ -2119,7 +2119,7 @@ Individual: OEO_00000426
 Individual: OEO_00000450
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xlsx"
     
     Types: 
@@ -2129,7 +2129,7 @@ Individual: OEO_00000450
 Individual: OEO_00000451
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "xml"
     
     Types: 
@@ -2139,7 +2139,7 @@ Individual: OEO_00000451
 Individual: OEO_00020023
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "top down"@en
     
     Types: 
@@ -2149,7 +2149,7 @@ Individual: OEO_00020023
 Individual: OEO_00020024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "bottom up"@en
     
     Types: 
@@ -2159,7 +2159,7 @@ Individual: OEO_00020024
 Individual: OEO_00020026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "hybrid"@en
     
     Types: 
@@ -2169,7 +2169,7 @@ Individual: OEO_00020026
 Individual: OEO_00020027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "spreadsheet"@en
     
     Types: 
@@ -2179,7 +2179,7 @@ Individual: OEO_00020027
 Individual: OEO_00020028
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "monte carlo"@en
     
     Types: 
@@ -2189,7 +2189,7 @@ Individual: OEO_00020028
 Individual: OEO_00020029
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         rdfs:label "econometric"@en
     
     Types: 
@@ -2199,7 +2199,7 @@ Individual: OEO_00020029
 Individual: OEO_00140045
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2213,7 +2213,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140046
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "center alignment",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
@@ -2228,7 +2228,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140047
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2242,7 +2242,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140069
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "value measured at or modelled for exactly one 0-dim temporal region, referenced by a time stamp, e.g. to represent a time step in a time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -2255,7 +2255,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140070
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "sum or integral of values, e.g. within a time step or a spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -2268,7 +2268,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140071
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "average value calculated by arithmetic mean over a set of data values, e.g. within a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -2281,7 +2281,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140072
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "minimum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -2294,7 +2294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140073
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "maximum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -2307,7 +2307,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140168
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "stochastic"@en
@@ -2319,7 +2319,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
 Individual: OEO_00140169
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "deterministic"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -47,10 +47,10 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
-AnnotationProperty: OEO_00110012
+AnnotationProperty: OEO_00040001
 
     
-AnnotationProperty: OEO_00269001
+AnnotationProperty: OEO_00110012
 
     
 AnnotationProperty: dc:contributor
@@ -891,7 +891,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0010006>
 Class: OEO_00000001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
@@ -913,7 +913,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
         rdfs:label "biofuel power unit"
     
@@ -929,7 +929,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -943,7 +943,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
         rdfs:label "biogas power unit"
     
@@ -955,7 +955,7 @@ Class: OEO_00000005
 Class: OEO_00000006
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
         rdfs:label "carbon dioxide",
@@ -973,7 +973,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
@@ -990,7 +990,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000008
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1009,7 +1009,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
         rdfs:label "electric heat pump"
     
@@ -1028,7 +1028,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
 Class: OEO_00000010
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
         rdfs:label "electro motive generator"
     
@@ -1043,7 +1043,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -1068,7 +1068,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
 Class: OEO_00000012
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
@@ -1082,7 +1082,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
 Class: OEO_00000013
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
         rdfs:label "fluorinated greenhouse gas"
     
@@ -1096,7 +1096,7 @@ Class: OEO_00000013
 Class: OEO_00000014
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
         rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
         rdfs:label "fossil combustion fuel"
@@ -1120,7 +1120,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
         rdfs:label "fuel cell"
     
@@ -1139,7 +1139,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
         rdfs:label "gas fired power unit"
     
@@ -1157,7 +1157,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1175,7 +1175,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000020
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -1193,7 +1193,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: OEO_00000021
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
         rdfs:label "hard coal power unit"
     
@@ -1205,7 +1205,7 @@ Class: OEO_00000021
 Class: OEO_00000022
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1224,7 +1224,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
         rdfs:label "lignite power unit"
     
@@ -1236,7 +1236,7 @@ Class: OEO_00000024
 Class: OEO_00000025
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
@@ -1260,7 +1260,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
         rdfs:label "nitrogen trifluoride"
@@ -1274,7 +1274,7 @@ Class: OEO_00000026
 Class: OEO_00000027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
         
@@ -1296,7 +1296,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000028
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -1309,7 +1309,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000029
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1328,7 +1328,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000030
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
         rdfs:label "oil power unit"
     
@@ -1349,7 +1349,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000031
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -1374,7 +1374,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
 Class: OEO_00000032
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
         <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
@@ -1408,7 +1408,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000033
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -1430,7 +1430,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
         rdfs:label "solar power unit"
     
@@ -1449,7 +1449,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
 Class: OEO_00000035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -1468,7 +1468,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000036
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1482,7 +1482,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000037
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
         rdfs:label "solid biomass power unit"
     
@@ -1494,7 +1494,7 @@ Class: OEO_00000037
 Class: OEO_00000038
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
@@ -1509,7 +1509,7 @@ Class: OEO_00000038
 Class: OEO_00000039
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
         rdfs:label "thermal energy storage"
     
@@ -1520,7 +1520,7 @@ Class: OEO_00000039
 Class: OEO_00000040
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -1541,7 +1541,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000041
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1560,7 +1560,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000042
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
@@ -1577,7 +1577,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000043
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
@@ -1595,7 +1595,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000044
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
@@ -1624,7 +1624,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000047
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -1641,7 +1641,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000054
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
@@ -1669,7 +1669,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000055
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
@@ -1688,7 +1688,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000056
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -1701,7 +1701,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00000058
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
@@ -1721,7 +1721,7 @@ Class: OEO_00000061
 Class: OEO_00000062
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "associated gas"
@@ -1733,7 +1733,7 @@ Class: OEO_00000062
 Class: OEO_00000066
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
@@ -1749,7 +1749,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00000068
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
@@ -1763,7 +1763,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000070
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
         rdfs:label "battery storage"
     
@@ -1777,7 +1777,7 @@ Class: OEO_00000070
 Class: OEO_00000071
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
@@ -1795,7 +1795,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
 Class: OEO_00000072
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
@@ -1833,7 +1833,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00000073
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1847,7 +1847,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000074
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -1873,7 +1873,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000075
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
@@ -1900,7 +1900,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
 Class: OEO_00000077
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "blast furnace gas"
@@ -1912,7 +1912,7 @@ Class: OEO_00000077
 Class: OEO_00000084
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -1937,7 +1937,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000088
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
         rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
@@ -1962,7 +1962,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000089
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1980,7 +1980,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000093
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "coke oven gas"
@@ -1992,7 +1992,7 @@ Class: OEO_00000093
 Class: OEO_00000094
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "coking coal"
@@ -2004,7 +2004,7 @@ Class: OEO_00000094
 Class: OEO_00000096
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
         rdfs:label "colliery gas"
     
@@ -2015,7 +2015,7 @@ Class: OEO_00000096
 Class: OEO_00000097
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
         rdfs:label "combustible energy carrier disposition"
     
@@ -2026,7 +2026,7 @@ Class: OEO_00000097
 Class: OEO_00000099
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
@@ -2046,7 +2046,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00000102
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
@@ -2061,7 +2061,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000115
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
@@ -2085,7 +2085,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000117
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
@@ -2099,7 +2099,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
 Class: OEO_00000126
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -2116,7 +2116,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000129
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -2131,7 +2131,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000131
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2148,7 +2148,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
 Class: OEO_00000132
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -2162,7 +2162,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000139
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
@@ -2197,7 +2197,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000143
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
@@ -2212,7 +2212,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
 Class: OEO_00000144
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -2229,7 +2229,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000146
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -2261,7 +2261,7 @@ Class: OEO_00000151
 Class: OEO_00000159
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
@@ -2274,7 +2274,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
 Class: OEO_00000165
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
         rdfs:label "field photovoltaic power plant"
@@ -2289,7 +2289,7 @@ Class: OEO_00000165
 Class: OEO_00000169
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
@@ -2304,7 +2304,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000173
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
@@ -2327,7 +2327,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
 Class: OEO_00000174
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
@@ -2344,7 +2344,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000175
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
@@ -2362,7 +2362,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000181
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
@@ -2387,7 +2387,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000183
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         
@@ -2421,7 +2421,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000184
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2435,7 +2435,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000185
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
@@ -2467,7 +2467,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000186
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
 
 The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
@@ -2481,7 +2481,7 @@ The production of other coal gases (i.e. coke oven gas, blast furnace gas and ox
 Class: OEO_00000188
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -2505,7 +2505,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000189
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
@@ -2519,7 +2519,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
 Class: OEO_00000191
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
@@ -2537,7 +2537,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000192
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2555,7 +2555,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000198
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -2572,7 +2572,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000199
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
@@ -2595,7 +2595,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100",
 Class: OEO_00000200
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
         <http://purl.obolibrary.org/obo/IAO_0000118> "network",
@@ -2613,7 +2613,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
 Class: OEO_00000204
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "hard coal"
@@ -2628,7 +2628,7 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2642,7 +2642,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000207
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
@@ -2659,7 +2659,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000210
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -2683,7 +2683,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000211
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2696,7 +2696,7 @@ Class: OEO_00000211
 Class: OEO_00000212
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
         rdfs:label "heat pump"
     
@@ -2707,7 +2707,7 @@ Class: OEO_00000212
 Class: OEO_00000218
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
@@ -2730,7 +2730,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00000219
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
@@ -2744,7 +2744,7 @@ Class: OEO_00000219
 Class: OEO_00000220
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
@@ -2764,7 +2764,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000221
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2778,7 +2778,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000222
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
@@ -2800,7 +2800,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000226
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -2813,7 +2813,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000240
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
@@ -2828,7 +2828,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
 Class: OEO_00000245
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2844,7 +2844,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
 Class: OEO_00000246
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
 [...]
 
@@ -2872,7 +2872,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000248
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
@@ -2888,7 +2888,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000251
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
@@ -2912,7 +2912,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000252
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2930,7 +2930,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000253
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -2944,7 +2944,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000255
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -2960,7 +2960,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00000257
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
@@ -2978,7 +2978,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00000258
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -3001,7 +3001,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000259
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
@@ -3016,7 +3016,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000263
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
@@ -3038,7 +3038,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000269
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
         rdfs:label "methanation gas storage"
     
@@ -3052,7 +3052,7 @@ Class: OEO_00000269
 Class: OEO_00000282
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
@@ -3067,7 +3067,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000286
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
 
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
@@ -3085,7 +3085,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00000290
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -3098,7 +3098,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000292
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
@@ -3132,7 +3132,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000293
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -3145,7 +3145,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: OEO_00000296
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -3161,7 +3161,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00000297
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
         rdfs:label "non associated gas"
@@ -3173,7 +3173,7 @@ Class: OEO_00000297
 Class: OEO_00000298
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
@@ -3188,7 +3188,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00000299
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
@@ -3208,7 +3208,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000300
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
@@ -3230,7 +3230,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000302
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -3248,7 +3248,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000303
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3266,7 +3266,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000308
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
         rdfs:label "offshore wind farm"
     
@@ -3280,7 +3280,7 @@ Class: OEO_00000308
 Class: OEO_00000310
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3294,7 +3294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000311
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
         rdfs:label "onshore wind farm"
     
@@ -3311,7 +3311,7 @@ Class: OEO_00000316
 Class: OEO_00000318
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -3331,7 +3331,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000320
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
@@ -3358,7 +3358,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000322
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
         rdfs:label "perfluorocarbon"
@@ -3371,7 +3371,7 @@ Class: OEO_00000322
 Class: OEO_00000324
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3385,7 +3385,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000330
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -3405,7 +3405,7 @@ Class: OEO_00000331
 Class: OEO_00000332
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
         <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
@@ -3431,7 +3431,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000333
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
@@ -3451,7 +3451,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
 Class: OEO_00000334
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that contains a generator, among other parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "block",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
@@ -3482,7 +3482,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000335
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -3501,7 +3501,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00000343
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
         rdfs:label "pumped storage"
     
@@ -3512,7 +3512,7 @@ Class: OEO_00000343
 Class: OEO_00000345
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
@@ -3531,7 +3531,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000348
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -3557,7 +3557,7 @@ Class: OEO_00000350
 Class: OEO_00000356
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
@@ -3584,7 +3584,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00000361
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
         rdfs:label "rooftop photovoltaic power plant"
     
@@ -3598,7 +3598,7 @@ Class: OEO_00000361
 Class: OEO_00000374
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
           A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
@@ -3611,7 +3611,7 @@ Class: OEO_00000374
 Class: OEO_00000376
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargable metal-ion battery that uses sodium ions as charge carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
@@ -3626,7 +3626,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000377
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
@@ -3642,7 +3642,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000384
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
@@ -3662,7 +3662,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
 Class: OEO_00000386
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3680,7 +3680,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000387
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
@@ -3711,7 +3711,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000388
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
@@ -3725,7 +3725,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000389
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3740,7 +3740,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000391
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
@@ -3762,7 +3762,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00000395
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
@@ -3776,7 +3776,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
 Class: OEO_00000396
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -3810,7 +3810,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000399
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
         rdfs:label "storage unit"
     
@@ -3822,7 +3822,7 @@ Class: OEO_00000399
 Class: OEO_00000401
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "sub bituminous coal",
@@ -3838,7 +3838,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000407
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
@@ -3854,7 +3854,7 @@ Class: OEO_00000419
 Class: OEO_00000420
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -3878,7 +3878,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000425
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
 https://github.com/OpenEnergyPlatform/ontology/pull/993
@@ -3906,7 +3906,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000429
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
@@ -3921,7 +3921,7 @@ Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
 Class: OEO_00000437
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
@@ -3950,7 +3950,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000439
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
@@ -3978,7 +3978,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000440
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3992,7 +3992,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000441
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
@@ -4025,7 +4025,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000442
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
@@ -4060,7 +4060,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000446
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
@@ -4088,7 +4088,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00000447
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -4102,7 +4102,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000448
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
@@ -4137,7 +4137,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000449
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -4158,7 +4158,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
 Class: OEO_00010000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
@@ -4186,7 +4186,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4206,7 +4206,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4226,7 +4226,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
@@ -4242,7 +4242,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4256,7 +4256,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
@@ -4273,7 +4273,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4291,7 +4291,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010010
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4309,7 +4309,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
@@ -4322,7 +4322,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010012
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
@@ -4342,7 +4342,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
 Class: OEO_00010015
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
@@ -4362,7 +4362,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
@@ -4382,7 +4382,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
         <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
@@ -4411,7 +4411,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00010018
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -4436,7 +4436,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
         <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
@@ -4458,7 +4458,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
 Class: OEO_00010020
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
@@ -4473,7 +4473,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
 Class: OEO_00010021
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
@@ -4509,7 +4509,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010022
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
@@ -4536,7 +4536,7 @@ Class: OEO_00010023
 Class: OEO_00010024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in an on-board battery.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -4554,7 +4554,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
 Class: OEO_00010025
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -4573,7 +4573,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
 Class: OEO_00010026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
@@ -4586,7 +4586,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -4607,7 +4607,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 Class: OEO_00010028
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
@@ -4625,7 +4625,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
 Class: OEO_00010029
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -4646,7 +4646,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
 Class: OEO_00010030
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -4665,7 +4665,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010031
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
@@ -4678,7 +4678,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010032
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -4709,7 +4709,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010072
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -4722,7 +4722,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010073
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -4735,7 +4735,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010074
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -4750,7 +4750,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010075
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -4764,7 +4764,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010076
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -4778,7 +4778,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010077
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -4792,7 +4792,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010078
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -4810,7 +4810,7 @@ Class: OEO_00010079
 Class: OEO_00010080
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
@@ -4842,7 +4842,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010081
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
@@ -4860,7 +4860,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010084
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
@@ -4876,7 +4876,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
 Class: OEO_00010085
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -4895,7 +4895,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010086
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -4911,7 +4911,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
@@ -4927,7 +4927,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010088
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
@@ -4945,7 +4945,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -4959,7 +4959,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010090
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
@@ -4988,7 +4988,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010091
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5002,7 +5002,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010092
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5016,7 +5016,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010093
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
@@ -5035,7 +5035,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010094
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
@@ -5049,7 +5049,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
 Class: OEO_00010095
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5062,7 +5062,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010096
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5076,7 +5076,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010097
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5102,7 +5102,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010098
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5132,7 +5132,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010099
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5156,7 +5156,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010100
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5177,7 +5177,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 Class: OEO_00010101
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5191,7 +5191,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010102
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5216,7 +5216,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010103
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5240,7 +5240,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010104
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5253,7 +5253,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010105
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
@@ -5268,7 +5268,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010106
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5281,7 +5281,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010107
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5294,7 +5294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010108
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5308,7 +5308,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010109
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5322,7 +5322,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010110
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5336,7 +5336,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010111
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5351,7 +5351,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010112
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5366,7 +5366,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010113
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5381,7 +5381,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010114
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
@@ -5395,7 +5395,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
 Class: OEO_00010127
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
@@ -5415,7 +5415,7 @@ pull: https://github.com/OpenEnergyPlatform/ontology/pull/865",
 Class: OEO_00010137
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
@@ -5430,7 +5430,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
 Class: OEO_00010138
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
@@ -5444,7 +5444,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010139
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Direct on air capture (DAC) is carbon dioxide capture from air.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
@@ -5459,7 +5459,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010140
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
@@ -5474,7 +5474,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010141
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
@@ -5494,7 +5494,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010144
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5511,7 +5511,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010145
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5528,7 +5528,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010146
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5545,7 +5545,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010147
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5562,7 +5562,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010148
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5579,7 +5579,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010149
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5596,7 +5596,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010150
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5613,7 +5613,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010151
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5630,7 +5630,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010153
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A gasoeus biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5647,7 +5647,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010154
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5664,7 +5664,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010155
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5681,7 +5681,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010156
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -5698,7 +5698,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010157
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
@@ -5719,7 +5719,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00010210
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
@@ -5736,7 +5736,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
 Class: OEO_00010211
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
@@ -5752,7 +5752,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
 Class: OEO_00010214
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
@@ -5766,7 +5766,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
 Class: OEO_00010215
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -5788,7 +5788,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
 Class: OEO_00010216
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -5813,7 +5813,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010217
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
@@ -5838,7 +5838,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010218
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
@@ -5853,7 +5853,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010219
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
@@ -5876,7 +5876,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010220
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
@@ -5893,7 +5893,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010221
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
@@ -5910,7 +5910,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
 Class: OEO_00010222
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
@@ -5925,7 +5925,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
 Class: OEO_00010223
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
@@ -5947,7 +5947,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010224
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -5964,7 +5964,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00010225
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
@@ -5986,7 +5986,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010226
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -6003,7 +6003,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00010256
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
@@ -6016,7 +6016,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00010257
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
@@ -6036,7 +6036,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
 Class: OEO_00010258
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
         <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
@@ -6053,7 +6053,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
 Class: OEO_00010259
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
@@ -6066,6 +6066,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
 Class: OEO_00010267
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reforming process is a chemical reaction that converts hydrocarbons and steam to syngas. As it converts chemical energy and thermal energy to a different type of chemical energy (and waste heat), it is also an energy transformation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
@@ -6084,7 +6085,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
 Class: OEO_00020001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -6113,7 +6114,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
@@ -6166,7 +6167,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
@@ -6180,7 +6181,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
@@ -6194,7 +6195,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020006
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
@@ -6210,7 +6211,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
 Class: OEO_00020007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
@@ -6228,7 +6229,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020008
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
@@ -6246,7 +6247,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -6261,7 +6262,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020037
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
@@ -6280,7 +6281,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020038
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
@@ -6300,7 +6301,7 @@ Class: OEO_00020039
 Class: OEO_00020040
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
@@ -6317,7 +6318,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020043
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
@@ -6337,7 +6338,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00020045
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
@@ -6354,7 +6355,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020046
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
@@ -6379,7 +6380,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00020047
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
@@ -6401,7 +6402,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020048
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
@@ -6423,7 +6424,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020050
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
@@ -6442,7 +6443,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020053
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
@@ -6456,7 +6457,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
 Class: OEO_00020054
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
@@ -6479,7 +6480,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00020058
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
@@ -6495,7 +6496,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
 Class: OEO_00020059
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
@@ -6522,7 +6523,7 @@ Class: OEO_00020068
 Class: OEO_00020073
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -6539,7 +6540,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020074
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
@@ -6552,7 +6553,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020085
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -6569,7 +6570,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020086
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -6582,7 +6583,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020087
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rain water, melted snow and ice).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -6597,7 +6598,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020088
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -6612,7 +6613,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020102
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
@@ -6631,7 +6632,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020103
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
@@ -6645,7 +6646,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
 Class: OEO_00020104
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perfom or operate.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -6659,7 +6660,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020105
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -6675,7 +6676,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020106
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -6691,7 +6692,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020107
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -6708,7 +6709,7 @@ Class: OEO_00020136
 Class: OEO_00020137
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -6721,7 +6722,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020139
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to contruct an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -6737,7 +6738,7 @@ Class: OEO_00020140
 Class: OEO_00020141
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -6751,7 +6752,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020144
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
@@ -6766,7 +6767,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
 Class: OEO_00020147
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
@@ -6791,7 +6792,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00020148
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of an material entity that contains non-renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
@@ -6804,7 +6805,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
 Class: OEO_00020149
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
@@ -6826,7 +6827,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
 Class: OEO_00020196
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
@@ -6846,7 +6847,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1196",
 Class: OEO_00020197
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
@@ -6860,7 +6861,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020198
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
@@ -6874,7 +6875,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020199
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
@@ -6891,7 +6892,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020200
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
@@ -6920,7 +6921,7 @@ Class: OEO_00020208
 Class: OEO_00020210
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
         <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
@@ -6936,7 +6937,7 @@ Class: OEO_00020210
 Class: OEO_00030000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -6959,7 +6960,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -6980,7 +6981,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
@@ -7010,7 +7011,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
@@ -7033,7 +7034,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -7065,7 +7066,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00030005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -7099,7 +7100,7 @@ Class: OEO_00030019
 Class: OEO_00030024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
@@ -7117,7 +7118,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123",
 Class: OEO_00030025
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
@@ -7130,7 +7131,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
 Class: OEO_00030026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
@@ -7157,7 +7158,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -7173,7 +7174,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030028
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -7195,7 +7196,7 @@ Class: OEO_00040011
 Class: OEO_00050000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
@@ -7210,7 +7211,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
 Class: OEO_00050001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
@@ -7237,7 +7238,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
 Class: OEO_00050002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7251,7 +7252,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7265,7 +7266,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7279,7 +7280,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7293,7 +7294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050006
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7307,7 +7308,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7321,7 +7322,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050008
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7335,7 +7336,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7349,7 +7350,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050010
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -7363,7 +7364,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
@@ -7388,7 +7389,7 @@ Class: OEO_00050016
 Class: OEO_00050017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
@@ -7426,7 +7427,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
 Class: OEO_00050018
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
@@ -7455,7 +7456,7 @@ Class: OEO_00050019
 Class: OEO_00050020
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
@@ -7480,7 +7481,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00090000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
 Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
@@ -7494,7 +7495,7 @@ Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
 Class: OEO_00110000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -7509,7 +7510,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -7528,7 +7529,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
 Class: OEO_00110002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -7543,7 +7544,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -7557,7 +7558,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -7576,7 +7577,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
 Class: OEO_00110005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -7597,7 +7598,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
@@ -7611,7 +7612,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
 Class: OEO_00140001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
@@ -7625,7 +7626,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
 Class: OEO_00140033
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -7638,7 +7639,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
@@ -7652,7 +7653,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -7665,7 +7666,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140036
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -7678,7 +7679,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140037
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -7691,7 +7692,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140038
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -7707,7 +7708,7 @@ Class: OEO_00140039
 Class: OEO_00140049
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
@@ -7722,7 +7723,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140050
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
@@ -7740,7 +7741,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140051
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
@@ -7755,7 +7756,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140052
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
@@ -7770,7 +7771,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140056
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
@@ -7787,7 +7788,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140057
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7800,7 +7801,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140058
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7813,7 +7814,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140059
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7826,7 +7827,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140060
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7839,7 +7840,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140061
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7852,7 +7853,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140062
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
@@ -7869,7 +7870,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140063
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7882,7 +7883,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140064
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7895,7 +7896,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140065
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7908,7 +7909,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140066
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7921,7 +7922,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140067
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -7934,7 +7935,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140075
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -7948,7 +7949,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140076
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -7962,7 +7963,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140077
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -7976,7 +7977,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140078
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
@@ -7993,7 +7994,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140079
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition secondary energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
@@ -8013,7 +8014,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678",
 Class: OEO_00140080
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
@@ -8033,7 +8034,7 @@ Class: OEO_00140081
 Class: OEO_00140082
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
@@ -8047,7 +8048,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
 Class: OEO_00140083
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -8061,7 +8062,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
 Class: OEO_00140091
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
@@ -8077,7 +8078,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140092
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
@@ -8093,7 +8094,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140101
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
@@ -8121,7 +8122,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140102
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
@@ -8150,7 +8151,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00140104
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -8164,7 +8165,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140105
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -8179,7 +8180,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140106
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
@@ -8198,7 +8199,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00140116
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
@@ -8215,7 +8216,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
 Class: OEO_00140126
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -8229,7 +8230,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140127
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "share",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
@@ -8243,7 +8244,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140128
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -8257,7 +8258,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140129
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -8271,7 +8272,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140133
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "RE-share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
@@ -8286,7 +8287,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780",
 Class: OEO_00140134
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
@@ -8300,7 +8301,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140135
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
@@ -8314,7 +8315,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140144
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -8328,7 +8329,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140159
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
@@ -8344,7 +8345,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
 Class: OEO_00140160
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
@@ -8375,7 +8376,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00140162
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
@@ -8393,7 +8394,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
 Class: OEO_00160001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -8406,7 +8407,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -8419,7 +8420,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -8432,7 +8433,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -8445,7 +8446,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00230000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
@@ -8459,7 +8460,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
 Class: OEO_00230001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
@@ -8489,7 +8490,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
@@ -8513,7 +8514,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
@@ -8539,7 +8540,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230020
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
@@ -8556,7 +8557,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00230021
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
@@ -8586,7 +8587,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
 Class: OEO_00240000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
@@ -8602,7 +8603,7 @@ Class: OEO_00240003
 Class: OEO_00240009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
@@ -8623,7 +8624,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00240010
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is a power generating unit that produces electrical energy and thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
@@ -8644,7 +8645,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 Class: OEO_00240011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is a power plant that has combined heat and power generating units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
@@ -8659,7 +8660,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
 Class: OEO_00240012
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
@@ -8674,7 +8675,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
 Class: OEO_00240013
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
@@ -8689,7 +8690,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
 Class: OEO_00240014
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
@@ -8713,7 +8714,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00240015
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
@@ -8728,7 +8729,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00240016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
@@ -8747,8 +8748,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
 Class: OEO_00240018
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
@@ -8762,7 +8763,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
 Class: OEO_00240019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
@@ -8776,7 +8777,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
 Class: OEO_00240026
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
         rdfs:label "industrial material"
     
@@ -8791,7 +8792,7 @@ Class: OEO_00240026
 Class: OEO_00240027
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8807,7 +8808,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240028
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8823,7 +8824,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240029
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8839,7 +8840,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240030
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8852,7 +8853,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240031
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
@@ -8868,7 +8869,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240032
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8881,7 +8882,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8897,7 +8898,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00240035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
@@ -8912,7 +8913,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
 Class: OEO_00260001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
@@ -8925,7 +8926,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
@@ -8939,7 +8940,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
@@ -8953,7 +8954,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00290000
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
@@ -8970,7 +8971,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00290001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
@@ -8985,7 +8986,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
 Individual: OEO_00000182
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
         rdfs:label "gaseous"
     
@@ -8996,7 +8997,7 @@ Individual: OEO_00000182
 Individual: OEO_00000256
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
         rdfs:label "liquid"
     
@@ -9007,7 +9008,7 @@ Individual: OEO_00000256
 Individual: OEO_00000326
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
@@ -9018,7 +9019,7 @@ Individual: OEO_00000326
 Individual: OEO_00000390
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,7 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
-Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: obda: <https://w3id.org/obda/vocabulary#>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -19,6 +16,12 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)"
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00110012>
+
+    
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -49,9 +52,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
-AnnotationProperty: OEO_00110012
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -73,6 +73,401 @@ AnnotationProperty: rdfs:label
 Datatype: rdf:PlainLiteral
 
     
+Datatype: xsd:string
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000521>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology.",
+        rdfs:label "applies technology"
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000525>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000523>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000524>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
+        rdfs:label "has global warming potential"
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010078>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000525>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object.",
+        rdfs:label "is applied to object"
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000521>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "is connected to"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Characteristics: 
+        Symmetric
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000527>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "has sink"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000528>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000528>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "has source"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000527>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000529>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "has normal state of matter"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000531>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000530>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
+        rdfs:label "has origin"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000531>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "has state of matter"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000532>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "has physical input"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Characteristics: 
+        Irreflexive,
+        Asymmetric
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000533>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "has physical output"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010234>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has energy input"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has energy output"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy participant of"
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020183>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy input to"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020184>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an ouput of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy output of"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140175>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has gross output"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140176>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has net output"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00240025>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is physical output of p iff: c output of p, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "physical output of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002353>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000533>
+    
+    
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
     Annotations: 
@@ -82,13 +477,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
         rdfs:label "has energy participant"@en
     
     Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
     
     Range: 
-        OEO_00000150
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
     
     InverseOf: 
-        OEO_00020182
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -153,400 +548,8080 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003001>
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
     
-ObjectProperty: OEO_00000500
-
-    
-ObjectProperty: OEO_00000501
-
-    
-ObjectProperty: OEO_00000502
-
-    
-ObjectProperty: OEO_00000503
-
-    
-ObjectProperty: OEO_00000521
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology.",
-        rdfs:label "applies technology"
-    
-    Domain: 
-        OEO_00000061
-    
-    Range: 
-        OEO_00000407
-    
-    InverseOf: 
-        OEO_00000525
-    
-    
-ObjectProperty: OEO_00000522
-
-    
-ObjectProperty: OEO_00000523
-
-    
-ObjectProperty: OEO_00000524
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
-        rdfs:label "has global warming potential"
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00140002
-    
-    Domain: 
-        OEO_00000020
-    
-    Range: 
-        OEO_00010078
-    
-    
-ObjectProperty: OEO_00000525
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object.",
-        rdfs:label "is applied to object"
-    
-    Domain: 
-        OEO_00000407
-    
-    Range: 
-        OEO_00000061
-    
-    InverseOf: 
-        OEO_00000521
-    
-    
-ObjectProperty: OEO_00000526
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "is connected to"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Characteristics: 
-        Symmetric
-    
-    
-ObjectProperty: OEO_00000527
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has sink"
-    
-    SubPropertyOf: 
-        OEO_00000526
-    
-    DisjointWith: 
-        OEO_00000528
-    
-    
-ObjectProperty: OEO_00000528
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has source"
-    
-    SubPropertyOf: 
-        OEO_00000526
-    
-    DisjointWith: 
-        OEO_00000527
-    
-    
-ObjectProperty: OEO_00000529
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has normal state of matter"
-    
-    SubPropertyOf: 
-        OEO_00000531
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
-    
-ObjectProperty: OEO_00000530
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        rdfs:label "has origin"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
-        OEO_00000150 or OEO_00000331
-    
-    Range: 
-        OEO_00000316
-    
-    
-ObjectProperty: OEO_00000531
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has state of matter"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
-    
-ObjectProperty: OEO_00000532
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-restrict range to 'material entity':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "has physical input"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Characteristics: 
-        Irreflexive,
-        Asymmetric
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-ObjectProperty: OEO_00000533
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716
-
-restrict range to 'material entity':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "has physical output"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    InverseOf: 
-        OEO_00240025
-    
-    
-ObjectProperty: OEO_00010121
-
-    
-ObjectProperty: OEO_00010234
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has energy input"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    
-ObjectProperty: OEO_00010235
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has energy output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    
-ObjectProperty: OEO_00020056
-
-    
-ObjectProperty: OEO_00020182
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy participant of"
-    
-    Domain: 
-        OEO_00000150
-    
-    Range: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    
-ObjectProperty: OEO_00020183
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy input to"
-    
-    SubPropertyOf: 
-        OEO_00020182
-    
-    
-ObjectProperty: OEO_00020184
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an ouput of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy output of"
-    
-    SubPropertyOf: 
-        OEO_00020182
-    
-    
-ObjectProperty: OEO_00040010
-
-    
-ObjectProperty: OEO_00140002
-
-    
-ObjectProperty: OEO_00140164
-
-    
-ObjectProperty: OEO_00140175
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has gross output"@en
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    
-ObjectProperty: OEO_00140176
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has net output"@en
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    
-ObjectProperty: OEO_00240025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is physical output of p iff: c output of p, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "physical output of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        OEO_00000533
-    
-    
 ObjectProperty: owl:topObjectProperty
 
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "fuel role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
+        rdfs:label "biofuel power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "biogas power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
+        rdfs:label "biogas power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        rdfs:label "carbon dioxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
+        rdfs:label "chemical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "coal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
+        rdfs:label "electric heat pump"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000212>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
+        rdfs:label "electro motive generator"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+renaming to component
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+redefine
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
+        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
+        rdfs:label "energy converting component"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000013>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
+        rdfs:label "fluorinated greenhouse gas"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000026> or <http://openenergy-platform.org/ontology/oeo/OEO_00000038> or <http://openenergy-platform.org/ontology/oeo/OEO_00000219> or <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
+        rdfs:label "fuel cell"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
+        rdfs:label "gas fired power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+             and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)),
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "geothermal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
+        rdfs:label "hard coal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hydrogen power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
+        rdfs:label "lignite power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
+        rdfs:label "methane",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000026>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
+        rdfs:label "nitrogen trifluoride"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000027>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
+        rdfs:label "nitrous oxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000028>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "nuclear power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
+        rdfs:label "oil power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000181> or <http://openenergy-platform.org/ontology/oeo/OEO_00000183>),
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces axiom to 'has energy output'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+Add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
+
+Update definition, label and axioms, add alternative terms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
+        rdfs:label "photovoltaic cell"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020048>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `renevable fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
+        rdfs:label "solar power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "solar thermal power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000036>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solid biomass power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
+        rdfs:label "solid biomass power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000038>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
+        rdfs:label "sulphur hexafluoride"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000039>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        rdfs:label "thermal energy storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000040>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "uranium",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "waste power unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000439>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000042>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:label "waste role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000043>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "wind energy converting unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000448>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020144>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00140000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "undirected",
+        rdfs:label "AC-line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+make subclass of gas mixture and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "air",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
+        rdfs:label "air pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000330>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000056>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "ambient thermal energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000058>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000062>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "associated gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000066>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "aviation gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
+        <http://purl.obolibrary.org/obo/RO_0000085> some <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
+        rdfs:label "battery storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000071>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:label "biodiesel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
+
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+redefine:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+fix subclassof:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
+
+alternative term and disjoint:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biofuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "biofuel power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "biogas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>),
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000075>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
+
+redefine and change axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:comment "biopetrol",
+        rdfs:label "biogasoline"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000077>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "blast furnace gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000084>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "charcoal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
+        rdfs:label "coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000089>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "coal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000093>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coke oven gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000094>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coking coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000096>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
+        rdfs:label "colliery gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "combustion fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000102>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "compressed air"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000115>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
+        rdfs:label "crude oil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+        rdfs:label "dam"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "directed",
+        rdfs:label "HVDC-line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "grid transferred thermal energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "relabel and add axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:label "fossil diesel fuel"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "district heating"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
+
+alternative term electricity:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
+
+add commodity role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+add axiom to electricity im/exports:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electrical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00020207>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00020208>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
+        rdfs:label "electricity grid"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "electricity grid component"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "electric vehicle"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage object"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
+        rdfs:label "field photovoltaic power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000169>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "flow battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+add role fuel commodity
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+shorten definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
+        rdfs:label "fuel"
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000174>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power plant"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power unit"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "gas diesel oil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+relabel and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000184>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "gas power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000185>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "gas turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000186>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
+
+The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gasworks gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "generator"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000189>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
+        rdfs:label "geographic coordinate"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+        rdfs:label "geothermal energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000192>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "geothermal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse effect disposition",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100",
+        rdfs:label "greenhouse gas emission"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000020>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
+        rdfs:label "supply grid"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "hard coal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000205>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hard coal power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        rdfs:label "thermal energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "heater"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000211>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "heating oil"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
+        rdfs:label "heat pump"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "hydro energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000219>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
+        rdfs:label "hydrofluorocarbon"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
+        rdfs:label "hydrogen",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000221>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hydrogen power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "hydrogen turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "industrial waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000240>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "internal combustion vehicle"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000245>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "convert second label to alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1230
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
+        rdfs:label "jet fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+[...]
+
+Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "kerosene"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000248>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "lithium-ion battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process.",
+        rdfs:label "lignite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000252>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "lignite power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "power line"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid component link"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
+        rdfs:label "liquid air"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000258>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid biofuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `liquid biofuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000259>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "liquid-metal battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "manufactured coal based gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
+        rdfs:label "methanation gas storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "molten-salt battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000286>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
+
+Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "motor gasoline"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "municipal waste fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+improve definition and make subclass of gas mixture and add disjoints:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
+        rdfs:label "natural gas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000293>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "negative emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid node"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000297>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "non associated gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "non-methane volatile organic compound"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000299>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non renewable municipal waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil municipal waste fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+convertion to nuclear binding energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
+        rdfs:label "nuclear binding energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000303>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "nuclear power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
+        rdfs:label "offshore wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000310>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "oil power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
+        rdfs:label "onshore wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "particulate matter",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>),
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000320>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
+        rdfs:label "peat",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
+        rdfs:label "perfluorocarbon"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "photovoltaic power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000330>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "solid biofuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `solid biofuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that contains a generator, among other parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "power generating unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020107>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000335>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "power-to-gas system"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010021>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010216>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000343>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
+        rdfs:label "pumped storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
+
+add secondary energy carrier disposition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "pumped water"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110000>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
+        rdfs:label "PV panel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000356>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+new definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic municipal waste fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000374>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
+          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
+        rdfs:label "SMES"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000376>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargable metal-ion battery that uses sodium ions as charge carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "sodium-ion battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000377>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "sodium-sulphur battery"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+restructure solar energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+remove disposition renewable fuel
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
+        rdfs:label "solar energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020040>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000386>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solar power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+        rdfs:label "solar thermal collector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000388>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020047>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "solar thermal energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000389>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solar thermal power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000035>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000391>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
+
+Update definition and axioms:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid fossil fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+        rdfs:label "state of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "steam turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110001>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        rdfs:label "storage unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000401>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000009"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
+        rdfs:label "technology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
+        rdfs:label "transformer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000423>
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140116>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000429>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
+        rdfs:label "underground hydrogen storage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatile organic compound",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000025> or <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `volatile organic compound`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>),
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
+
+comment:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/629
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
+        rdfs:label "waste fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000042>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `waste fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000440>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "waste power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000441>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
+add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "water",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000442>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "water turbine"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+reclassify and change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+remove disposition renewable fuel
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
+add and change axioms
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "wind energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00000043>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020183> some <http://openenergy-platform.org/ontology/oeo/OEO_00020043>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "wind farm"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000448>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "wind rotor"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020043>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020144>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000449>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+add dispositions:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
+        rdfs:label "wood"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010214>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "trihydridonitrogen",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+Adapt definiton and axioms, add alternative  terms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "ammonia"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "carbon monoxide"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen oxides"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitric oxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen dioxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "sulphur dioxide"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM10"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010010>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM2.5"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
+        rdfs:label "air pollutant"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010015>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "fossil hydrogen"
+    
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic hydrogen"
+    
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "synthetic fuel"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `synthetic fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010018>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+Re-definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "synthetic methane"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+new label and axioms:
+https://github.com/OpenEnergyPlatform/ontology/issues/934
+pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
+        rdfs:label "PtL fuel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010156>,
+        <http://purl.obolibrary.org/obo/RO_0003001> some <http://openenergy-platform.org/ontology/oeo/OEO_00010020>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010020>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "power-to-liquid system"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "water electrolyser"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0003000> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010022>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
+        rdfs:label "steam reformer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
+        <http://purl.obolibrary.org/obo/RO_0003000> some <http://openenergy-platform.org/ontology/oeo/OEO_00140160>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in an on-board battery.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
+        rdfs:label "battery electric vehicle"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
+        rdfs:label "fuel cell electric vehicle"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
+        rdfs:label "traction battery"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "electric motor"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+relabel and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
+        rdfs:label "electric traction motor"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010027>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "internal combustion engine"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140038>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "plug-in hybrid electric vehicle"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "grid supplied electric vehicle"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "motor",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010072>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal power density unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010073>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal energy density unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010074>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal power density"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00010072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010075>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal energy density"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00010073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010076>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal solar power density"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010074>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010077>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal solar energy density"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010075>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010078>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
+        rdfs:label "global warming potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010080>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+add 'has physical output' some 'electrical energy'
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar-steam-electric process"@en
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020047>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00050020>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010081>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar chemical energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010084>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+        rdfs:label "reservoir"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010085>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power unit"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000442>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010086>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010087>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "run of river power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010093>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010088>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro storage power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010084>),
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010089>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010088>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010090>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010090>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "pump"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140116>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00020045> or <http://openenergy-platform.org/ontology/oeo/OEO_00230020>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010091>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "open-loop pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010089>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010092>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "closed-loop pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010089>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> only <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010093>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
+
+Make river a subclass of water body:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "river"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010104>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010094>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
+        rdfs:label "reservoir hydro storage power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010088>,
+        not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010090>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010095>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine thermal energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010096>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine thermal energy transfer"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010097>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+add and change axioms
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine current energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010107>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020183> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+remove wrong axiom 
+https://github.com/OpenEnergyPlatform/ontology/pull/1044",
+        rdfs:label "marine current energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010097>,
+        
+            Annotations: rdfs:comment "reintroduce axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010107>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "marine tidal energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010100>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010100>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine tidal energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "tidal flow"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010102>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine wave energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "marine wave energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010102>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010104>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "water body"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010105>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "ocean"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "wave"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010107>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "ocean current"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010108>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy converting unit"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010109>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy converting unit"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010110>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy converting unit"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010111>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010108>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010112>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010109>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010113>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy power plant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010110>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010114>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
+        rdfs:label "waste thermal energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010127>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/865",
+        rdfs:label "secondary energy production"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00140079>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010137>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "t",
+        rdfs:label "metric ton"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010138>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon capture"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010139>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct on air capture (DAC) is carbon dioxide capture from air.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "direct air capture"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010138>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010140>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon storage"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010141>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon capture and storage"@en
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010138>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010140>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010144>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid combustion fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010145>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid combustion fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010146>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous combustion fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010147>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid fossil fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010148>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous fossil fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010149>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid renewable fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010150>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid renewable fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010151>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous renewable fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010153>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A gasoeus biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous biofuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010154>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid synthetic fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010155>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous synthetic fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010156>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid synthetic fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010157>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+Make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "power value"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010210>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
+        rdfs:label "energy use"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010211>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010211>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
+        rdfs:label "non-energy use"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010210>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010214>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
+        rdfs:label "biomass"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010215>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "biomethane"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010216>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "power-to-gas process"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010155>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010217>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "power-to-methane process"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010216>,
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010018>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>),
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010219>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010218>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "oxygen"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010219>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "water electrolysis process"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010218>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>),
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010220>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "methanation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140034>,
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>),
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010221>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "synthetic ammonia"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010222>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "power-to-ammonia process"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010216>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010223>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic waste fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010224>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil waste fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010225>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic industrial waste fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010226>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil industrial waste fuel"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010256>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "maximum value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010257>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
+
+Fix 'quantity value of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
+        rdfs:label "power capacity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010256>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000188> or <http://openenergy-platform.org/ontology/oeo/OEO_00000334>),
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010258>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
+        rdfs:label "bioenergy"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010259>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
+        rdfs:label "measurement device"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
+axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
+        rdfs:label "ethanol"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000075>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
+
+make class a subclass of transformation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+add input and output relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+add relation to energy transformation unit:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+add axiom relating to energy carrier / input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182"@en,
+        rdfs:label "energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020039>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "gas grid"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "heating grid"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020004>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020037>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+        rdfs:label "radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00230021>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020038>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+        rdfs:label "solar radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020037>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020040>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+        rdfs:label "radiative energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020043>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
+        rdfs:label "wind energy transformation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020045>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020046>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+has input relation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+delete has physical output relation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar energy transformation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020047>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar thermal energy transformation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000388>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020048>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "photovoltaic energy transformation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020050>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+change def and equivalence
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020053>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
+        rdfs:label "nuclear fission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020054>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "nuclear energy transformation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000300>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020058>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+        rdfs:label "rock"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020059>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "geothermal heat transfer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> only <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "grid-bound heating"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00110000> or <http://openenergy-platform.org/ontology/oeo/OEO_00110001>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020074>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "industrial grid-bound heating"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020085>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020086>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020087>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rain water, melted snow and ice).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "natural hydro energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010104>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020088>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "pumped hydro energy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000345>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "energy transformation unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020103>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "energy transfer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perfom or operate.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "outage"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020105>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "forced outage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020106>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020106>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "planned outage"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020105>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020107>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "curtailment"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020137>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "operational space requirement"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020139>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to contruct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "space requirement for construction"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020141>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "specific space requirement"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020144>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
+        rdfs:label "rotor diameter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "conventional"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020148>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of an material entity that contains non-renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
+        rdfs:label "conventional energy carrier disposition"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020149>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Update definition and axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1172
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
+        rdfs:label "fossil energy"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>)
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000014>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020196>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
+
+Fix spelling of label:
+https://github.com/OpenEnergyPlatform/ontology/pull/1196",
+        rdfs:label "fissile material entity"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020197>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "tangential proper part"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "surface"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020197>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020199>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "solar radiation receiving surface"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020200>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+        rdfs:label "solar receiving object"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020201>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020202>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020210>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "sirup"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "anthropogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "biogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Update definition and add disjoint:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Shift part of the definition into an editor note:
+Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "fossil"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "geogenic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
+include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "renewable"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Make subclass of anthropogenic:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "synthetic"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030015>
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00030024>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030024>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
+
+make subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123",
+        rdfs:label "energy system"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030025>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030025>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
+        rdfs:label "supply system"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+add axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy production"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00140078>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030027>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy carrier mining"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030028>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy carrier harvest"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
+        rdfs:label "industrial process"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some 
+            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
+
+Update definition and axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
+        rdfs:label "fuel-powered electricity generation"@en
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240014>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240014>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00000148>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000174>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>,
+        <http://purl.obolibrary.org/obo/RO_0002418> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
+        rdfs:label "kilojoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
+        rdfs:label "megajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
+        rdfs:label "gigajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
+        rdfs:label "terajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
+        rdfs:label "petajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
+        rdfs:label "exajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
+        rdfs:label "megawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
+        rdfs:label "terawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050010>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
+        rdfs:label "petawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
+        rdfs:label "gigawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
+
+Gross inland energy consumption covers:
+  - consumption by the energy sector itself;
+  - distribution and transformation losses;
+  - final energy consumption by end users;
+  - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
+
+Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross inland consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary energy consumption including non-energy use of energy carriers"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "become a subclass of quantity value:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "gross inland energy consumption"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240019>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010210>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010211>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050018>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "primary energy consumption"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010211>))
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010210>),
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050020>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "steam-electric process"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
+        rdfs:label "volumetric flow rate value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000270>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "liquid water"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
+        rdfs:label "steam"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "water flow"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00110003>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "water flow rate"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00090000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "hydro energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "hydroelectric energy transformation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110004>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "hub height"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "length value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "chemical reaction"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "redox reaction"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "oxidation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140036>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "reduction"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140037>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "electrochemical reaction"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140038>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "combustion"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140049>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "energy conversion efficiency"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140050>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140050>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "efficiency value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140051>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "coefficient of performance value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140052>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140052>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "energy conversion performance"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
+
+change: adjust definition to be based on parent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
+        rdfs:label "flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140057>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "theoretical flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140058>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "technological flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140059>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "economic flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140060>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "developable flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140061>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "sustainable flow potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
+
+change: adjust definition to be based on parent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
+        rdfs:label "stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140063>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "theoretical stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140064>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "technological stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140065>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "economic stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140066>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "developable stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140067>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "sustainable stock potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140075>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "primary energy carrier disposition"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "secondary energy carrier disposition"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140077>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "final energy carrier disposition"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140078>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "primary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140079>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition secondary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
+fix error in definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678",
+        rdfs:label "secondary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140080>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "final energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140077>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140082>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
+        rdfs:label "greenhouse gas emission value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140083>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
+        rdfs:label "carbon dioxide equivalent quantity"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140082>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140091>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
+        rdfs:label "plutonium"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140092>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
+        rdfs:label "thorium"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140101>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
+
+subclass of energy transfer
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "heat transfer"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020103>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> only <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> only <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140102>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "heat exchanger"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140101>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140104>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "natural ambient thermal energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140105>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "artificial ambient thermal energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140106>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "ambient thermal energy transfer"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140116>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
+        rdfs:label "fluid"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and ((<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000326>))
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140126>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "planned availability"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "share",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "fraction value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140128>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "block size"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230002>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140129>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "unplanned availability"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140133>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "RE-share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780",
+        rdfs:label "RE-share"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140134>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
+        rdfs:label "hydrogen fuel cell"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000016>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140135>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
+        rdfs:label "natural gas turbine"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140144>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "full load hours"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000032>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140159>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
+        rdfs:label "hydrocarbon"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140160>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
+
+add axioms:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "syngas"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010001>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140162>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
+        rdfs:label "power plant with electro motive generator"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "frequency control"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "primary control"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "secondary control"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "tertiary control"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "storage capacity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "power rating"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "declared net capacity"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000031> or <http://openenergy-platform.org/ontology/oeo/OEO_00000334>),
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+extend to artificial objects:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "nameplate capacity"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        rdfs:label "kinetic energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230021>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
+add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+classify as material entity
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
+        rdfs:label "photon"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020040>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
+        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
+        rdfs:label "rotational energy"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "combined heat and power generation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240010>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is a power generating unit that produces electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
+
+change produces energy axioms to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "combined heat and power generating unit"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00240009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is a power plant that has combined heat and power generating units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
+        rdfs:label "combined heat and power plant"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00240010>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240012>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+        rdfs:label "gross electricity generation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240013>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+        rdfs:label "net electricity generation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240014>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "electricity generation process"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00240012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00240013>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240015>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
+        rdfs:label "liquid air production"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
+
+make subclass of 'fraction value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
+        rdfs:label "net capacity factor"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240018>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00110012> "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
+        rdfs:label "gross national electricity consumption"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240019>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00050017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
+        rdfs:label "energy consumption value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00050019>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240026>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
+        rdfs:label "industrial material"
+    
+    EquivalentTo: 
+        (<http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240027>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "chemical substance"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00140033>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240028>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "paper"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240029>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "cement"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240030>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "mineral"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240031>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "non-metallic mineral"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240030>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240032>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "metal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "steel"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240032>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "non-ferrous metal"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240032>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "ramping"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "start-up speed"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00260001>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00260003>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "cold start"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00260002>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
+
+make subclass of 'maximum value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "potential"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010256>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00290001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
+        rdfs:label "slope"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000122>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
 
@@ -557,8 +8632,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "gas mixture"@en
     
     SubClassOf: 
-        OEO_00000331,
-        OEO_00000529 value OEO_00000182
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010237>
@@ -571,11 +8646,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1016",
         rdfs:label "liquified natural gas"@en
     
     EquivalentTo: 
-        OEO_00000292
-         and (OEO_00000531 value OEO_00000256)
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
     
     SubClassOf: 
-        OEO_00000292
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
@@ -591,7 +8666,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel role"@en
     
     SubClassOf: 
-        OEO_00000001
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
@@ -603,7 +8678,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel fuel role"@en
     
     SubClassOf: 
-        OEO_00000001
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
@@ -619,11 +8694,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel"@en
     
     EquivalentTo: 
-        OEO_00000099
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
          and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>)
     
     SubClassOf: 
-        OEO_00000099
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
@@ -635,11 +8710,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel fuel"@en
     
     EquivalentTo: 
-        OEO_00000099
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
          and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>)
     
     SubClassOf: 
-        OEO_00000099
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
@@ -656,8 +8731,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline engine"@en
     
     SubClassOf: 
-        OEO_00010029,
-        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010029>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>
@@ -670,8 +8745,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel engine"@en
     
     SubClassOf: 
-        OEO_00010029,
-        OEO_00000503 some OEO_00000131
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010029>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
@@ -687,11 +8762,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline vehicle"@en
     
     SubClassOf: 
-        OEO_00000240,
-        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000240>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>,
         <http://purl.obolibrary.org/obo/BFO_0000051> only 
-            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243> or (not (OEO_00010032)))
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243> or (not (<http://openenergy-platform.org/ontology/oeo/OEO_00010032>)))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010246>
@@ -703,11 +8778,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel vehicle"@en
     
     SubClassOf: 
-        OEO_00000240,
-        OEO_00000503 some OEO_00000131,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000240>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000131>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>,
         <http://purl.obolibrary.org/obo/BFO_0000051> only 
-            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032)))
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (<http://openenergy-platform.org/ontology/oeo/OEO_00010032>)))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
@@ -719,11 +8794,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
         rdfs:label "heat generation process"@en
     
     EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000207)
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>)
     
     SubClassOf: 
-        OEO_00020003
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010249>
@@ -739,12 +8814,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210",
         rdfs:label "combustion thermal energy transformation"@en
     
     SubClassOf: 
-        OEO_00020003,
-        OEO_00000532 some OEO_00000099,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
-        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140038>,
+        <http://purl.obolibrary.org/obo/RO_0002418> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
@@ -770,11 +8845,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
         rdfs:label "traction motor"@en
     
     EquivalentTo: 
-        OEO_00010032
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
          and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>)
     
     SubClassOf: 
-        OEO_00010032
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
     
     
 Class: <http://opennergy-plattform.org/ontology/oeo/OEO_00290002>
@@ -787,8 +8862,8 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
         rdfs:label "surface azimuth angle"@en
     
     SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000122>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -884,7679 +8959,53 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: OEO_00000001
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "fuel role",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00010121 some OEO_00000331
-    
-    
-Class: OEO_00000003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
-        rdfs:label "biofuel power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000072,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
-    
-    
-Class: OEO_00000004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biogas power plant"
-    
-    SubClassOf: 
-        OEO_00000073,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000005
-    
-    
-Class: OEO_00000005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
-        rdfs:label "biogas power unit"
-    
-    SubClassOf: 
-        OEO_00000003,
-        OEO_00000503 some OEO_00000074
-    
-    
-Class: OEO_00000006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
-        rdfs:label "chemical energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000088,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
-        rdfs:label "electric heat pump"
-    
-    SubClassOf: 
-        OEO_00000212,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        OEO_00010235 some OEO_00000139
-    
-    
-Class: OEO_00000010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
-        rdfs:label "electro motive generator"
-    
-    SubClassOf: 
-        OEO_00000188,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00230020
-    
-    
-Class: OEO_00000011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-renaming to component
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-redefine
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
-        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
-        rdfs:label "energy converting component"
-    
-    SubClassOf: 
-        OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
-    
-    
-Class: OEO_00000012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage"
-    
-    SubClassOf: 
-        OEO_00000151,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: OEO_00000013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
-        rdfs:label "fluorinated greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000026 or OEO_00000038 or OEO_00000219 or OEO_00000322
-    
-    SubClassOf: 
-        OEO_00000020
-    
-    
-Class: OEO_00000014
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000099,
-        OEO_00000530 some OEO_00030003
-    
-    DisjointWith: 
-        OEO_00000072
-    
-    
-Class: OEO_00000016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
-        rdfs:label "fuel cell"
-    
-    SubClassOf: 
-        OEO_00000188,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000173,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140034
-    
-    
-Class: OEO_00000017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
-        rdfs:label "gas fired power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some 
-            (OEO_00000173
-             and (OEO_00000529 value OEO_00000182)),
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
-    
-    
-Class: OEO_00000019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
-        rdfs:label "hard coal power unit"
-    
-    SubClassOf: 
-        OEO_00000008,
-        OEO_00000503 some OEO_00000204
-    
-    
-Class: OEO_00000022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hydrogen power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000220,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
-    
-    
-Class: OEO_00000024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
-        rdfs:label "lignite power unit"
-    
-    SubClassOf: 
-        OEO_00000008,
-        OEO_00000503 some OEO_00000251
-    
-    
-Class: OEO_00000025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "methane",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
-    
-    SubClassOf: 
-        OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
-        rdfs:label "nitrogen trifluoride"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030000,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
-        rdfs:label "nitrous oxide",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000028
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00000029
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000302,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000030
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
-        rdfs:label "oil power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024"
-        OEO_00000503 some 
-            (OEO_00000181 or OEO_00000183),
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "power plant"
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020006,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
-    
-    
-Class: OEO_00000032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces axiom to 'has energy output'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-Add axiom to 'has part some solar radiation receiving surface'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
-
-Update definition, label and axioms, add alternative terms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
-        rdfs:label "photovoltaic cell"
-    
-    SubClassOf: 
-        OEO_00000188,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000384,
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020048
-    
-    
-Class: OEO_00000033
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `renevable fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
-        rdfs:label "solar power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        OEO_00010234 some OEO_00000384
-    
-    
-Class: OEO_00000035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "solar thermal power unit"
-    
-    SubClassOf: 
-        OEO_00000034,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
-    
-    
-Class: OEO_00000036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solid biomass power plant"
-    
-    SubClassOf: 
-        OEO_00000073,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000037
-    
-    
-Class: OEO_00000037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
-        rdfs:label "solid biomass power unit"
-    
-    SubClassOf: 
-        OEO_00000003,
-        OEO_00000503 some OEO_00000332
-    
-    
-Class: OEO_00000038
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
-        rdfs:label "sulphur hexafluoride"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030000,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
-        rdfs:label "thermal energy storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    
-Class: OEO_00000040
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030003,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000041
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "waste power unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000439,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000042
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:label "waste role",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00000043
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000054
-    
-    
-Class: OEO_00000044
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
-Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "wind energy converting unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000446,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
-    
-    
-Class: OEO_00000047
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "undirected",
-        rdfs:label "AC-line"@en
-    
-    SubClassOf: 
-        OEO_00000253
-    
-    DisjointWith: 
-        OEO_00000126
-    
-    
-Class: OEO_00000054
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-make subclass of gas mixture and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "air",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        OEO_00000501 some OEO_00000399,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000055
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
-    
-    SubClassOf: 
-        OEO_00000330,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010012
-    
-    
-Class: OEO_00000056
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "ambient thermal energy"
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00000058
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
-    
-    SubClassOf: 
-        OEO_00000204
-    
-    
-Class: OEO_00000061
-
-    
-Class: OEO_00000062
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "associated gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000066
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "aviation gasoline"
-    
-    SubClassOf: 
-        OEO_00000183
-    
-    
-Class: OEO_00000068
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "battery"
-    
-    SubClassOf: 
-        OEO_00000159,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
-    
-    
-Class: OEO_00000070
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
-        rdfs:label "battery storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    DisjointWith: 
-        OEO_00000269
-    
-    
-Class: OEO_00000071
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:label "biodiesel"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000072
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
-
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-redefine:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-fix subclassof:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-
-alternative term and disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biofuel"
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000530 some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000099,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086
-    
-    DisjointWith: 
-        OEO_00000014
-    
-    
-Class: OEO_00000073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biofuel power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000003
-    
-    
-Class: OEO_00000074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "biogas",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000006)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025),
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000075
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
-
-redefine and change axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:comment "biopetrol",
-        rdfs:label "biogasoline"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000077
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "blast furnace gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000084
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "charcoal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000088
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
-        rdfs:label "coal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000089
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008
-    
-    
-Class: OEO_00000093
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coke oven gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000094
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coking coal"
-    
-    SubClassOf: 
-        OEO_00000204
-    
-    
-Class: OEO_00000096
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
-        rdfs:label "colliery gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000097
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00000099
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
-    
-    SubClassOf: 
-        OEO_00000173
-    
-    
-Class: OEO_00000102
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "compressed air"
-    
-    SubClassOf: 
-        OEO_00000054,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
-    
-Class: OEO_00000115
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024",
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000117
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
-        rdfs:label "dam"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00000501 some OEO_00000399
-    
-    
-Class: OEO_00000126
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "directed",
-        rdfs:label "HVDC-line"@en
-    
-    SubClassOf: 
-        OEO_00000253
-    
-    DisjointWith: 
-        OEO_00000047
-    
-    
-Class: OEO_00000129
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "grid transferred thermal energy"
-    
-    SubClassOf: 
-        OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020073
-    
-    
-Class: OEO_00000131
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "relabel and add axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:label "fossil diesel fuel"@en
-    
-    SubClassOf: 
-        OEO_00000181,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
-    
-    
-Class: OEO_00000132
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "district heating"
-    
-    SubClassOf: 
-        OEO_00020073
-    
-    
-Class: OEO_00000139
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
-
-alternative term electricity:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
-
-add commodity role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
-
-add axiom to electricity im/exports:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
-    
-Class: OEO_00000143
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 OEO_00000253
-    
-    
-Class: OEO_00000144
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00000146
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "electric vehicle"
-    
-    SubClassOf: 
-        OEO_00010023,
-        OEO_00010234 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028
-    
-    
-Class: OEO_00000147
-
-    
-Class: OEO_00000148
-
-    
-Class: OEO_00000150
-
-    
-Class: OEO_00000151
-
-    
-Class: OEO_00000159
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage object"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000165
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
-        rdfs:label "field photovoltaic power plant"
-    
-    SubClassOf: 
-        OEO_00000324
-    
-    DisjointWith: 
-        OEO_00000361
-    
-    
-Class: OEO_00000169
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "flow battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000173
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-add role fuel commodity
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-shorten definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00000174
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power plant"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050001
-    
-    
-Class: OEO_00000175
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power unit"
-    
-    EquivalentTo: 
-        OEO_00000334
-         and (OEO_00000503 some OEO_00000173)
-    
-    SubClassOf: 
-        OEO_00000334,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050001
-    
-    
-Class: OEO_00000181
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "gas diesel oil"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000183
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-relabel and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "gasoline"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000184
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "gas power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000017
-    
-    
-Class: OEO_00000185
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "gas turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000099,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000
-    
-    
-Class: OEO_00000186
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
-
-The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gasworks gas"
-    
-    SubClassOf: 
-        OEO_00000263
-    
-    
-Class: OEO_00000188
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
-    
-    
-Class: OEO_00000189
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
-        rdfs:label "geographic coordinate"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
-    
-    
-Class: OEO_00000191
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "geothermal energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
-    
-    SubClassOf: 
-        OEO_00000207,
-        OEO_00000530 some OEO_00030004
-    
-    
-Class: OEO_00000192
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019
-    
-    
-Class: OEO_00000198
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse effect disposition",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: OEO_00000199
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100",
-        rdfs:label "greenhouse gas emission"
-    
-    EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020)
-    
-    SubClassOf: 
-        OEO_00000147
-    
-    
-Class: OEO_00000200
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: OEO_00000204
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "hard coal"
-    
-    SubClassOf: 
-        OEO_00000088
-    
-    DisjointWith: 
-        OEO_00000251
-    
-    
-Class: OEO_00000205
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hard coal power plant"
-    
-    SubClassOf: 
-        OEO_00000089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
-    
-    
-Class: OEO_00000207
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "thermal energy"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00000210
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "heater"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000207
-    
-    
-Class: OEO_00000211
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil"@en
-    
-    SubClassOf: 
-        OEO_00000181
-    
-    
-Class: OEO_00000212
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
-        rdfs:label "heat pump"
-    
-    SubClassOf: 
-        OEO_00000210
-    
-    
-Class: OEO_00000218
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "hydro energy"
-    
-    SubClassOf: 
-        OEO_00230020,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002
-    
-    
-Class: OEO_00000219
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
-        rdfs:label "hydrofluorocarbon"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030000
-    
-    
-Class: OEO_00000220
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000221
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hydrogen power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022
-    
-    
-Class: OEO_00000222
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "hydrogen turbine"
-    
-    SubClassOf: 
-        OEO_00000185,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000220
-    
-    
-Class: OEO_00000226
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "industrial waste fuel"
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00000240
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "internal combustion vehicle"
-    
-    SubClassOf: 
-        OEO_00010023,
-        OEO_00000503 some OEO_00000099,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
-    
-    
-Class: OEO_00000245
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "convert second label to alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1230
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
-        rdfs:label "jet fuel"
-    
-    SubClassOf: 
-        OEO_00000246
-    
-    
-Class: OEO_00000246
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
-[...]
-
-Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "kerosene"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000248
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "lithium-ion battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000251
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process.",
-        rdfs:label "lignite",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
-    
-    SubClassOf: 
-        OEO_00000088,
-        OEO_00000530 some OEO_00030002,
-        OEO_00000529 value OEO_00000390
-    
-    DisjointWith: 
-        OEO_00000204
-    
-    
-Class: OEO_00000252
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "lignite power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
-    
-    SubClassOf: 
-        OEO_00000089,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000024
-    
-    
-Class: OEO_00000253
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        OEO_00000255,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
-    
-Class: OEO_00000255
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    DisjointWith: 
-        OEO_00000296
-    
-    
-Class: OEO_00000257
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
-        rdfs:label "liquid air"
-    
-    EquivalentTo: 
-        OEO_00000054
-         and (OEO_00000531 value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00000054
-    
-    
-Class: OEO_00000258
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid biofuel"
-    
-    EquivalentTo: 
-        OEO_00000072
-         and (OEO_00000529 value OEO_00000256)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `liquid biofuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000072,
-        OEO_00000530 some OEO_00030001,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000259
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "liquid-metal battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000263
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "manufactured coal based gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000269
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
-        rdfs:label "methanation gas storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    DisjointWith: 
-        OEO_00000070
-    
-    
-Class: OEO_00000282
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "molten-salt battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000286
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
-
-Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "motor gasoline"
-    
-    SubClassOf: 
-        OEO_00000183
-    
-    
-Class: OEO_00000290
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "municipal waste fuel"
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00000292
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-improve definition and make subclass of gas mixture and add disjoints:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
-        rdfs:label "natural gas",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00000293
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "negative emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000296
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid node"
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    DisjointWith: 
-        OEO_00000255
-    
-    
-Class: OEO_00000297
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "non associated gas"
-    
-    SubClassOf: 
-        OEO_00000292
-    
-    
-Class: OEO_00000298
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "non-methane volatile organic compound"
-    
-    SubClassOf: 
-        OEO_00000437
-    
-    
-Class: OEO_00000299
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non renewable municipal waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil municipal waste fuel"
-    
-    EquivalentTo: 
-        OEO_00000290
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        OEO_00000290
-    
-    
-Class: OEO_00000300
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-convertion to nuclear binding energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear binding energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00000530 some OEO_00020147
-    
-    
-Class: OEO_00000302
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
-    
-    SubClassOf: 
-        OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000300
-    
-    
-Class: OEO_00000303
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029
-    
-    
-Class: OEO_00000308
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
-        rdfs:label "offshore wind farm"
-    
-    SubClassOf: 
-        OEO_00000447
-    
-    DisjointWith: 
-        OEO_00000311
-    
-    
-Class: OEO_00000310
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "oil power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030
-    
-    
-Class: OEO_00000311
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
-        rdfs:label "onshore wind farm"
-    
-    SubClassOf: 
-        OEO_00000447
-    
-    DisjointWith: 
-        OEO_00000308
-    
-    
-Class: OEO_00000316
-
-    
-Class: OEO_00000318
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
-    
-    SubClassOf: 
-        OEO_00000331,
-        (OEO_00000529 value OEO_00000256) or (OEO_00000529 value OEO_00000390),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
-    
-    
-Class: OEO_00000320
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
-        rdfs:label "peat",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000322
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
-        rdfs:label "perfluorocarbon"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030000
-    
-    
-Class: OEO_00000324
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "photovoltaic power plant"
-    
-    SubClassOf: 
-        OEO_00000386,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
-    
-    
-Class: OEO_00000330
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
-    
-    SubClassOf: 
-        OEO_00000147
-    
-    
-Class: OEO_00000331
-
-    
-Class: OEO_00000332
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "solid biofuel"@en
-    
-    EquivalentTo: 
-        OEO_00000072
-         and (OEO_00000529 value OEO_00000390)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `solid biofuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000072,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000333
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003
-    
-    
-Class: OEO_00000334
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that contains a generator, among other parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "power generating unit"
-    
-    SubClassOf: 
-        OEO_00020102,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
-    
-    
-Class: OEO_00000335
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "power-to-gas system"
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
-    
-    
-Class: OEO_00000343
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
-        rdfs:label "pumped storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    
-Class: OEO_00000345
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
-
-add secondary energy carrier disposition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "pumped water"
-    
-    SubClassOf: 
-        OEO_00110000,
-        OEO_00000501 some OEO_00000399,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
-    
-Class: OEO_00000348
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
-        rdfs:label "PV panel"
-    
-    SubClassOf: 
-        OEO_00000034,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032
-    
-    
-Class: OEO_00000350
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: OEO_00000356
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-new definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic municipal waste fuel"
-    
-    EquivalentTo: 
-        OEO_00000290
-         and (OEO_00000530 some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000290,
-        OEO_00000530 some OEO_00030001
-    
-    
-Class: OEO_00000361
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
-        rdfs:label "rooftop photovoltaic power plant"
-    
-    SubClassOf: 
-        OEO_00000324
-    
-    DisjointWith: 
-        OEO_00000165
-    
-    
-Class: OEO_00000374
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
-        rdfs:label "SMES"
-    
-    SubClassOf: 
-        OEO_00000159
-    
-    
-Class: OEO_00000376
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargable metal-ion battery that uses sodium ions as charge carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "sodium-ion battery"
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00000377
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "sodium-sulphur battery"
-    
-    SubClassOf: 
-        OEO_00000282
-    
-    
-Class: OEO_00000384
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-restructure solar energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-remove disposition renewable fuel
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
-        rdfs:label "solar energy"
-    
-    SubClassOf: 
-        OEO_00020040,
-        OEO_00000530 some OEO_00030004
-    
-    
-Class: OEO_00000386
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000034
-    
-    
-Class: OEO_00000387
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-add axiom to 'has part some solar radiation receiving surface'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
-        rdfs:label "solar thermal collector"
-    
-    SubClassOf: 
-        OEO_00000210,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000384,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000388,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
-    
-    
-Class: OEO_00000388
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "solar thermal energy"
-    
-    SubClassOf: 
-        OEO_00000207,
-        OEO_00000530 some OEO_00030004
-    
-    
-Class: OEO_00000389
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar thermal power plant"
-    
-    SubClassOf: 
-        OEO_00000386,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000035,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
-    
-    
-Class: OEO_00000391
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
-
-Update definition and axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid fossil fuel"
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00000529 value OEO_00000390)
-    
-    SubClassOf: 
-        OEO_00000014,
-        OEO_00000530 some OEO_00030002,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00000395
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: OEO_00000396
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "steam turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00110001,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000207,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050020
-    
-    
-Class: OEO_00000399
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
-        rdfs:label "storage unit"
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
-    
-Class: OEO_00000401
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000009"
-    
-    SubClassOf: 
-        OEO_00000088
-    
-    
-Class: OEO_00000407
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
-        rdfs:label "technology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00000419
-
-    
-Class: OEO_00000420
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
-        rdfs:label "transformer"
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
-    
-Class: OEO_00000423
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00000143
-    
-    
-Class: OEO_00000425
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "turbine"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
-        OEO_00000503 some OEO_00140116,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000
-    
-    
-Class: OEO_00000429
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
-        rdfs:label "underground hydrogen storage"
-    
-    SubClassOf: 
-        OEO_00000159,
-        OEO_00000503 some OEO_00000220
-    
-    
-Class: OEO_00000437
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
-    
-    EquivalentTo: 
-        OEO_00000025 or OEO_00000298
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `volatile organic compound`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000331,
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
-    
-    
-Class: OEO_00000439
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
-
-comment:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/629
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
-        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
-        rdfs:label "waste fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000042)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `waste fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00000440
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "waste power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041
-    
-    
-Class: OEO_00000441
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
-add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "water",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00000442
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "water turbine"
-    
-    SubClassOf: 
-        OEO_00000425,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010234 some OEO_00000218,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110004
-    
-    
-Class: OEO_00000446
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-reclassify and change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-remove disposition renewable fuel
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
-add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "wind energy"
-    
-    SubClassOf: 
-        OEO_00230020,
-        OEO_00000530 some OEO_00030004,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043
-    
-    
-Class: OEO_00000447
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "wind farm"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000044
-    
-    
-Class: OEO_00000448
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "wind rotor"
-    
-    SubClassOf: 
-        OEO_00000425,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000446,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020043,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144
-    
-    
-Class: OEO_00000449
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-add dispositions:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
-        rdfs:label "wood"
-    
-    SubClassOf: 
-        OEO_00010214,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00010000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "trihydridonitrogen",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
-
-Adapt definiton and axioms, add alternative  terms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "ammonia"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitric oxide"@en
-    
-    SubClassOf: 
-        OEO_00010002
-    
-    
-Class: OEO_00010004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen dioxide"@en
-    
-    SubClassOf: 
-        OEO_00010002
-    
-    
-Class: OEO_00010007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "sulphur dioxide"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
-    
-    SubClassOf: 
-        OEO_00000318
-    
-    
-Class: OEO_00010010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
-    
-    SubClassOf: 
-        OEO_00000318
-    
-    
-Class: OEO_00010011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: OEO_00010012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/815
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
-        rdfs:label "air pollutant"@en
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055)
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00010015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "fossil hydrogen"
-    
-    EquivalentTo: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
-        OEO_00000220
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        OEO_00000220
-    
-    
-Class: OEO_00010016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic hydrogen"
-    
-    EquivalentTo: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
-        OEO_00000220
-         and (OEO_00000530 some OEO_00030005)
-    
-    SubClassOf: 
-        OEO_00000220
-    
-    
-Class: OEO_00010017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "synthetic fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (OEO_00000530 some OEO_00030005)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `synthetic fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
-    
-Class: OEO_00010018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-Re-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "synthetic methane"
-    
-    EquivalentTo: 
-        OEO_00000025
-         and (OEO_00000530 some OEO_00030005)
-    
-    SubClassOf: 
-        OEO_00000025
-    
-    
-Class: OEO_00010019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-new label and axioms:
-https://github.com/OpenEnergyPlatform/ontology/issues/934
-pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
-        rdfs:label "PtL fuel"
-    
-    SubClassOf: 
-        OEO_00010156,
-        <http://purl.obolibrary.org/obo/RO_0003001> some OEO_00010020,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00010020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "power-to-liquid system"
-    
-    SubClassOf: 
-        OEO_00000159
-    
-    
-Class: OEO_00010021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "water electrolyser"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000441,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000139,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000007,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000220
-    
-    
-Class: OEO_00010022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993",
-        rdfs:label "steam reformer"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        OEO_00000503 some OEO_00140159,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00140160
-    
-    
-Class: OEO_00010023
-
-    
-Class: OEO_00010024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in an on-board battery.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
-        rdfs:label "battery electric vehicle"@en
-    
-    SubClassOf: 
-        OEO_00000146,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026
-    
-    
-Class: OEO_00010025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
-        rdfs:label "fuel cell electric vehicle"@en
-    
-    SubClassOf: 
-        OEO_00000146,
-        OEO_00000503 some OEO_00000220,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000016
-    
-    
-Class: OEO_00010026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
-        rdfs:label "traction battery"@en
-    
-    SubClassOf: 
-        OEO_00000068
-    
-    
-Class: OEO_00010027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "electric motor"@en
-    
-    SubClassOf: 
-        OEO_00010032,
-        OEO_00010234 some OEO_00000139
-    
-    
-Class: OEO_00010028
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-relabel and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
-        rdfs:label "electric traction motor"@en
-    
-    SubClassOf: 
-        OEO_00010027,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
-    
-    
-Class: OEO_00010029
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "internal combustion engine"@en
-    
-    SubClassOf: 
-        OEO_00010032,
-        OEO_00000503 some OEO_00000099,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140038
-    
-    
-Class: OEO_00010030
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "plug-in hybrid electric vehicle"@en
-    
-    SubClassOf: 
-        OEO_00010023,
-        OEO_00000503 some OEO_00000099,
-        OEO_00000503 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
-    
-    
-Class: OEO_00010031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "grid supplied electric vehicle"@en
-    
-    SubClassOf: 
-        OEO_00000146
-    
-    
-Class: OEO_00010032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "motor",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00230020
-    
-    
-Class: OEO_00010072
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal power density unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00010073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal energy density unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00010074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal power density"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00010072
-    
-    
-Class: OEO_00010075
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal energy density"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00010073
-    
-    
-Class: OEO_00010076
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal solar power density"
-    
-    SubClassOf: 
-        OEO_00010074
-    
-    
-Class: OEO_00010077
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal solar energy density"
-    
-    SubClassOf: 
-        OEO_00010075
-    
-    
-Class: OEO_00010078
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
-        rdfs:label "global warming potential"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00010079
-
-    
-Class: OEO_00010080
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-add 'has physical output' some 'electrical energy'
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar-steam-electric process"@en
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020047)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00050020)
-    
-    SubClassOf: 
-        OEO_00020046,
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
-    
-    
-Class: OEO_00010081
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar chemical energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00020046,
-        OEO_00010235 some OEO_00000007
-    
-    
-Class: OEO_00010084
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
-        rdfs:label "reservoir"@en
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00000503 some OEO_00110000,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
-    
-    
-Class: OEO_00010085
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro power unit"@en
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00000503 some OEO_00000441,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
-    
-    
-Class: OEO_00010086
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro power plant"@en
-    
-    SubClassOf: 
-        OEO_00000031,
-        OEO_00000503 some OEO_00000441,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
-    
-    
-Class: OEO_00010087
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "run of river power plant"@en
-    
-    SubClassOf: 
-        OEO_00010086,
-        OEO_00000503 some OEO_00010093,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
-    
-    
-Class: OEO_00010088
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro storage power plant"@en
-    
-    SubClassOf: 
-        OEO_00010086,
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010084),
-        OEO_00000503 some OEO_00110000
-    
-    
-Class: OEO_00010089
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        OEO_00010088,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090
-    
-    
-Class: OEO_00010090
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "pump"@en
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
-        OEO_00000503 some OEO_00140116,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some 
-            (OEO_00020045 or OEO_00230020)
-    
-    
-Class: OEO_00010091
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "open-loop pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        OEO_00010089,
-        OEO_00000503 some OEO_00000345
-    
-    
-Class: OEO_00010092
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "closed-loop pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        OEO_00010089,
-        OEO_00000503 only OEO_00000345
-    
-    
-Class: OEO_00010093
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
-
-Make river a subclass of water body:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "river"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
-    
-    SubClassOf: 
-        OEO_00010104,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110002
-    
-    
-Class: OEO_00010094
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
-        rdfs:label "reservoir hydro storage power plant"@en
-    
-    SubClassOf: 
-        OEO_00010088,
-        not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090)
-    
-    
-Class: OEO_00010095
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00140104
-    
-    
-Class: OEO_00010096
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine thermal energy transfer"@en
-    
-    SubClassOf: 
-        OEO_00140101,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105
-    
-    
-Class: OEO_00010097
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine current energy"@en
-    
-    SubClassOf: 
-        OEO_00020087,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00010107,
-        OEO_00020183 some OEO_00010098
-    
-    
-Class: OEO_00010098
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-remove wrong axiom 
-https://github.com/OpenEnergyPlatform/ontology/pull/1044",
-        rdfs:label "marine current energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110005,
-        OEO_00010234 some OEO_00010097,
-        
-            Annotations: rdfs:comment "reintroduce axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107
-    
-    
-Class: OEO_00010099
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "marine tidal energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110005,
-        OEO_00010234 some OEO_00010100,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101
-    
-    
-Class: OEO_00010100
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine tidal energy"@en
-    
-    SubClassOf: 
-        OEO_00020087,
-        OEO_00020182 some OEO_00010101
-    
-    
-Class: OEO_00010101
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "tidal flow"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
-    
-    SubClassOf: 
-        OEO_00110002
-    
-    
-Class: OEO_00010102
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine wave energy"@en
-    
-    SubClassOf: 
-        OEO_00020087,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00010106
-    
-    
-Class: OEO_00010103
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "marine wave energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110005,
-        OEO_00010234 some OEO_00010102,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106
-    
-    
-Class: OEO_00010104
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "water body"@en
-    
-    SubClassOf: 
-        OEO_00110000
-    
-    
-Class: OEO_00010105
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "ocean"@en
-    
-    SubClassOf: 
-        OEO_00010104
-    
-    
-Class: OEO_00010106
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "wave"@en
-    
-    SubClassOf: 
-        OEO_00110002
-    
-    
-Class: OEO_00010107
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "ocean current"@en
-    
-    SubClassOf: 
-        OEO_00110002
-    
-    
-Class: OEO_00010108
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine current energy converting unit"@en
-    
-    SubClassOf: 
-        OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
-    
-    
-Class: OEO_00010109
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine tidal energy converting unit"@en
-    
-    SubClassOf: 
-        OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
-    
-    
-Class: OEO_00010110
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy converting unit"@en
-    
-    SubClassOf: 
-        OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
-    
-    
-Class: OEO_00010111
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine current energy power plant"@en
-    
-    SubClassOf: 
-        OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010108,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
-    
-    
-Class: OEO_00010112
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine tidal energy power plant"@en
-    
-    SubClassOf: 
-        OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010109,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
-    
-    
-Class: OEO_00010113
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy power plant"@en
-    
-    SubClassOf: 
-        OEO_00010086,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010110,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
-    
-    
-Class: OEO_00010114
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
-        rdfs:label "waste thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00000207
-    
-    
-Class: OEO_00010127
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865",
-        rdfs:label "secondary energy production"@en
-    
-    SubClassOf: 
-        OEO_00240003,
-        OEO_00000533 some OEO_00140079,
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00010137
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "t",
-        rdfs:label "metric ton"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000002>
-    
-    
-Class: OEO_00010138
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon capture"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000532 some OEO_00000006
-    
-    
-Class: OEO_00010139
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct on air capture (DAC) is carbon dioxide capture from air.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "direct air capture"@en
-    
-    SubClassOf: 
-        OEO_00010138,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000054
-    
-    
-Class: OEO_00010140
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon storage"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000532 some OEO_00000006
-    
-    
-Class: OEO_00010141
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon capture and storage"@en
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010138)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010140)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000532 some OEO_00000006
-    
-    
-Class: OEO_00010144
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid combustion fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000529 value OEO_00000390)
-    
-    SubClassOf: 
-        OEO_00000099
-    
-    
-Class: OEO_00010145
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid combustion fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000529 value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00000099
-    
-    
-Class: OEO_00010146
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous combustion fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000529 value OEO_00000182)
-    
-    SubClassOf: 
-        OEO_00000099
-    
-    
-Class: OEO_00010147
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid fossil fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00000529 value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00000014
-    
-    
-Class: OEO_00010148
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous fossil fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00000529 value OEO_00000182)
-    
-    SubClassOf: 
-        OEO_00000014
-    
-    
-Class: OEO_00010149
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid renewable fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000033
-         and (OEO_00000529 value OEO_00000390)
-    
-    SubClassOf: 
-        OEO_00000033
-    
-    
-Class: OEO_00010150
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid renewable fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000033
-         and (OEO_00000529 value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00000033
-    
-    
-Class: OEO_00010151
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous renewable fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000033
-         and (OEO_00000529 value OEO_00000182)
-    
-    SubClassOf: 
-        OEO_00000033
-    
-    
-Class: OEO_00010153
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A gasoeus biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous biofuel"@en
-    
-    EquivalentTo: 
-        OEO_00000072
-         and (OEO_00000529 value OEO_00000182)
-    
-    SubClassOf: 
-        OEO_00000072
-    
-    
-Class: OEO_00010154
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid synthetic fuel"@en
-    
-    EquivalentTo: 
-        OEO_00010017
-         and (OEO_00000529 value OEO_00000390)
-    
-    SubClassOf: 
-        OEO_00010017
-    
-    
-Class: OEO_00010155
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous synthetic fuel"@en
-    
-    EquivalentTo: 
-        OEO_00010017
-         and (OEO_00000529 value OEO_00000182)
-    
-    SubClassOf: 
-        OEO_00010017
-    
-    
-Class: OEO_00010156
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid synthetic fuel"@en
-    
-    EquivalentTo: 
-        OEO_00010017
-         and (OEO_00000529 value OEO_00000256)
-    
-    SubClassOf: 
-        OEO_00010017
-    
-    
-Class: OEO_00010157
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-Make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "power value"@en
-    
-    EquivalentTo: 
-        OEO_00000350
-         and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>)
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00010210
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
-        rdfs:label "energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
-    
-    DisjointWith: 
-        OEO_00010211
-    
-    
-Class: OEO_00010211
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
-        rdfs:label "non-energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039
-    
-    DisjointWith: 
-        OEO_00010210
-    
-    
-Class: OEO_00010214
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
-        rdfs:label "biomass"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030001
-    
-    
-Class: OEO_00010215
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "biomethane"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010216
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "power-to-gas process"@en
-    
-    SubClassOf: 
-        OEO_00020003,
-        (OEO_00000532 some OEO_00000331)
-         and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00010155)
-         and (OEO_00010235 some OEO_00000007)
-    
-    
-Class: OEO_00010217
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "power-to-methane process"@en
-    
-    SubClassOf: 
-        OEO_00010216,
-        (OEO_00000532 some OEO_00000006)
-         and (OEO_00000532 some OEO_00000441)
-         and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00010018)
-         and (OEO_00010235 some OEO_00000007),
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010220
-    
-    
-Class: OEO_00010218
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "oxygen"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00010219
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "water electrolysis process"@en
-    
-    SubClassOf: 
-        OEO_00020003,
-        (OEO_00000532 some OEO_00000441)
-         and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00000220)
-         and (OEO_00000533 some OEO_00010218)
-         and (OEO_00010235 some OEO_00000007),
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010021
-    
-    
-Class: OEO_00010220
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "methanation"@en
-    
-    SubClassOf: 
-        OEO_00140034,
-        (OEO_00000532 some OEO_00000006)
-         and (OEO_00000532 some OEO_00000220),
-        (OEO_00000533 some OEO_00000006)
-         and (OEO_00000533 some OEO_00000441)
-    
-    
-Class: OEO_00010221
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "synthetic ammonia"@en
-    
-    EquivalentTo: 
-        OEO_00010000
-         and (OEO_00000530 some OEO_00030005)
-    
-    SubClassOf: 
-        OEO_00010000
-    
-    
-Class: OEO_00010222
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "power-to-ammonia process"@en
-    
-    SubClassOf: 
-        OEO_00010216,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010000
-    
-    
-Class: OEO_00010223
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic waste fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000439
-         and (OEO_00000530 some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00010224
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil waste fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000439
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        OEO_00000439
-    
-    
-Class: OEO_00010225
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic industrial waste fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000226
-         and (OEO_00000530 some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000226
-    
-    
-Class: OEO_00010226
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil industrial waste fuel"@en
-    
-    EquivalentTo: 
-        OEO_00000226
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        OEO_00000226
-    
-    
-Class: OEO_00010256
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "maximum value"
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00010257
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
-
-Fix 'quantity value of' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
-        rdfs:label "power capacity"
-    
-    SubClassOf: 
-        OEO_00010256,
-        OEO_00020056 some 
-            (OEO_00000188 or OEO_00000334),
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: OEO_00010258
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
-        rdfs:label "bioenergy"
-    
-    EquivalentTo: 
-        OEO_00000007
-         and (OEO_00000530 some OEO_00030001)
-    
-    SubClassOf: 
-        OEO_00000007
-    
-    
-Class: OEO_00010259
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
-        rdfs:label "measurement device"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00020001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
-axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
-        rdfs:label "ethanol"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000075,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        OEO_00000529 value OEO_00000256
-    
-    
-Class: OEO_00020003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182"@en,
-        rdfs:label "energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00010234 some OEO_00000150,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000150,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
-    
-Class: OEO_00020004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "gas grid"@en
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
-    
-    
-Class: OEO_00020005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "heating grid"@en
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
-    
-    
-Class: OEO_00020006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
-    
-Class: OEO_00020007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "gas grid component"@en
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "heating grid component"@en
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
-    
-    SubClassOf: 
-        OEO_00020006
-    
-    
-Class: OEO_00020009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@en
-    
-    SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
-    
-    
-Class: OEO_00020037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "radiation",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00230021
-    
-    
-Class: OEO_00020038
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "solar radiation",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
-    
-    SubClassOf: 
-        OEO_00020037
-    
-    
-Class: OEO_00020039
-
-    
-Class: OEO_00020040
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
-        rdfs:label "radiative energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00020043
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
-        rdfs:label "wind energy transformation"
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010234 some OEO_00000446,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
-    
-    
-Class: OEO_00020045
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
-        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00020046
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-has input relation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
-delete has physical output relation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar energy transformation"
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010234 some OEO_00000384
-    
-    
-Class: OEO_00020047
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar thermal energy transformation"
-    
-    SubClassOf: 
-        OEO_00020046,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000388,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
-    
-    
-Class: OEO_00020048
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "photovoltaic energy transformation"
-    
-    SubClassOf: 
-        OEO_00020046,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
-    
-    
-Class: OEO_00020050
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-change def and equivalence
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086)
-    
-    SubClassOf: 
-        OEO_00020039
-    
-    
-Class: OEO_00020053
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear fission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000302
-    
-    
-Class: OEO_00020054
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "nuclear energy transformation"
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010234 some OEO_00000300,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000207
-    
-    
-Class: OEO_00020058
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "rock"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030003,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00020059
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "geothermal heat transfer"
-    
-    SubClassOf: 
-        OEO_00140101,
-        OEO_00010234 only OEO_00000191
-    
-    
-Class: OEO_00020066
-
-    
-Class: OEO_00020068
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
-    
-    
-Class: OEO_00020073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "grid-bound heating"
-    
-    SubClassOf: 
-        OEO_00140101,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020005,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00110000 or OEO_00110001)
-    
-    
-Class: OEO_00020074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "industrial grid-bound heating"
-    
-    SubClassOf: 
-        OEO_00020073
-    
-    
-Class: OEO_00020085
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy"
-    
-    EquivalentTo: 
-        OEO_00000150
-         and (OEO_00000530 some OEO_00030004)
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00020086
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00020087
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rain water, melted snow and ice).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "natural hydro energy"
-    
-    SubClassOf: 
-        OEO_00000218,
-        OEO_00000503 some OEO_00010104,
-        OEO_00000530 some OEO_00030004
-    
-    
-Class: OEO_00020088
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "pumped hydro energy"
-    
-    SubClassOf: 
-        OEO_00000218,
-        OEO_00000503 some OEO_00000345,
-        OEO_00000530 some OEO_00020147
-    
-    
-Class: OEO_00020102
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "energy transformation unit"
-    
-    SubClassOf: 
-        OEO_00000061,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
-    
-    
-Class: OEO_00020103
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "energy transfer"
-    
-    SubClassOf: 
-        OEO_00020003
-    
-    
-Class: OEO_00020104
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perfom or operate.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "outage"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
-    
-Class: OEO_00020105
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "forced outage"
-    
-    SubClassOf: 
-        OEO_00020104
-    
-    DisjointWith: 
-        OEO_00020106
-    
-    
-Class: OEO_00020106
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "planned outage"
-    
-    SubClassOf: 
-        OEO_00020104
-    
-    DisjointWith: 
-        OEO_00020105
-    
-    
-Class: OEO_00020107
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "curtailment"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
-    
-    
-Class: OEO_00020136
-
-    
-Class: OEO_00020137
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "operational space requirement"
-    
-    SubClassOf: 
-        OEO_00020136
-    
-    
-Class: OEO_00020139
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to contruct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "space requirement for construction"
-    
-    SubClassOf: 
-        OEO_00020136
-    
-    
-Class: OEO_00020140
-
-    
-Class: OEO_00020141
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "specific space requirement"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00020140
-    
-    
-Class: OEO_00020144
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
-        rdfs:label "rotor diameter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001
-    
-    
-Class: OEO_00020147
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "conventional"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000150
-    
-    DisjointWith: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
-        OEO_00030004
-    
-    
-Class: OEO_00020148
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of an material entity that contains non-renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
-        rdfs:label "conventional energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00020149
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
-
-Update definition and axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1172
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
-        rdfs:label "fossil energy"
-    
-    EquivalentTo: 
-        OEO_00000007
-         and (OEO_00000530 some OEO_00020147)
-         and (OEO_00010121 some OEO_00000014)
-    
-    SubClassOf: 
-        OEO_00000007
-    
-    
-Class: OEO_00020196
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
-
-Fix spelling of label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1196",
-        rdfs:label "fissile material entity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: OEO_00020197
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "tangential proper part"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000024>
-    
-    
-Class: OEO_00020198
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "surface"
-    
-    SubClassOf: 
-        OEO_00020197,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    
-Class: OEO_00020199
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "solar radiation receiving surface"
-    
-    EquivalentTo: 
-        OEO_00020198
-         and (OEO_00010234 some OEO_00000384)
-    
-    SubClassOf: 
-        OEO_00020198
-    
-    
-Class: OEO_00020200
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
-        rdfs:label "solar receiving object"
-    
-    EquivalentTo: 
-        OEO_00000061
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199)
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00020201
-
-    
-Class: OEO_00020202
-
-    
-Class: OEO_00020207
-
-    
-Class: OEO_00020208
-
-    
-Class: OEO_00020210
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "sirup"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
-        OEO_00000531 value OEO_00000256
-    
-    
-Class: OEO_00030000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "anthropogenic"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
-    
-Class: OEO_00030001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "biogenic"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000331
-    
-    DisjointWith: 
-        OEO_00030002
-    
-    
-Class: OEO_00030002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Update definition and add disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Shift part of the definition into an editor note:
-Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        OEO_00030003,
-        OEO_00010121 some OEO_00000331
-    
-    DisjointWith: 
-        OEO_00030001
-    
-    
-Class: OEO_00030003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
-    
-Class: OEO_00030004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "renewable"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000150
-    
-    DisjointWith: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
-        OEO_00020147
-    
-    
-Class: OEO_00030005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Make subclass of anthropogenic:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "synthetic"
-    
-    SubClassOf: 
-        OEO_00030000,
-        OEO_00010121 some OEO_00000331
-    
-    
-Class: OEO_00030015
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00030024
-    
-    
-Class: OEO_00030019
-
-    
-Class: OEO_00030024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-make subclass of supply system:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123",
-        rdfs:label "energy system"
-    
-    SubClassOf: 
-        OEO_00030025
-    
-    
-Class: OEO_00030025
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
-        rdfs:label "supply system"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
-Class: OEO_00030026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-add axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy production"
-    
-    SubClassOf: 
-        OEO_00240003,
-        OEO_00000533 some OEO_00140078,
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00030027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy carrier mining"
-    
-    SubClassOf: 
-        OEO_00030026
-    
-    
-Class: OEO_00030028
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy carrier harvest"
-    
-    SubClassOf: 
-        OEO_00030026
-    
-    
-Class: OEO_00030035
-
-    
-Class: OEO_00040011
-
-    
-Class: OEO_00050000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
-        rdfs:label "industrial process"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some 
-            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
-    
-    
-Class: OEO_00050001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
-
-Update definition and axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
-        rdfs:label "fuel-powered electricity generation"@en
-    
-    EquivalentTo: 
-        OEO_00240014
-         and (OEO_00000532 some OEO_00000099)
-    
-    SubClassOf: 
-        OEO_00240014,
-        OEO_00000500 some OEO_00000148,
-        OEO_00000533 some OEO_00000331,
-        OEO_00010234 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
-        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
-    
-    
-Class: OEO_00050002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
-        rdfs:label "kilojoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
-        rdfs:label "megajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
-        rdfs:label "gigajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
-        rdfs:label "terajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
-        rdfs:label "petajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
-        rdfs:label "exajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
-        rdfs:label "megawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
-        rdfs:label "terawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
-        rdfs:label "petawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
-        rdfs:label "gigawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00050016
-
-    SubClassOf: 
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00050017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
-
-Gross inland energy consumption covers:
-  - consumption by the energy sector itself;
-  - distribution and transformation losses;
-  - final energy consumption by end users;
-  - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
-
-Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gross inland consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary energy consumption including non-energy use of energy carriers"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "become a subclass of quantity value:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "gross inland energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00240019,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211)
-    
-    
-Class: OEO_00050018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "primary energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210),
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00050019
-
-    
-Class: OEO_00050020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "steam-electric process"@en
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010234 some OEO_00000207,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
-    
-    
-Class: OEO_00090000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
-Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
-        rdfs:label "volumetric flow rate value"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000270>
-    
-    
-Class: OEO_00110000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "liquid water"@en
-    
-    SubClassOf: 
-        OEO_00000441,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000218,
-        OEO_00000531 value OEO_00000256
-    
-    
-Class: OEO_00110001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
-        rdfs:label "steam"@en
-    
-    SubClassOf: 
-        OEO_00000441,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000531 value OEO_00000182
-    
-    
-Class: OEO_00110002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "water flow"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000500 some OEO_00110003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00110000
-    
-    
-Class: OEO_00110003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "water flow rate"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00140002 some OEO_00090000
-    
-    
-Class: OEO_00110004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "hydro energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010234 some OEO_00000218
-    
-    
-Class: OEO_00110005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "hydroelectric energy transformation"@en
-    
-    SubClassOf: 
-        OEO_00110004,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139
-    
-    
-Class: OEO_00140000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "hub height"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001
-    
-    
-Class: OEO_00140001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "length value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
-    
-    
-Class: OEO_00140033
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "chemical reaction"@en
-    
-    SubClassOf: 
-        OEO_00000419
-    
-    
-Class: OEO_00140034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "redox reaction"@en
-    
-    SubClassOf: 
-        OEO_00140033
-    
-    
-Class: OEO_00140035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "oxidation"@en
-    
-    SubClassOf: 
-        OEO_00140033
-    
-    
-Class: OEO_00140036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "reduction"@en
-    
-    SubClassOf: 
-        OEO_00140033
-    
-    
-Class: OEO_00140037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "electrochemical reaction"@en
-    
-    SubClassOf: 
-        OEO_00140033
-    
-    
-Class: OEO_00140038
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "combustion"@en
-    
-    SubClassOf: 
-        OEO_00140034
-    
-    
-Class: OEO_00140039
-
-    
-Class: OEO_00140049
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "energy conversion efficiency"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003,
-        OEO_00140002 some OEO_00140050
-    
-    
-Class: OEO_00140050
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "efficiency value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00140051
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "coefficient of performance value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some OEO_00140052,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00140052
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "energy conversion performance"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003,
-        OEO_00140002 some OEO_00140051
-    
-    
-Class: OEO_00140056
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
-
-change: adjust definition to be based on parent class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        rdfs:label "flow potential"@en
-    
-    SubClassOf: 
-        OEO_00290000
-    
-    
-Class: OEO_00140057
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "theoretical flow potential"@en
-    
-    SubClassOf: 
-        OEO_00140056
-    
-    
-Class: OEO_00140058
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "technological flow potential"@en
-    
-    SubClassOf: 
-        OEO_00140056
-    
-    
-Class: OEO_00140059
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "economic flow potential"@en
-    
-    SubClassOf: 
-        OEO_00140056
-    
-    
-Class: OEO_00140060
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "developable flow potential"@en
-    
-    SubClassOf: 
-        OEO_00140056
-    
-    
-Class: OEO_00140061
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "sustainable flow potential"@en
-    
-    SubClassOf: 
-        OEO_00140056
-    
-    
-Class: OEO_00140062
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
-
-change: adjust definition to be based on parent class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        rdfs:label "stock potential"@en
-    
-    SubClassOf: 
-        OEO_00290000
-    
-    
-Class: OEO_00140063
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "theoretical stock potential"@en
-    
-    SubClassOf: 
-        OEO_00140062
-    
-    
-Class: OEO_00140064
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "technological stock potential"@en
-    
-    SubClassOf: 
-        OEO_00140062
-    
-    
-Class: OEO_00140065
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "economic stock potential"@en
-    
-    SubClassOf: 
-        OEO_00140062
-    
-    
-Class: OEO_00140066
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "developable stock potential"@en
-    
-    SubClassOf: 
-        OEO_00140062
-    
-    
-Class: OEO_00140067
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "sustainable stock potential"@en
-    
-    SubClassOf: 
-        OEO_00140062
-    
-    
-Class: OEO_00140075
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "primary energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00140076
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "secondary energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00140077
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "final energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00140078
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "primary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075)
-    
-    SubClassOf: 
-        OEO_00020039
-    
-    
-Class: OEO_00140079
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition secondary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-fix error in definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678",
-        rdfs:label "secondary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
-    
-    SubClassOf: 
-        OEO_00020039
-    
-    
-Class: OEO_00140080
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "final energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140077)
-    
-    SubClassOf: 
-        OEO_00020039
-    
-    
-Class: OEO_00140081
-
-    
-Class: OEO_00140082
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
-        rdfs:label "greenhouse gas emission value"@en
-    
-    SubClassOf: 
-        OEO_00140081,
-        OEO_00000502 some OEO_00000199
-    
-    
-Class: OEO_00140083
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
-        rdfs:label "carbon dioxide equivalent quantity"@en
-    
-    SubClassOf: 
-        OEO_00140082
-    
-    
-Class: OEO_00140091
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
-        rdfs:label "plutonium"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00140092
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
-        rdfs:label "thorium"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00140101
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
-
-subclass of energy transfer
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "heat transfer"@en
-    
-    SubClassOf: 
-        OEO_00020103,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010234 only OEO_00000207,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 only OEO_00000207
-    
-    
-Class: OEO_00140102
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "heat exchanger"@en
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000207,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101
-    
-    
-Class: OEO_00140104
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "natural ambient thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00000056,
-        OEO_00000530 some OEO_00030004
-    
-    
-Class: OEO_00140105
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "artificial ambient thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00000056,
-        OEO_00000530 some OEO_00020147,
-        OEO_00000530 some OEO_00030000
-    
-    
-Class: OEO_00140106
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "ambient thermal energy transfer"@en
-    
-    SubClassOf: 
-        OEO_00140101,
-        OEO_00010234 some OEO_00000056,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: OEO_00140116
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
-        rdfs:label "fluid"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and ((OEO_00000531 value OEO_00000182) or (OEO_00000531 value OEO_00000256) or (OEO_00000531 value OEO_00000326))
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: OEO_00140126
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "planned availability"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127
-    
-    
-Class: OEO_00140127
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "share",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "fraction value"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00140128
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "block size"@en
-    
-    SubClassOf: 
-        OEO_00230002,
-        OEO_00020056 some OEO_00000334
-    
-    
-Class: OEO_00140129
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "unplanned availability"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127
-    
-    
-Class: OEO_00140133
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "RE-share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780",
-        rdfs:label "RE-share"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00140002 some OEO_00140127
-    
-    
-Class: OEO_00140134
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
-        rdfs:label "hydrogen fuel cell"@en
-    
-    SubClassOf: 
-        OEO_00000016,
-        OEO_00000503 some OEO_00000220
-    
-    
-Class: OEO_00140135
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
-        rdfs:label "natural gas turbine"@en
-    
-    SubClassOf: 
-        OEO_00000185,
-        OEO_00000503 some OEO_00000292
-    
-    
-Class: OEO_00140144
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "full load hours"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000032>
-    
-    
-Class: OEO_00140159
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "hydrocarbon"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
-    
-Class: OEO_00140160
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
-
-add axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
-
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "syngas"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000220,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010001,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
-        OEO_00000529 value OEO_00000182
-    
-    
-Class: OEO_00140162
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
-        rdfs:label "power plant with electro motive generator"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010)
-    
-    SubClassOf: 
-        OEO_00000031
-    
-    
-Class: OEO_00160001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "frequency control"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00160002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "primary control"@en
-    
-    SubClassOf: 
-        OEO_00160001
-    
-    
-Class: OEO_00160003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "secondary control"@en
-    
-    SubClassOf: 
-        OEO_00160001
-    
-    
-Class: OEO_00160004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "tertiary control"@en
-    
-    SubClassOf: 
-        OEO_00160001
-    
-    
-Class: OEO_00230000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "storage capacity"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some OEO_00000159
-    
-    
-Class: OEO_00230001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "power rating"@en
-    
-    SubClassOf: 
-        OEO_00010257,
-        OEO_00020056 some OEO_00000011,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: OEO_00230002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "declared net capacity"@en
-    
-    SubClassOf: 
-        OEO_00010257,
-        OEO_00020056 some 
-            (OEO_00000031 or OEO_00000334),
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: OEO_00230003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-extend to artificial objects:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "nameplate capacity"@en
-    
-    SubClassOf: 
-        OEO_00010257,
-        OEO_00020056 some OEO_00000061
-    
-    
-Class: OEO_00230020
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "kinetic energy"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
-    
-    SubClassOf: 
-        OEO_00000150
-    
-    
-Class: OEO_00230021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
-add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-classify as material entity
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
-        rdfs:label "photon"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020040,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
-    
-    
-Class: OEO_00240000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
-        rdfs:label "rotational energy"@en
-    
-    SubClassOf: 
-        OEO_00230020
-    
-    
-Class: OEO_00240003
-
-    
-Class: OEO_00240009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "combined heat and power generation"
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00010235 some OEO_00000139,
-        OEO_00010235 some OEO_00000207
-    
-    
-Class: OEO_00240010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is a power generating unit that produces electrical energy and thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
-
-change produces energy axioms to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "combined heat and power generating unit"
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00010235 some OEO_00000139,
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240009
-    
-    
-Class: OEO_00240011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is a power plant that has combined heat and power generating units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
-        rdfs:label "combined heat and power plant"
-    
-    SubClassOf: 
-        OEO_00000031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00240010
-    
-    
-Class: OEO_00240012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
-        rdfs:label "gross electricity generation"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00240013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
-        rdfs:label "net electricity generation"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00140002 some OEO_00050019
-    
-    
-Class: OEO_00240014
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "electricity generation process"
-    
-    EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
-    
-    SubClassOf: 
-        OEO_00020003,
-        OEO_00000500 some OEO_00240012,
-        OEO_00000500 some OEO_00240013,
-        OEO_00010235 some OEO_00000139
-    
-    
-Class: OEO_00240015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
-        rdfs:label "liquid air production"
-    
-    SubClassOf: 
-        OEO_00240003,
-        OEO_00000532 some OEO_00000054,
-        OEO_00000533 some OEO_00000257
-    
-    
-Class: OEO_00240016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
-
-make subclass of 'fraction value':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
-        rdfs:label "net capacity factor"
-    
-    SubClassOf: 
-        OEO_00140127
-    
-    
-Class: OEO_00240018
-
-    Annotations: 
-        OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        rdfs:label "gross national electricity consumption"
-    
-    SubClassOf: 
-        OEO_00240019,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00050017
-    
-    
-Class: OEO_00240019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        OEO_00050019,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
-    
-    
-Class: OEO_00240026
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
-        rdfs:label "industrial material"
-    
-    EquivalentTo: 
-        (OEO_00240025 some OEO_00050000)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00240027
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "chemical substance"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00240025 some OEO_00050000,
-        OEO_00240025 some OEO_00140033,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
-    
-Class: OEO_00240028
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "paper"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00240029
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "cement"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00240030
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "mineral"
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00240031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "non-metallic mineral"
-    
-    SubClassOf: 
-        OEO_00240030,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
-    
-Class: OEO_00240032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "metal"
-    
-    SubClassOf: 
-        OEO_00000331
-    
-    
-Class: OEO_00240034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "steel"
-    
-    SubClassOf: 
-        OEO_00240032,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
-        OEO_00000529 value OEO_00000390
-    
-    
-Class: OEO_00240035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "non-ferrous metal"
-    
-    SubClassOf: 
-        OEO_00240032,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
-    
-Class: OEO_00260001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "ramping"@en
-    
-    SubClassOf: 
-        OEO_00030019
-    
-    
-Class: OEO_00260002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "start-up speed"@en
-    
-    SubClassOf: 
-        OEO_00260001
-         and (OEO_00000502 some OEO_00260003)
-    
-    
-Class: OEO_00260003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "cold start"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-         and (OEO_00000500 some OEO_00260002)
-    
-    
-Class: OEO_00290000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
-
-make subclass of 'maximum value':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "potential"@en
-    
-    SubClassOf: 
-        OEO_00010256
-    
-    
-Class: OEO_00290001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
-        rdfs:label "slope"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
-    
-    
-Individual: OEO_00000182
-
-    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
         rdfs:label "gaseous"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000256
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
         rdfs:label "liquid"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000326
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000326>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
-Individual: OEO_00000390
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     
     Types: 
-        OEO_00000395
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
     
     
 DisjointClasses: 
-    OEO_00000074,OEO_00000263,OEO_00000292,OEO_00010215,OEO_00140160
+    <http://openenergy-platform.org/ontology/oeo/OEO_00000074>,<http://openenergy-platform.org/ontology/oeo/OEO_00000263>,<http://openenergy-platform.org/ontology/oeo/OEO_00000292>,<http://openenergy-platform.org/ontology/oeo/OEO_00010215>,<http://openenergy-platform.org/ontology/oeo/OEO_00140160>
 
 DisjointClasses: 
-    OEO_00000188,OEO_00000210,OEO_00000425
+    <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,3 +1,4 @@
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -16,12 +17,6 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Physical module)"
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00110012>
-
-    
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
-
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -52,6 +47,12 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
+AnnotationProperty: OEO_00110012
+
+    
+AnnotationProperty: OEO_00269001
+
+    
 AnnotationProperty: dc:contributor
 
     
@@ -76,398 +77,6 @@ Datatype: rdf:PlainLiteral
 Datatype: xsd:string
 
     
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000521>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology.",
-        rdfs:label "applies technology"
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000525>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000523>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000524>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
-        rdfs:label "has global warming potential"
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010078>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000525>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object.",
-        rdfs:label "is applied to object"
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000521>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "is connected to"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Characteristics: 
-        Symmetric
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000527>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has sink"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000528>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000528>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
-        rdfs:label "has source"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000526>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000527>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000529>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has normal state of matter"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000531>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000530>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        rdfs:label "has origin"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000531>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has state of matter"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000532>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-restrict range to 'material entity':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "has physical input"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Characteristics: 
-        Irreflexive,
-        Asymmetric
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000533>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716
-
-restrict range to 'material entity':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "has physical output"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010234>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has energy input"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has energy output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy participant of"
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020183>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy input to"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020184>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an ouput of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "is energy output of"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140175>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has gross output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140176>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "has net output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00240025>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is physical output of p iff: c output of p, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "physical output of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000533>
-    
-    
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
     Annotations: 
@@ -477,13 +86,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
         rdfs:label "has energy participant"@en
     
     Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061> or <http://purl.obolibrary.org/obo/BFO_0000015>
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
     
     Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+        OEO_00000150
     
     InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182>
+        OEO_00020182
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -548,8080 +157,400 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003001>
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
     
+ObjectProperty: OEO_00000500
+
+    
+ObjectProperty: OEO_00000501
+
+    
+ObjectProperty: OEO_00000502
+
+    
+ObjectProperty: OEO_00000503
+
+    
+ObjectProperty: OEO_00000521
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "the property of an artificial object to apply to a technology.",
+        rdfs:label "applies technology"
+    
+    Domain: 
+        OEO_00000061
+    
+    Range: 
+        OEO_00000407
+    
+    InverseOf: 
+        OEO_00000525
+    
+    
+ObjectProperty: OEO_00000522
+
+    
+ObjectProperty: OEO_00000523
+
+    
+ObjectProperty: OEO_00000524
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
+        rdfs:label "has global warming potential"
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00140002
+    
+    Domain: 
+        OEO_00000020
+    
+    Range: 
+        OEO_00010078
+    
+    
+ObjectProperty: OEO_00000525
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The property of a technology to be applied to an artificial object.",
+        rdfs:label "is applied to object"
+    
+    Domain: 
+        OEO_00000407
+    
+    Range: 
+        OEO_00000061
+    
+    InverseOf: 
+        OEO_00000521
+    
+    
+ObjectProperty: OEO_00000526
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "is connected to"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Characteristics: 
+        Symmetric
+    
+    
+ObjectProperty: OEO_00000527
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "has sink"
+    
+    SubPropertyOf: 
+        OEO_00000526
+    
+    DisjointWith: 
+        OEO_00000528
+    
+    
+ObjectProperty: OEO_00000528
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+        rdfs:label "has source"
+    
+    SubPropertyOf: 
+        OEO_00000526
+    
+    DisjointWith: 
+        OEO_00000527
+    
+    
+ObjectProperty: OEO_00000529
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "has normal state of matter"
+    
+    SubPropertyOf: 
+        OEO_00000531
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
+    
+ObjectProperty: OEO_00000530
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
+        rdfs:label "has origin"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
+        OEO_00000150 or OEO_00000331
+    
+    Range: 
+        OEO_00000316
+    
+    
+ObjectProperty: OEO_00000531
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "has state of matter"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
+    
+ObjectProperty: OEO_00000532
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "has physical input"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Characteristics: 
+        Irreflexive,
+        Asymmetric
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+ObjectProperty: OEO_00000533
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request:: https://github.com/OpenEnergyPlatform/ontology/pull/716
+
+restrict range to 'material entity':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "has physical output"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    InverseOf: 
+        OEO_00240025
+    
+    
+ObjectProperty: OEO_00010121
+
+    
+ObjectProperty: OEO_00010234
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has energy input"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00010235
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has energy output"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00020056
+
+    
+ObjectProperty: OEO_00020182
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy participant of"
+    
+    Domain: 
+        OEO_00000150
+    
+    Range: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    
+ObjectProperty: OEO_00020183
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy input to"
+    
+    SubPropertyOf: 
+        OEO_00020182
+    
+    
+ObjectProperty: OEO_00020184
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an ouput of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "is energy output of"
+    
+    SubPropertyOf: 
+        OEO_00020182
+    
+    
+ObjectProperty: OEO_00040010
+
+    
+ObjectProperty: OEO_00140002
+
+    
+ObjectProperty: OEO_00140164
+
+    
+ObjectProperty: OEO_00140175
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has gross output"@en
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00140176
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "has net output"@en
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00240025
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is physical output of p iff: c output of p, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "physical output of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002353>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        OEO_00000533
+    
+    
 ObjectProperty: owl:topObjectProperty
 
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "fuel role",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
-        rdfs:label "biofuel power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biogas power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
-        rdfs:label "biogas power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
-        rdfs:label "chemical energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
-        rdfs:label "electric heat pump"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000212>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
-        rdfs:label "electro motive generator"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-renaming to component
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-redefine
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
-        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
-        rdfs:label "energy converting component"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000013>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
-        rdfs:label "fluorinated greenhouse gas"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000026> or <http://openenergy-platform.org/ontology/oeo/OEO_00000038> or <http://openenergy-platform.org/ontology/oeo/OEO_00000219> or <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
-        rdfs:label "fuel cell"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
-        rdfs:label "gas fired power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-             and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)),
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000020>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
-        rdfs:label "hard coal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hydrogen power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
-        rdfs:label "lignite power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000008>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "methane",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000026>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
-        rdfs:label "nitrogen trifluoride"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000027>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
-        rdfs:label "nitrous oxide",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000198>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000028>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
-        rdfs:label "oil power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000181> or <http://openenergy-platform.org/ontology/oeo/OEO_00000183>),
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces axiom to 'has energy output'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-Add axiom to 'has part some solar radiation receiving surface'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
-
-Update definition, label and axioms, add alternative terms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
-        rdfs:label "photovoltaic cell"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020048>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `renevable fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
-        rdfs:label "solar power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "solar thermal power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000036>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solid biomass power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000073>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000037>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
-        rdfs:label "solid biomass power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000038>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
-        rdfs:label "sulphur hexafluoride"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000039>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
-        rdfs:label "thermal energy storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000040>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "waste power unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000439>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000042>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
-        rdfs:label "waste role",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000043>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
-Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "wind energy converting unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000448>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020144>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00140000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "undirected",
-        rdfs:label "AC-line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-make subclass of gas mixture and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "air",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000330>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000056>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "ambient thermal energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000058>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000062>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "associated gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000066>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "aviation gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
-        <http://purl.obolibrary.org/obo/RO_0000085> some <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
-        rdfs:label "battery storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000071>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:label "biodiesel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
-
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-redefine:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-fix subclassof:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-
-alternative term and disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biofuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000073>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "biofuel power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000074>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "biogas",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>),
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000075>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
-
-redefine and change axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:comment "biopetrol",
-        rdfs:label "biogasoline"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000077>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "blast furnace gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000084>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "charcoal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
-        rdfs:label "coal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000089>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000008>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000093>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coke oven gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000094>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "coking coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000096>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
-        rdfs:label "colliery gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "combustion fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000102>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "compressed air"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000115>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024",
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
-        rdfs:label "dam"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000126>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:comment "directed",
-        rdfs:label "HVDC-line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000047>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000129>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "grid transferred thermal energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "relabel and add axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
-        rdfs:label "fossil diesel fuel"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000132>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "district heating"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
-
-alternative term electricity:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
-
-add commodity role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
-
-add axiom to electricity im/exports:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00020207>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00020208>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000144>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000144>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "electric vehicle"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage object"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
-        rdfs:label "field photovoltaic power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000169>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "flow battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-add role fuel commodity
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-shorten definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000174>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power plant"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000175>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
-        rdfs:label "fueled power unit"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000173>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "gas diesel oil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-relabel and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000184>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "gas power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000185>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "gas turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000186>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
-
-The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gasworks gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000188>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000189>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
-        rdfs:label "geographic coordinate"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "geothermal energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000192>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000198>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "greenhouse effect disposition",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100",
-        rdfs:label "greenhouse gas emission"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000020>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "hard coal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000205>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hard coal power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000021>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "thermal energy"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "heater"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000211>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000181>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000212>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
-        rdfs:label "heat pump"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "hydro energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000219>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
-        rdfs:label "hydrofluorocarbon"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000221>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "hydrogen power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000022>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000222>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        rdfs:label "hydrogen turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "industrial waste fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000240>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "internal combustion vehicle"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000245>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "convert second label to alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1230
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
-        rdfs:label "jet fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000246>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
-[...]
-
-Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "kerosene"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000248>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "lithium-ion battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000251>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process.",
-        rdfs:label "lignite",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000204>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000252>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "lignite power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000089>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000253>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
-        rdfs:label "liquid air"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000258>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid biofuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `liquid biofuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000259>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "liquid-metal battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000263>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "manufactured coal based gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000269>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
-        rdfs:label "methanation gas storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000070>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "molten-salt battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000286>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
-
-Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "motor gasoline"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "municipal waste fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-improve definition and make subclass of gas mixture and add disjoints:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
-        rdfs:label "natural gas",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000293>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "negative emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000296>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "grid node"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000255>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000297>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "non associated gas"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "non-methane volatile organic compound"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000299>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non renewable municipal waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil municipal waste fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-convertion to nuclear binding energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear binding energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "nuclear fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000300>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000303>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
-        rdfs:label "offshore wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000310>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "oil power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000311>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
-        rdfs:label "onshore wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000308>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>),
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000320>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
-        rdfs:label "peat",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000322>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
-        rdfs:label "perfluorocarbon"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "photovoltaic power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000330>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000332>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
-        rdfs:label "solid biofuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `solid biofuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000333>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that contains a generator, among other parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "power generating unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020107>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000335>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "power-to-gas system"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010021>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010216>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000343>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
-        rdfs:label "pumped storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
-
-add secondary energy carrier disposition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "pumped water"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110000>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000501> some <http://openenergy-platform.org/ontology/oeo/OEO_00000399>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000348>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
-        rdfs:label "PV panel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000034>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000356>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-new definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic municipal waste fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000290>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000361>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
-        rdfs:label "rooftop photovoltaic power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000324>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000165>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000374>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
-        rdfs:label "SMES"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000376>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargable metal-ion battery that uses sodium ions as charge carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "sodium-ion battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000377>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
-        rdfs:label "sodium-sulphur battery"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000282>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-restructure solar energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-remove disposition renewable fuel
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
-        rdfs:label "solar energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020040>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000386>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar power plant",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-add axiom to 'has part some solar radiation receiving surface'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
-        rdfs:label "solar thermal collector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000210>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000388>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020047>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000388>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "solar thermal energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000389>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar thermal power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000386>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000035>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000391>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
-
-Update definition and axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid fossil fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "steam turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110001>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00050020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000399>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
-        rdfs:label "storage unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000401>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000009"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000088>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
-        rdfs:label "technology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
-        rdfs:label "transformer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000423>
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000425>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140116>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000429>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
-        rdfs:label "underground hydrogen storage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000437>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000025> or <http://openenergy-platform.org/ontology/oeo/OEO_00000298>
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `volatile organic compound`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00010011>),
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
-
-comment:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/629
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
-        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
-        rdfs:label "waste fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000042>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `waste fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000440>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "waste power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000041>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000441>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
-add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "water",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000442>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "water turbine"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000446>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-reclassify and change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-remove disposition renewable fuel
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
-add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "wind energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00000043>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020183> some <http://openenergy-platform.org/ontology/oeo/OEO_00020043>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000447>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "wind farm"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000448>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "wind rotor"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000425>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00240000>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020043>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020144>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000449>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-add dispositions:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
-        rdfs:label "wood"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010214>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "trihydridonitrogen",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
-
-Adapt definiton and axioms, add alternative  terms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "ammonia"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitric oxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen dioxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "sulphur dioxide"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010010>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000318>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010012>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/815
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
-        rdfs:label "air pollutant"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000055>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010015>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "fossil hydrogen"
-    
-    EquivalentTo: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "synthetic hydrogen"
-    
-    EquivalentTo: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "synthetic fuel"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `synthetic fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000173>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010018>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-Re-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "synthetic methane"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000025>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-new label and axioms:
-https://github.com/OpenEnergyPlatform/ontology/issues/934
-pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
-        rdfs:label "PtL fuel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010156>,
-        <http://purl.obolibrary.org/obo/RO_0003001> some <http://openenergy-platform.org/ontology/oeo/OEO_00010020>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010020>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
-        rdfs:label "power-to-liquid system"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "water electrolyser"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0003000> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010022>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993",
-        rdfs:label "steam reformer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140159>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        <http://purl.obolibrary.org/obo/RO_0003000> some <http://openenergy-platform.org/ontology/oeo/OEO_00140160>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010024>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in an on-board battery.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
-        rdfs:label "battery electric vehicle"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010025>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
-        rdfs:label "fuel cell electric vehicle"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010026>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
-        rdfs:label "traction battery"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000068>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010027>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-change uses energy axiom to 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "electric motor"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010028>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-relabel and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
-        rdfs:label "electric traction motor"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010027>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "internal combustion engine"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140038>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010030>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "plug-in hybrid electric vehicle"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010026>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010028>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010029>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010031>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
-        rdfs:label "grid supplied electric vehicle"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000146>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "motor",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010072>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal power density unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010073>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal energy density unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010074>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal power density"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00010072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010075>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal energy density"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00010073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010076>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal solar power density"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010074>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010077>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        rdfs:label "areal solar energy density"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010075>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010078>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
-        rdfs:label "global warming potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010080>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-add 'has physical output' some 'electrical energy'
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar-steam-electric process"@en
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020047>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00050020>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010081>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar chemical energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010084>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
-        rdfs:label "reservoir"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010085>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro power unit"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000442>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010086>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010087>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "run of river power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010093>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010088>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "hydro storage power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000117>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010084>),
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010089>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010088>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010090>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010090>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "pump"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00140116>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00020045> or <http://openenergy-platform.org/ontology/oeo/OEO_00230020>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010091>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "open-loop pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010089>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010092>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
-        rdfs:label "closed-loop pumped hydro storage power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010089>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> only <http://openenergy-platform.org/ontology/oeo/OEO_00000345>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010093>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
-
-Make river a subclass of water body:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "river"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010104>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010094>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
-        rdfs:label "reservoir hydro storage power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010088>,
-        not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010090>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010095>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine thermal energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010096>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine thermal energy transfer"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010097>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine current energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010107>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020183> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-remove wrong axiom 
-https://github.com/OpenEnergyPlatform/ontology/pull/1044",
-        rdfs:label "marine current energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010097>,
-        
-            Annotations: rdfs:comment "reintroduce axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010107>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "marine tidal energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010100>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010100>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine tidal energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010101>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "tidal flow"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010102>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-fix classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
-
-change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        rdfs:label "marine wave energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020087>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020182> some <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "marine wave energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110005>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010102>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010105>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010104>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "water body"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010105>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "ocean"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010106>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "wave"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010107>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "ocean current"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010108>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine current energy converting unit"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010109>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine tidal energy converting unit"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010110>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy converting unit"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010085>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010111>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine current energy power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010108>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010098>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010112>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine tidal energy power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010109>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010113>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "marine wave energy power plant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010086>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010110>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010103>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010114>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
-        rdfs:label "waste thermal energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010127>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865",
-        rdfs:label "secondary energy production"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00140079>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010137>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "t",
-        rdfs:label "metric ton"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010138>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon capture"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010139>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct on air capture (DAC) is carbon dioxide capture from air.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "direct air capture"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010138>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010140>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon storage"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010141>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
-        rdfs:label "carbon capture and storage"@en
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010138>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010140>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010144>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid combustion fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010145>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid combustion fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010146>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous combustion fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010147>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid fossil fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010148>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous fossil fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000014>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010149>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid renewable fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010150>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid renewable fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010151>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous renewable fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010153>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A gasoeus biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous biofuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000072>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010154>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid synthetic fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010155>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "gaseous synthetic fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010156>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "liquid synthetic fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010157>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-Make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "power value"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010210>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
-        rdfs:label "energy use"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010211>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010211>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
-        rdfs:label "non-energy use"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010210>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010214>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
-        rdfs:label "biomass"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010215>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "biomethane"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000025>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010216>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "power-to-gas process"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010155>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010217>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "power-to-methane process"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010216>,
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010018>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>),
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010219>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010218>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "oxygen"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010219>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "water electrolysis process"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>),
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00010218>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>),
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010021>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010220>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
-        rdfs:label "methanation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140034>,
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>),
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000006>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010221>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "synthetic ammonia"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030005>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010222>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "power-to-ammonia process"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010216>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00010000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010223>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic waste fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010224>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil waste fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000439>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010225>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
-
-rename class and change axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        rdfs:label "biogenic industrial waste fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010226>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
-        rdfs:label "fossil industrial waste fuel"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030002>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000226>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010256>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "maximum value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010257>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
-
-Fix 'quantity value of' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
-        rdfs:label "power capacity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010256>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000188> or <http://openenergy-platform.org/ontology/oeo/OEO_00000334>),
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010258>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
-        rdfs:label "bioenergy"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030001>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010259>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
-        rdfs:label "measurement device"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
-axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
-        rdfs:label "ethanol"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000075>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182"@en,
-        rdfs:label "energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020039>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "gas grid"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/385",
-        rdfs:label "heating grid"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000200>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020102>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000200>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "gas grid component"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020004>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "heating grid component"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
-        rdfs:label "switchyard"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020006>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00000143>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000420>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020037>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "radiation",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00230021>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020038>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
-        rdfs:label "solar radiation",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020037>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020040>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
-        rdfs:label "radiative energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020043>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
-        rdfs:label "wind energy transformation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000446>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020045>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
-        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020046>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-has input relation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
-delete has physical output relation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar energy transformation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020047>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "solar thermal energy transformation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000388>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000387>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020048>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "photovoltaic energy transformation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020046>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000032>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020050>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-change def and equivalence
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00020086>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020053>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear fission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000302>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020054>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "nuclear energy transformation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000300>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020058>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "rock"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020059>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "geothermal heat transfer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> only <http://openenergy-platform.org/ontology/oeo/OEO_00000191>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "grid-bound heating"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020005>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00110000> or <http://openenergy-platform.org/ontology/oeo/OEO_00110001>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020074>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
-        rdfs:label "industrial grid-bound heating"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020073>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020085>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020086>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "renewable energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020087>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rain water, melted snow and ice).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "natural hydro energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010104>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020088>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "pumped hydro energy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000345>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "energy transformation unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020103>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "energy transfer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perfom or operate.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "outage"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020105>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "forced outage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020106>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020106>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "planned outage"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020104>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020105>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020107>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "curtailment"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020137>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "operational space requirement"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020139>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to contruct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "space requirement for construction"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020141>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "specific space requirement"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020144>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
-        rdfs:label "rotor diameter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "conventional"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    DisjointWith: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020148>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of an material entity that contains non-renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
-        rdfs:label "conventional energy carrier disposition"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020149>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
-
-Update definition and axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1172
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
-        rdfs:label "fossil energy"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>)
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000014>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000007>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020196>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
-
-Fix spelling of label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1196",
-        rdfs:label "fissile material entity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020197>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "tangential proper part"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "surface"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020197>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020199>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
-        rdfs:label "solar radiation receiving surface"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000384>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020198>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020200>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
-        rdfs:label "solar receiving object"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00020199>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020201>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020202>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020210>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "sirup"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "anthropogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "biogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Update definition and add disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Shift part of the definition into an editor note:
-Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "renewable"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000316>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    DisjointWith: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Make subclass of anthropogenic:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "synthetic"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030000>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030015>
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00030024>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030024>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-make subclass of supply system:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123",
-        rdfs:label "energy system"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030025>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030025>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
-        rdfs:label "supply system"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-add axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy production"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00140078>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030027>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy carrier mining"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030028>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        rdfs:label "primary energy carrier harvest"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030026>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
-        rdfs:label "industrial process"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some 
-            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
-
-Update definition and axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
-        rdfs:label "fuel-powered electricity generation"@en
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240014>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240014>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00000148>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000174>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000175>,
-        <http://purl.obolibrary.org/obo/RO_0002418> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
-        rdfs:label "kilojoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
-        rdfs:label "megajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
-        rdfs:label "gigajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
-        rdfs:label "terajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
-        rdfs:label "petajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
-        rdfs:label "exajoule"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
-        rdfs:label "megawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
-        rdfs:label "terawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050010>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
-        rdfs:label "petawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
-        rdfs:label "gigawatt-hour"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
-
-Gross inland energy consumption covers:
-  - consumption by the energy sector itself;
-  - distribution and transformation losses;
-  - final energy consumption by end users;
-  - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
-
-Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gross inland consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary energy consumption including non-energy use of energy carriers"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "become a subclass of quantity value:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "gross inland energy consumption"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240019>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010210>)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010211>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050018>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
-        rdfs:label "primary energy consumption"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010211>))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010210>),
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050020>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "steam-electric process"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000396>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
-Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
-        rdfs:label "volumetric flow rate value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000270>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "liquid water"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
-        rdfs:label "steam"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000441>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "water flow"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00110003>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00110000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
-        rdfs:label "water flow rate"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00090000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "hydro energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000218>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00110005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        rdfs:label "hydroelectric energy transformation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110004>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "hub height"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "length value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "chemical reaction"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "redox reaction"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "oxidation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140036>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "reduction"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140037>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "electrochemical reaction"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140033>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140038>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
-        rdfs:label "combustion"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140034>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140049>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "energy conversion efficiency"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140050>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140050>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "efficiency value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140051>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "coefficient of performance value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140052>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140052>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
-        rdfs:label "energy conversion performance"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
-
-change: adjust definition to be based on parent class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        rdfs:label "flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140057>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "theoretical flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140058>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "technological flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140059>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "economic flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140060>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "developable flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140061>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "sustainable flow potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140056>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
-
-change: adjust definition to be based on parent class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        rdfs:label "stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140063>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "theoretical stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140064>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "technological stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140065>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "economic stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140066>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "developable stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140067>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
-        rdfs:label "sustainable stock potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140062>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140075>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "primary energy carrier disposition"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140076>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "secondary energy carrier disposition"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140077>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "final energy carrier disposition"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140078>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "primary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140075>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140079>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition secondary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-fix error in definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678",
-        rdfs:label "secondary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140080>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
-        rdfs:label "final energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140077>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140082>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
-        rdfs:label "greenhouse gas emission value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140083>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
-        rdfs:label "carbon dioxide equivalent quantity"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140082>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140091>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
-        rdfs:label "plutonium"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140092>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
-        rdfs:label "thorium"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000028>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140101>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
-
-subclass of energy transfer
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "heat transfer"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020103>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> only <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> only <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140102>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "heat exchanger"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00140101>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140104>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "natural ambient thermal energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140105>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
-        rdfs:label "artificial ambient thermal energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00020147>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00030000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140106>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "ambient thermal energy transfer"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140101>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000056>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140116>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
-        rdfs:label "fluid"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and ((<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>) or (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000326>))
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140126>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "planned availability"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "share",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "fraction value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140128>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "block size"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230002>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000334>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140129>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "unplanned availability"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140133>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "RE-share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780",
-        rdfs:label "RE-share"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140134>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
-        rdfs:label "hydrogen fuel cell"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000016>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140135>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
-        rdfs:label "natural gas turbine"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000185>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140144>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "full load hours"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000032>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140159>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "hydrocarbon"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140160>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
-
-add axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
-
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
-
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "syngas"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000220>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010001>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000001>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000097>,
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00140076>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140162>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
-        rdfs:label "power plant with electro motive generator"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00000010>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "frequency control"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "primary control"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "secondary control"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00160004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
-        rdfs:label "tertiary control"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00160001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "storage capacity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000159>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "power rating"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000011>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "declared net capacity"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000031> or <http://openenergy-platform.org/ontology/oeo/OEO_00000334>),
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000113>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
-extend to artificial objects:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-Make it subclass of power value and add unit axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
-
-use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993
-
-Make subclass of 'power capacity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "nameplate capacity"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010257>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "kinetic energy"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230021>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
-pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
-add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-classify as material entity
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
-        rdfs:label "photon"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0000086> some <http://openenergy-platform.org/ontology/oeo/OEO_00020040>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
-        <http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
-        rdfs:label "rotational energy"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230020>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "combined heat and power generation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240010>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is a power generating unit that produces electrical energy and thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
-
-change produces energy axioms to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "combined heat and power generating unit"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000334>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00240009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is a power plant that has combined heat and power generating units as parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
-        rdfs:label "combined heat and power plant"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000031>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00240010>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240012>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
-        rdfs:label "gross electricity generation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240013>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
-        rdfs:label "net electricity generation"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240014>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "electricity generation process"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00240012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00240013>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000139>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240015>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
-        rdfs:label "liquid air production"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000054>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000533> some <http://openenergy-platform.org/ontology/oeo/OEO_00000257>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
-
-make subclass of 'fraction value':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
-        rdfs:label "net capacity factor"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140127>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240018>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00110012> "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        rdfs:label "gross national electricity consumption"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240019>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00050017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00050019>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240026>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
-        rdfs:label "industrial material"
-    
-    EquivalentTo: 
-        (<http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240027>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "chemical substance"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00140033>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240028>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "paper"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240029>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "cement"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240030>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "mineral"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240031>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "non-metallic mineral"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240030>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240032>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "metal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "steel"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240032>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
-        rdfs:label "non-ferrous metal"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240032>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240025> some <http://openenergy-platform.org/ontology/oeo/OEO_00050000>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "ramping"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "start-up speed"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00260001>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00260003>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00260003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
-        rdfs:label "cold start"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00260002>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00290000>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
-
-make subclass of 'maximum value':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        rdfs:label "potential"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010256>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00290001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
-        rdfs:label "slope"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000122>
-    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
 
@@ -8632,8 +561,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
         rdfs:label "gas mixture"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000331>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000529> value <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+        OEO_00000331,
+        OEO_00000529 value OEO_00000182
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010237>
@@ -8646,11 +575,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1016",
         rdfs:label "liquified natural gas"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00000531> value <http://openenergy-platform.org/ontology/oeo/OEO_00000256>)
+        OEO_00000292
+         and (OEO_00000531 value OEO_00000256)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000292>
+        OEO_00000292
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
@@ -8666,7 +595,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel role"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+        OEO_00000001
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
@@ -8678,7 +607,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel fuel role"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000001>
+        OEO_00000001
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
@@ -8694,11 +623,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline fuel"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+        OEO_00000099
          and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+        OEO_00000099
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
@@ -8710,11 +639,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel fuel"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+        OEO_00000099
          and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000099>
+        OEO_00000099
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
@@ -8731,8 +660,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline engine"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010029>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
+        OEO_00010029,
+        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>
@@ -8745,8 +674,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel engine"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010029>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000131>
+        OEO_00010029,
+        OEO_00000503 some OEO_00000131
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
@@ -8762,11 +691,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "gasoline vehicle"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000240>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>,
+        OEO_00000240,
+        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>,
         <http://purl.obolibrary.org/obo/BFO_0000051> only 
-            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243> or (not (<http://openenergy-platform.org/ontology/oeo/OEO_00010032>)))
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243> or (not (OEO_00010032)))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010246>
@@ -8778,11 +707,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         rdfs:label "diesel vehicle"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000240>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00000131>,
+        OEO_00000240,
+        OEO_00000503 some OEO_00000131,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>,
         <http://purl.obolibrary.org/obo/BFO_0000051> only 
-            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (<http://openenergy-platform.org/ontology/oeo/OEO_00010032>)))
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032)))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
@@ -8794,11 +723,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
         rdfs:label "heat generation process"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>)
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000207)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+        OEO_00020003
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010249>
@@ -8814,12 +743,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210",
         rdfs:label "combustion thermal energy transformation"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000532> some <http://openenergy-platform.org/ontology/oeo/OEO_00000099>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010234> some <http://openenergy-platform.org/ontology/oeo/OEO_00000007>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010235> some <http://openenergy-platform.org/ontology/oeo/OEO_00000207>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140038>,
-        <http://purl.obolibrary.org/obo/RO_0002418> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+        OEO_00020003,
+        OEO_00000532 some OEO_00000099,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000207,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
+        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
@@ -8845,11 +774,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
         rdfs:label "traction motor"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
+        OEO_00010032
          and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010032>
+        OEO_00010032
     
     
 Class: <http://opennergy-plattform.org/ontology/oeo/OEO_00290002>
@@ -8862,8 +791,8 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
         rdfs:label "surface azimuth angle"@en
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000122>
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -8959,53 +888,8125 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000182>
+Class: OEO_00000001
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "fuel role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00000331
+    
+    
+Class: OEO_00000003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
+        rdfs:label "biofuel power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000072,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
+    
+    
+Class: OEO_00000004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "biogas power plant"
+    
+    SubClassOf: 
+        OEO_00000073,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000005
+    
+    
+Class: OEO_00000005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
+        rdfs:label "biogas power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        OEO_00000503 some OEO_00000074
+    
+    
+Class: OEO_00000006
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        rdfs:label "carbon dioxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214",
+        rdfs:label "chemical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000008
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "coal power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000088,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
+        rdfs:label "electric heat pump"
+    
+    SubClassOf: 
+        OEO_00000212,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+        OEO_00010235 some OEO_00000139
+    
+    
+Class: OEO_00000010
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
+        rdfs:label "electro motive generator"
+    
+    SubClassOf: 
+        OEO_00000188,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00230020
+    
+    
+Class: OEO_00000011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+renaming to component
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+redefine
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
+        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
+        rdfs:label "energy converting component"
+    
+    SubClassOf: 
+        OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
+    
+    
+Class: OEO_00000012
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage"
+    
+    SubClassOf: 
+        OEO_00000151,
+        <http://purl.obolibrary.org/obo/BFO_0000034>
+    
+    
+Class: OEO_00000013
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
+        rdfs:label "fluorinated greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000026 or OEO_00000038 or OEO_00000219 or OEO_00000322
+    
+    SubClassOf: 
+        OEO_00000020
+    
+    
+Class: OEO_00000014
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000099,
+        OEO_00000530 some OEO_00030003
+    
+    DisjointWith: 
+        OEO_00000072
+    
+    
+Class: OEO_00000016
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
+        rdfs:label "fuel cell"
+    
+    SubClassOf: 
+        OEO_00000188,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00000173,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140034
+    
+    
+Class: OEO_00000017
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
+        rdfs:label "gas fired power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some 
+            (OEO_00000173
+             and (OEO_00000529 value OEO_00000182)),
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
+    
+    
+Class: OEO_00000019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "geothermal power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000020
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000021
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
+        rdfs:label "hard coal power unit"
+    
+    SubClassOf: 
+        OEO_00000008,
+        OEO_00000503 some OEO_00000204
+    
+    
+Class: OEO_00000022
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hydrogen power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000220,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
+    
+    
+Class: OEO_00000024
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
+        rdfs:label "lignite power unit"
+    
+    SubClassOf: 
+        OEO_00000008,
+        OEO_00000503 some OEO_00000251
+    
+    
+Class: OEO_00000025
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
+        rdfs:label "methane",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
+    
+    SubClassOf: 
+        OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000026
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
+        rdfs:label "nitrogen trifluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030000,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000027
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
+        rdfs:label "nitrous oxide",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000028
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00000029
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "nuclear power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000302,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000030
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
+        rdfs:label "oil power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024"
+        OEO_00000503 some 
+            (OEO_00000181 or OEO_00000183),
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000031
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "power plant"
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020006,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
+    
+    
+Class: OEO_00000032
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces axiom to 'has energy output'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+Add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
+
+Update definition, label and axioms, add alternative terms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
+        rdfs:label "photovoltaic cell"
+    
+    SubClassOf: 
+        OEO_00000188,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000384,
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020048
+    
+    
+Class: OEO_00000033
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `renevable fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000173,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000034
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
+        rdfs:label "solar power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+        OEO_00010234 some OEO_00000384
+    
+    
+Class: OEO_00000035
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "solar thermal power unit"
+    
+    SubClassOf: 
+        OEO_00000034,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000207,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
+    
+    
+Class: OEO_00000036
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solid biomass power plant"
+    
+    SubClassOf: 
+        OEO_00000073,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000037
+    
+    
+Class: OEO_00000037
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
+        rdfs:label "solid biomass power unit"
+    
+    SubClassOf: 
+        OEO_00000003,
+        OEO_00000503 some OEO_00000332
+    
+    
+Class: OEO_00000038
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
+        rdfs:label "sulphur hexafluoride"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030000,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000039
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        rdfs:label "thermal energy storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00000040
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "uranium",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030003,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000041
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "waste power unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000439,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000042
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+        rdfs:label "waste role",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000043
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000054
+    
+    
+Class: OEO_00000044
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "wind energy converting unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000446,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
+    
+    
+Class: OEO_00000047
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "undirected",
+        rdfs:label "AC-line"@en
+    
+    SubClassOf: 
+        OEO_00000253
+    
+    DisjointWith: 
+        OEO_00000126
+    
+    
+Class: OEO_00000054
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+make subclass of gas mixture and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "air",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00000501 some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000055
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
+        rdfs:label "air pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
+    
+    SubClassOf: 
+        OEO_00000330,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010012
+    
+    
+Class: OEO_00000056
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "ambient thermal energy"
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00000058
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
+    
+    SubClassOf: 
+        OEO_00000204
+    
+    
+Class: OEO_00000061
+
+    
+Class: OEO_00000062
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "associated gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000066
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "aviation gasoline"
+    
+    SubClassOf: 
+        OEO_00000183
+    
+    
+Class: OEO_00000068
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "battery"
+    
+    SubClassOf: 
+        OEO_00000159,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
+    
+    
+Class: OEO_00000070
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
+        rdfs:label "battery storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    DisjointWith: 
+        OEO_00000269
+    
+    
+Class: OEO_00000071
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:label "biodiesel"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000072
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
+
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+redefine:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+fix subclassof:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
+
+alternative term and disjoint:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biofuel"
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000530 some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000099,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086
+    
+    DisjointWith: 
+        OEO_00000014
+    
+    
+Class: OEO_00000073
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "biofuel power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000003
+    
+    
+Class: OEO_00000074
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "biogas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000006)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025),
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000075
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
+
+redefine and change axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:comment "biopetrol",
+        rdfs:label "biogasoline"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000077
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "blast furnace gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000084
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter an can be used as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "charcoal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000088
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen.coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
+        rdfs:label "coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000089
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "coal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000008
+    
+    
+Class: OEO_00000093
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coke oven gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000094
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "coking coal"
+    
+    SubClassOf: 
+        OEO_00000204
+    
+    
+Class: OEO_00000096
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
+        rdfs:label "colliery gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000097
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00000099
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+    
+    SubClassOf: 
+        OEO_00000173
+    
+    
+Class: OEO_00000102
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "compressed air"
+    
+    SubClassOf: 
+        OEO_00000054,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+    
+    
+Class: OEO_00000115
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024",
+        rdfs:label "crude oil"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000117
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+        rdfs:label "dam"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00000501 some OEO_00000399
+    
+    
+Class: OEO_00000126
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:comment "directed",
+        rdfs:label "HVDC-line"@en
+    
+    SubClassOf: 
+        OEO_00000253
+    
+    DisjointWith: 
+        OEO_00000047
+    
+    
+Class: OEO_00000129
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "grid transferred thermal energy"
+    
+    SubClassOf: 
+        OEO_00000207,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020073
+    
+    
+Class: OEO_00000131
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TransportDiesel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "relabel and add axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+        rdfs:label "fossil diesel fuel"@en
+    
+    SubClassOf: 
+        OEO_00000181,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
+    
+    
+Class: OEO_00000132
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "district heating"
+    
+    SubClassOf: 
+        OEO_00020073
+    
+    
+Class: OEO_00000139
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
+
+alternative term electricity:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
+
+add commodity role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+add axiom to electricity im/exports:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electrical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
+    
+    SubClassOf: 
+        OEO_00000150,
+        OEO_00020182 some OEO_00020207,
+        OEO_00020182 some OEO_00020208,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00000143
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165",
+        rdfs:label "electricity grid"
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
+        <http://purl.obolibrary.org/obo/BFO_0000051> min 1 OEO_00000253
+    
+    
+Class: OEO_00000144
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "electricity grid component"
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00000146
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric motors for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "electric vehicle"
+    
+    SubClassOf: 
+        OEO_00010023,
+        OEO_00010234 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028
+    
+    
+Class: OEO_00000147
+
+    
+Class: OEO_00000148
+
+    
+Class: OEO_00000150
+
+    
+Class: OEO_00000151
+
+    
+Class: OEO_00000159
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+        rdfs:label "energy storage object"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000165
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
+        rdfs:label "field photovoltaic power plant"
+    
+    SubClassOf: 
+        OEO_00000324
+    
+    DisjointWith: 
+        OEO_00000361
+    
+    
+Class: OEO_00000169
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "flow battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000173
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+add role fuel commodity
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+shorten definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
+        rdfs:label "fuel"
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00000174
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power plant"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050001
+    
+    
+Class: OEO_00000175
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
+        rdfs:label "fueled power unit"
+    
+    EquivalentTo: 
+        OEO_00000334
+         and (OEO_00000503 some OEO_00000173)
+    
+    SubClassOf: 
+        OEO_00000334,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050001
+    
+    
+Class: OEO_00000181
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "gas diesel oil"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000183
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+relabel and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "gasoline"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000184
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "gas power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000017
+    
+    
+Class: OEO_00000185
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that converts chemical energy into rotational energy using a continous internal combustion process. Hence it is also called combustion turbine."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "gas turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00000099,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00240000
+    
+    
+Class: OEO_00000186
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
+
+The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gasworks gas"
+    
+    SubClassOf: 
+        OEO_00000263
+    
+    
+Class: OEO_00000188
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "generator"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
+    
+    
+Class: OEO_00000189
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geografic coordinate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
+        rdfs:label "geographic coordinate"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000018>
+    
+    
+Class: OEO_00000191
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+        rdfs:label "geothermal energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
+    
+    SubClassOf: 
+        OEO_00000207,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00000192
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "geothermal power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000019
+    
+    
+Class: OEO_00000198
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "greenhouse effect disposition",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: OEO_00000199
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100",
+        rdfs:label "greenhouse gas emission"
+    
+    EquivalentTo: 
+        OEO_00000147
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020)
+    
+    SubClassOf: 
+        OEO_00000147
+    
+    
+Class: OEO_00000200
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
+        rdfs:label "supply grid"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: OEO_00000204
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "hard coal"
+    
+    SubClassOf: 
+        OEO_00000088
+    
+    DisjointWith: 
+        OEO_00000251
+    
+    
+Class: OEO_00000205
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hard coal power plant"
+    
+    SubClassOf: 
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
+    
+    
+Class: OEO_00000207
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        rdfs:label "thermal energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00000210
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "heater"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000207
+    
+    
+Class: OEO_00000211
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "OtherGasOil"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "heating oil"@en
+    
+    SubClassOf: 
+        OEO_00000181
+    
+    
+Class: OEO_00000212
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
+        rdfs:label "heat pump"
+    
+    SubClassOf: 
+        OEO_00000210
+    
+    
+Class: OEO_00000218
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "hydro energy"
+    
+    SubClassOf: 
+        OEO_00230020,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        OEO_00020182 some OEO_00110002
+    
+    
+Class: OEO_00000219
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
+        rdfs:label "hydrofluorocarbon"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030000
+    
+    
+Class: OEO_00000220
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
+        rdfs:label "hydrogen",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000221
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "hydrogen power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000022
+    
+    
+Class: OEO_00000222
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
+        rdfs:label "hydrogen turbine"
+    
+    SubClassOf: 
+        OEO_00000185,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00000220
+    
+    
+Class: OEO_00000226
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "industrial waste fuel"
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00000240
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle powered by an internal combustion engine.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "internal combustion vehicle"
+    
+    SubClassOf: 
+        OEO_00010023,
+        OEO_00000503 some OEO_00000099,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
+    
+    
+Class: OEO_00000245
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International air Transport Association (IATA).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "convert second label to alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1230
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
+        rdfs:label "jet fuel"
+    
+    SubClassOf: 
+        OEO_00000246
+    
+    
+Class: OEO_00000246
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+[...]
+
+Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "kerosene"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000248
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "lithium-ion battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000251
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process.",
+        rdfs:label "lignite",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
+    
+    SubClassOf: 
+        OEO_00000088,
+        OEO_00000530 some OEO_00030002,
+        OEO_00000529 value OEO_00000390
+    
+    DisjointWith: 
+        OEO_00000204
+    
+    
+Class: OEO_00000252
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "lignite power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
+    
+    SubClassOf: 
+        OEO_00000089,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000024
+    
+    
+Class: OEO_00000253
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
+        rdfs:label "power line"@en
+    
+    SubClassOf: 
+        OEO_00000255,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
+    
+Class: OEO_00000255
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid component link"
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    DisjointWith: 
+        OEO_00000296
+    
+    
+Class: OEO_00000257
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
+        rdfs:label "liquid air"
+    
+    EquivalentTo: 
+        OEO_00000054
+         and (OEO_00000531 value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00000054
+    
+    
+Class: OEO_00000258
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid biofuel"
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (OEO_00000529 value OEO_00000256)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `liquid biofuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000072,
+        OEO_00000530 some OEO_00030001,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000259
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "liquid-metal battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000263
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "manufactured coal based gas"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000269
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
+        rdfs:label "methanation gas storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    DisjointWith: 
+        OEO_00000070
+    
+    
+Class: OEO_00000282
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "molten-salt battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000286
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 oC and 215 oC. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
+
+Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "motor gasoline"
+    
+    SubClassOf: 
+        OEO_00000183
+    
+    
+Class: OEO_00000290
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "municipal waste fuel"
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00000292
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+improve definition and make subclass of gas mixture and add disjoints:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
+        rdfs:label "natural gas",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00000293
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "negative emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000296
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "grid node"
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    DisjointWith: 
+        OEO_00000255
+    
+    
+Class: OEO_00000297
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "non associated gas"
+    
+    SubClassOf: 
+        OEO_00000292
+    
+    
+Class: OEO_00000298
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "non-methane volatile organic compound"
+    
+    SubClassOf: 
+        OEO_00000437
+    
+    
+Class: OEO_00000299
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non renewable municipal waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil municipal waste fuel"
+    
+    EquivalentTo: 
+        OEO_00000290
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        OEO_00000290
+    
+    
+Class: OEO_00000300
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+convertion to nuclear binding energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
+        rdfs:label "nuclear binding energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
+    
+    SubClassOf: 
+        OEO_00000150,
+        OEO_00000530 some OEO_00020147
+    
+    
+Class: OEO_00000302
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
+        rdfs:label "nuclear fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
+    
+    SubClassOf: 
+        OEO_00000173,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000300
+    
+    
+Class: OEO_00000303
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "nuclear power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000029
+    
+    
+Class: OEO_00000308
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
+        rdfs:label "offshore wind farm"
+    
+    SubClassOf: 
+        OEO_00000447
+    
+    DisjointWith: 
+        OEO_00000311
+    
+    
+Class: OEO_00000310
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "oil power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000030
+    
+    
+Class: OEO_00000311
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
+        rdfs:label "onshore wind farm"
+    
+    SubClassOf: 
+        OEO_00000447
+    
+    DisjointWith: 
+        OEO_00000308
+    
+    
+Class: OEO_00000316
+
+    
+Class: OEO_00000318
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "particulate matter",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
+    
+    SubClassOf: 
+        OEO_00000331,
+        (OEO_00000529 value OEO_00000256) or (OEO_00000529 value OEO_00000390),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
+    
+    
+Class: OEO_00000320
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
+        rdfs:label "peat",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000322
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
+        rdfs:label "perfluorocarbon"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030000
+    
+    
+Class: OEO_00000324
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "photovoltaic power plant"
+    
+    SubClassOf: 
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000348
+    
+    
+Class: OEO_00000330
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
+    
+    SubClassOf: 
+        OEO_00000147
+    
+    
+Class: OEO_00000331
+
+    
+Class: OEO_00000332
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
+        rdfs:label "solid biofuel"@en
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (OEO_00000529 value OEO_00000390)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `solid biofuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000072,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000333
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369",
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003
+    
+    
+Class: OEO_00000334
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that contains a generator, among other parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "power generating unit"
+    
+    SubClassOf: 
+        OEO_00020102,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
+    
+    
+Class: OEO_00000335
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "power-to-gas system"
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
+    
+    
+Class: OEO_00000343
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
+        rdfs:label "pumped storage"
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00000345
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
+
+add secondary energy carrier disposition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "pumped water"
+    
+    SubClassOf: 
+        OEO_00110000,
+        OEO_00000501 some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+    
+    
+Class: OEO_00000348
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
+        rdfs:label "PV panel"
+    
+    SubClassOf: 
+        OEO_00000034,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032
+    
+    
+Class: OEO_00000350
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00000356
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+new definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic municipal waste fuel"
+    
+    EquivalentTo: 
+        OEO_00000290
+         and (OEO_00000530 some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000290,
+        OEO_00000530 some OEO_00030001
+    
+    
+Class: OEO_00000361
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
+        rdfs:label "rooftop photovoltaic power plant"
+    
+    SubClassOf: 
+        OEO_00000324
+    
+    DisjointWith: 
+        OEO_00000165
+    
+    
+Class: OEO_00000374
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
+          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
+        rdfs:label "SMES"
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00000376
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargable metal-ion battery that uses sodium ions as charge carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "sodium-ion battery"
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00000377
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S).This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
+        rdfs:label "sodium-sulphur battery"
+    
+    SubClassOf: 
+        OEO_00000282
+    
+    
+Class: OEO_00000384
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+restructure solar energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+remove disposition renewable fuel
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
+        rdfs:label "solar energy"
+    
+    SubClassOf: 
+        OEO_00020040,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00000386
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solar power plant",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000034
+    
+    
+Class: OEO_00000387
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+add axiom to 'has part some solar radiation receiving surface'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+        rdfs:label "solar thermal collector"
+    
+    SubClassOf: 
+        OEO_00000210,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000384,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000388,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
+    
+    
+Class: OEO_00000388
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "solar thermal energy"
+    
+    SubClassOf: 
+        OEO_00000207,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00000389
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solar thermal power plant"
+    
+    SubClassOf: 
+        OEO_00000386,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000035,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+    
+    
+Class: OEO_00000391
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
+
+Update definition and axioms:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid fossil fuel"
+    
+    EquivalentTo: 
+        OEO_00000014
+         and (OEO_00000529 value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00000014,
+        OEO_00000530 some OEO_00030002,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00000395
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+        rdfs:label "state of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00000396
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "steam turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00110001,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000207,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00240000,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050020
+    
+    
+Class: OEO_00000399
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        rdfs:label "storage unit"
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
+    
+Class: OEO_00000401
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000009"
+    
+    SubClassOf: 
+        OEO_00000088
+    
+    
+Class: OEO_00000407
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A Technology is an information content entity that specifies how to create an artificial object."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334",
+        rdfs:label "technology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00000419
+
+    
+Class: OEO_00000420
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
+        rdfs:label "transformer"
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
+    
+Class: OEO_00000423
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        OEO_00140164 some OEO_00000143
+    
+    
+Class: OEO_00000425
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "turbine"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
+        OEO_00000503 some OEO_00140116,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00240000
+    
+    
+Class: OEO_00000429
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
+        rdfs:label "underground hydrogen storage"
+    
+    SubClassOf: 
+        OEO_00000159,
+        OEO_00000503 some OEO_00000220
+    
+    
+Class: OEO_00000437
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatile organic compound",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
+    
+    EquivalentTo: 
+        OEO_00000025 or OEO_00000298
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `volatile organic compound`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000331,
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010011),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055
+    
+    
+Class: OEO_00000439
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
+
+comment:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/629
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
+        rdfs:label "waste fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000042)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `waste fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000173,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00000440
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "waste power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000041
+    
+    
+Class: OEO_00000441
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1099"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "We are aware that water is defined as pure H2O in the OEO and that naturally occuring water usually also contains impurities of other portions of matter (e.g. minerals). We purposely neglect this inconsistency for usability reasons.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H2O",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
+add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "water",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00000442
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "water turbine"
+    
+    SubClassOf: 
+        OEO_00000425,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010234 some OEO_00000218,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00240000,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110004
+    
+    
+Class: OEO_00000446
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+reclassify and change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+remove disposition renewable fuel
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
+add and change axioms
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "wind energy"
+    
+    SubClassOf: 
+        OEO_00230020,
+        OEO_00000530 some OEO_00030004,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        OEO_00020182 some OEO_00000043,
+        OEO_00020183 some OEO_00020043
+    
+    
+Class: OEO_00000447
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "wind farm"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000044
+    
+    
+Class: OEO_00000448
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "wind rotor"
+    
+    SubClassOf: 
+        OEO_00000425,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000446,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00240000,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020043,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144
+    
+    
+Class: OEO_00000449
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+add dispositions:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
+        rdfs:label "wood"
+    
+    SubClassOf: 
+        OEO_00010214,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00010000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "trihydridonitrogen",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+Adapt definiton and axioms, add alternative  terms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "ammonia"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "carbon monoxide"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen oxides"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitric oxide"@en
+    
+    SubClassOf: 
+        OEO_00010002
+    
+    
+Class: OEO_00010004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "nitrogen dioxide"@en
+    
+    SubClassOf: 
+        OEO_00010002
+    
+    
+Class: OEO_00010007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "sulphur dioxide"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM10"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
+    
+    SubClassOf: 
+        OEO_00000318
+    
+    
+Class: OEO_00010010
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM2.5"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
+    
+    SubClassOf: 
+        OEO_00000318
+    
+    
+Class: OEO_00010011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "volatility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
+Class: OEO_00010012
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
+        rdfs:label "air pollutant"@en
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000055)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00010015
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin. It is usually produced from fossil fuels applying the steam reforming process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "fossil hydrogen"
+    
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        OEO_00000220
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        OEO_00000220
+    
+    
+Class: OEO_00010016
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin. It is usually produced from water applying the water electrolysis process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "synthetic hydrogen"
+    
+    EquivalentTo: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
+        OEO_00000220
+         and (OEO_00000530 some OEO_00030005)
+    
+    SubClassOf: 
+        OEO_00000220
+    
+    
+Class: OEO_00010017
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "synthetic fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (OEO_00000530 some OEO_00030005)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `synthetic fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000173,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+    
+    
+Class: OEO_00010018
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+Re-definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "synthetic methane"
+    
+    EquivalentTo: 
+        OEO_00000025
+         and (OEO_00000530 some OEO_00030005)
+    
+    SubClassOf: 
+        OEO_00000025
+    
+    
+Class: OEO_00010019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+new label and axioms:
+https://github.com/OpenEnergyPlatform/ontology/issues/934
+pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
+        rdfs:label "PtL fuel"
+    
+    SubClassOf: 
+        OEO_00010156,
+        <http://purl.obolibrary.org/obo/RO_0003001> some OEO_00010020,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00010020
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+        rdfs:label "power-to-liquid system"
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
+Class: OEO_00010021
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "water electrolyser"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00000441,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000139,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000007,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000220
+    
+    
+Class: OEO_00010022
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993",
+        rdfs:label "steam reformer"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
+        OEO_00000503 some OEO_00140159,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
+        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00140160
+    
+    
+Class: OEO_00010023
+
+    
+Class: OEO_00010024
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in an on-board battery.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
+        rdfs:label "battery electric vehicle"@en
+    
+    SubClassOf: 
+        OEO_00000146,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026
+    
+    
+Class: OEO_00010025
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/637
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655",
+        rdfs:label "fuel cell electric vehicle"@en
+    
+    SubClassOf: 
+        OEO_00000146,
+        OEO_00000503 some OEO_00000220,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000016
+    
+    
+Class: OEO_00010026
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        dc:description "A traction battery is a battery that is used in vehicles for propulsion.",
+        rdfs:label "traction battery"@en
+    
+    SubClassOf: 
+        OEO_00000068
+    
+    
+Class: OEO_00010027
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+change uses energy axiom to 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "electric motor"@en
+    
+    SubClassOf: 
+        OEO_00010032,
+        OEO_00010234 some OEO_00000139
+    
+    
+Class: OEO_00010028
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+relabel and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
+        rdfs:label "electric traction motor"@en
+    
+    SubClassOf: 
+        OEO_00010027,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>
+    
+    
+Class: OEO_00010029
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "internal combustion engine"@en
+    
+    SubClassOf: 
+        OEO_00010032,
+        OEO_00000503 some OEO_00000099,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140038
+    
+    
+Class: OEO_00010030
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "plug-in hybrid electric vehicle"@en
+    
+    SubClassOf: 
+        OEO_00010023,
+        OEO_00000503 some OEO_00000099,
+        OEO_00000503 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010029
+    
+    
+Class: OEO_00010031
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that uses electrical energy via a conductor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+        rdfs:label "grid supplied electric vehicle"@en
+    
+    SubClassOf: 
+        OEO_00000146
+    
+    
+Class: OEO_00010032
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "motor",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00230020
+    
+    
+Class: OEO_00010072
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal power density unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00010073
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal energy density unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00010074
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal power density"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00010072
+    
+    
+Class: OEO_00010075
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal energy density"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00010073
+    
+    
+Class: OEO_00010076
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal solar power density"
+    
+    SubClassOf: 
+        OEO_00010074
+    
+    
+Class: OEO_00010077
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+        rdfs:label "areal solar energy density"
+    
+    SubClassOf: 
+        OEO_00010075
+    
+    
+Class: OEO_00010078
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683",
+        rdfs:label "global warming potential"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00010079
+
+    
+Class: OEO_00010080
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+add 'has physical output' some 'electrical energy'
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar-steam-electric process"@en
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020047)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00050020)
+    
+    SubClassOf: 
+        OEO_00020046,
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
+    
+    
+Class: OEO_00010081
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar chemical energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00020046,
+        OEO_00010235 some OEO_00000007
+    
+    
+Class: OEO_00010084
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
+        rdfs:label "reservoir"@en
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00000503 some OEO_00110000,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
+    
+    
+Class: OEO_00010085
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power unit"@en
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00000503 some OEO_00000441,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
+    
+    
+Class: OEO_00010086
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro power plant"@en
+    
+    SubClassOf: 
+        OEO_00000031,
+        OEO_00000503 some OEO_00000441,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
+    
+    
+Class: OEO_00010087
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "run of river power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086,
+        OEO_00000503 some OEO_00010093,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
+    
+    
+Class: OEO_00010088
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086,
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010084),
+        OEO_00000503 some OEO_00110000
+    
+    
+Class: OEO_00010089
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010088,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090
+    
+    
+Class: OEO_00010090
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "pump"@en
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
+        OEO_00000503 some OEO_00140116,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some 
+            (OEO_00020045 or OEO_00230020)
+    
+    
+Class: OEO_00010091
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "open-loop pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010089,
+        OEO_00000503 some OEO_00000345
+    
+    
+Class: OEO_00010092
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+        rdfs:label "closed-loop pumped hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010089,
+        OEO_00000503 only OEO_00000345
+    
+    
+Class: OEO_00010093
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
+
+Make river a subclass of water body:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "river"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
+    
+    SubClassOf: 
+        OEO_00010104,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110002
+    
+    
+Class: OEO_00010094
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
+        rdfs:label "reservoir hydro storage power plant"@en
+    
+    SubClassOf: 
+        OEO_00010088,
+        not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090)
+    
+    
+Class: OEO_00010095
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00140104
+    
+    
+Class: OEO_00010096
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine thermal energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00140101,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105
+    
+    
+Class: OEO_00010097
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+add and change axioms
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine current energy"@en
+    
+    SubClassOf: 
+        OEO_00020087,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        OEO_00020182 some OEO_00010107,
+        OEO_00020183 some OEO_00010098
+    
+    
+Class: OEO_00010098
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+remove wrong axiom 
+https://github.com/OpenEnergyPlatform/ontology/pull/1044",
+        rdfs:label "marine current energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005,
+        OEO_00010234 some OEO_00010097,
+        
+            Annotations: rdfs:comment "reintroduce axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107
+    
+    
+Class: OEO_00010099
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "marine tidal energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005,
+        OEO_00010234 some OEO_00010100,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101
+    
+    
+Class: OEO_00010100
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine tidal energy"@en
+    
+    SubClassOf: 
+        OEO_00020087,
+        OEO_00020182 some OEO_00010101
+    
+    
+Class: OEO_00010101
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "tidal flow"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
+    
+    SubClassOf: 
+        OEO_00110002
+    
+    
+Class: OEO_00010102
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+fix classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
+
+change axiom from participates in to is energy participant of
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+        rdfs:label "marine wave energy"@en
+    
+    SubClassOf: 
+        OEO_00020087,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
+        OEO_00020182 some OEO_00010106
+    
+    
+Class: OEO_00010103
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "marine wave energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110005,
+        OEO_00010234 some OEO_00010102,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "replace 'has input' with 'causally downstream of or within'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106
+    
+    
+Class: OEO_00010104
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "water body"@en
+    
+    SubClassOf: 
+        OEO_00110000
+    
+    
+Class: OEO_00010105
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "ocean"@en
+    
+    SubClassOf: 
+        OEO_00010104
+    
+    
+Class: OEO_00010106
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "wave"@en
+    
+    SubClassOf: 
+        OEO_00110002
+    
+    
+Class: OEO_00010107
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "ocean current"@en
+    
+    SubClassOf: 
+        OEO_00110002
+    
+    
+Class: OEO_00010108
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
+    
+    
+Class: OEO_00010109
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
+    
+    
+Class: OEO_00010110
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy converting unit"@en
+    
+    SubClassOf: 
+        OEO_00010085,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
+    
+    
+Class: OEO_00010111
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine current energy power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010108,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098
+    
+    
+Class: OEO_00010112
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine tidal energy power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010109,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099
+    
+    
+Class: OEO_00010113
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+        rdfs:label "marine wave energy power plant"@en
+    
+    SubClassOf: 
+        OEO_00010086,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010110,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103
+    
+    
+Class: OEO_00010114
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
+        rdfs:label "waste thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00010127
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/865",
+        rdfs:label "secondary energy production"@en
+    
+    SubClassOf: 
+        OEO_00240003,
+        OEO_00000533 some OEO_00140079,
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00010137
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "t",
+        rdfs:label "metric ton"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000002>
+    
+    
+Class: OEO_00010138
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon capture"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000532 some OEO_00000006
+    
+    
+Class: OEO_00010139
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct on air capture (DAC) is carbon dioxide capture from air.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "direct air capture"@en
+    
+    SubClassOf: 
+        OEO_00010138,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000054
+    
+    
+Class: OEO_00010140
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon storage"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000532 some OEO_00000006
+    
+    
+Class: OEO_00010141
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
+        rdfs:label "carbon capture and storage"@en
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010138)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010140)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000532 some OEO_00000006
+    
+    
+Class: OEO_00010144
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid combustion fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000529 value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00000099
+    
+    
+Class: OEO_00010145
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid combustion fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000529 value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00000099
+    
+    
+Class: OEO_00010146
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous combustion fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000529 value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00000099
+    
+    
+Class: OEO_00010147
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid fossil fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000014
+         and (OEO_00000529 value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00000014
+    
+    
+Class: OEO_00010148
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous fossil fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000014
+         and (OEO_00000529 value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00000014
+    
+    
+Class: OEO_00010149
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid renewable fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000033
+         and (OEO_00000529 value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00000033
+    
+    
+Class: OEO_00010150
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid renewable fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000033
+         and (OEO_00000529 value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00000033
+    
+    
+Class: OEO_00010151
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous renewable fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000033
+         and (OEO_00000529 value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00000033
+    
+    
+Class: OEO_00010153
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A gasoeus biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous biofuel"@en
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (OEO_00000529 value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00000072
+    
+    
+Class: OEO_00010154
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "solid synthetic fuel"@en
+    
+    EquivalentTo: 
+        OEO_00010017
+         and (OEO_00000529 value OEO_00000390)
+    
+    SubClassOf: 
+        OEO_00010017
+    
+    
+Class: OEO_00010155
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "gaseous synthetic fuel"@en
+    
+    EquivalentTo: 
+        OEO_00010017
+         and (OEO_00000529 value OEO_00000182)
+    
+    SubClassOf: 
+        OEO_00010017
+    
+    
+Class: OEO_00010156
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
+        rdfs:label "liquid synthetic fuel"@en
+    
+    EquivalentTo: 
+        OEO_00010017
+         and (OEO_00000529 value OEO_00000256)
+    
+    SubClassOf: 
+        OEO_00010017
+    
+    
+Class: OEO_00010157
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+Make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "power value"@en
+    
+    EquivalentTo: 
+        OEO_00000350
+         and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>)
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00010210
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
+        rdfs:label "energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
+    
+    DisjointWith: 
+        OEO_00010211
+    
+    
+Class: OEO_00010211
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
+        rdfs:label "non-energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    DisjointWith: 
+        OEO_00010210
+    
+    
+Class: OEO_00010214
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
+        rdfs:label "biomass"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030001
+    
+    
+Class: OEO_00010215
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+        rdfs:label "biomethane"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00000530 some OEO_00030001,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010216
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "power-to-gas process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010155)
+         and (OEO_00010235 some OEO_00000007)
+    
+    
+Class: OEO_00010217
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "power-to-methane process"@en
+    
+    SubClassOf: 
+        OEO_00010216,
+        (OEO_00000532 some OEO_00000006)
+         and (OEO_00000532 some OEO_00000441)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010018)
+         and (OEO_00010235 some OEO_00000007),
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010219,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010220
+    
+    
+Class: OEO_00010218
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "oxygen"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010219
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "water electrolysis process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000441)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00000220)
+         and (OEO_00000533 some OEO_00010218)
+         and (OEO_00010235 some OEO_00000007),
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010021
+    
+    
+Class: OEO_00010220
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+        rdfs:label "methanation"@en
+    
+    SubClassOf: 
+        OEO_00140034,
+        (OEO_00000532 some OEO_00000006)
+         and (OEO_00000532 some OEO_00000220),
+        (OEO_00000533 some OEO_00000006)
+         and (OEO_00000533 some OEO_00000441)
+    
+    
+Class: OEO_00010221
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "synthetic ammonia"@en
+    
+    EquivalentTo: 
+        OEO_00010000
+         and (OEO_00000530 some OEO_00030005)
+    
+    SubClassOf: 
+        OEO_00010000
+    
+    
+Class: OEO_00010222
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+        rdfs:label "power-to-ammonia process"@en
+    
+    SubClassOf: 
+        OEO_00010216,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010000
+    
+    
+Class: OEO_00010223
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic waste fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000439
+         and (OEO_00000530 some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00010224
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil waste fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000439
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        OEO_00000439
+    
+    
+Class: OEO_00010225
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
+
+rename class and change axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+        rdfs:label "biogenic industrial waste fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000226
+         and (OEO_00000530 some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000226
+    
+    
+Class: OEO_00010226
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
+        rdfs:label "fossil industrial waste fuel"@en
+    
+    EquivalentTo: 
+        OEO_00000226
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        OEO_00000226
+    
+    
+Class: OEO_00010256
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "maximum value"
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00010257
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
+
+Fix 'quantity value of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
+        rdfs:label "power capacity"
+    
+    SubClassOf: 
+        OEO_00010256,
+        OEO_00020056 some 
+            (OEO_00000188 or OEO_00000334),
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: OEO_00010258
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
+        rdfs:label "bioenergy"
+    
+    EquivalentTo: 
+        OEO_00000007
+         and (OEO_00000530 some OEO_00030001)
+    
+    SubClassOf: 
+        OEO_00000007
+    
+    
+Class: OEO_00010259
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
+        rdfs:label "measurement device"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00020001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "C2H6O",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
+axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
+        rdfs:label "ethanol"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000075,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000256
+    
+    
+Class: OEO_00020003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
+
+make class a subclass of transformation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+add input and output relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+add relation to energy transformation unit:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+add axiom relating to energy carrier / input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182"@en,
+        rdfs:label "energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00000419,
+        OEO_00010234 some OEO_00000150,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000150,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+    
+    
+Class: OEO_00020004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "gas grid"@en
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020007
+    
+    
+Class: OEO_00020005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/385",
+        rdfs:label "heating grid"@en
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
+    
+    
+Class: OEO_00020006
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
+    
+Class: OEO_00020007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "gas grid component"@en
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00020008
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "heating grid component"@en
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
+    
+    SubClassOf: 
+        OEO_00020006
+    
+    
+Class: OEO_00020009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
+        rdfs:label "switchyard"@en
+    
+    SubClassOf: 
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
+    
+    
+Class: OEO_00020037
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+        rdfs:label "radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00230021
+    
+    
+Class: OEO_00020038
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+        rdfs:label "solar radiation",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
+    
+    SubClassOf: 
+        OEO_00020037
+    
+    
+Class: OEO_00020039
+
+    
+Class: OEO_00020040
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+        rdfs:label "radiative energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00020043
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
+        rdfs:label "wind energy transformation"
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010234 some OEO_00000446,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
+    
+    
+Class: OEO_00020045
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00020046
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+has input relation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/668
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
+delete has physical output relation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar energy transformation"
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010234 some OEO_00000384
+    
+    
+Class: OEO_00020047
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "solar thermal energy transformation"
+    
+    SubClassOf: 
+        OEO_00020046,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        OEO_00010235 some OEO_00000388,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
+    
+    
+Class: OEO_00020048
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "photovoltaic energy transformation"
+    
+    SubClassOf: 
+        OEO_00020046,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
+    
+    
+Class: OEO_00020050
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+change def and equivalence
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00020053
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
+        rdfs:label "nuclear fission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000302
+    
+    
+Class: OEO_00020054
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "nuclear energy transformation"
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010234 some OEO_00000300,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000207
+    
+    
+Class: OEO_00020058
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+        rdfs:label "rock"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030003,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00020059
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "geothermal heat transfer"
+    
+    SubClassOf: 
+        OEO_00140101,
+        OEO_00010234 only OEO_00000191
+    
+    
+Class: OEO_00020066
+
+    
+Class: OEO_00020068
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
+    
+    
+Class: OEO_00020073
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "grid-bound heating"
+    
+    SubClassOf: 
+        OEO_00140101,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020005,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00110000 or OEO_00110001)
+    
+    
+Class: OEO_00020074
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
+        rdfs:label "industrial grid-bound heating"
+    
+    SubClassOf: 
+        OEO_00020073
+    
+    
+Class: OEO_00020085
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy"
+    
+    EquivalentTo: 
+        OEO_00000150
+         and (OEO_00000530 some OEO_00030004)
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00020086
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "renewable energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00020087
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rain water, melted snow and ice).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "natural hydro energy"
+    
+    SubClassOf: 
+        OEO_00000218,
+        OEO_00000503 some OEO_00010104,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00020088
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
+        rdfs:label "pumped hydro energy"
+    
+    SubClassOf: 
+        OEO_00000218,
+        OEO_00000503 some OEO_00000345,
+        OEO_00000530 some OEO_00020147
+    
+    
+Class: OEO_00020102
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "energy transformation unit"
+    
+    SubClassOf: 
+        OEO_00000061,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
+    
+    
+Class: OEO_00020103
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+        rdfs:label "energy transfer"
+    
+    SubClassOf: 
+        OEO_00020003
+    
+    
+Class: OEO_00020104
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perfom or operate.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "outage"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+    
+    
+Class: OEO_00020105
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "forced outage"
+    
+    SubClassOf: 
+        OEO_00020104
+    
+    DisjointWith: 
+        OEO_00020106
+    
+    
+Class: OEO_00020106
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "planned outage"
+    
+    SubClassOf: 
+        OEO_00020104
+    
+    DisjointWith: 
+        OEO_00020105
+    
+    
+Class: OEO_00020107
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
+        rdfs:label "curtailment"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
+    
+    
+Class: OEO_00020136
+
+    
+Class: OEO_00020137
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "operational space requirement"
+    
+    SubClassOf: 
+        OEO_00020136
+    
+    
+Class: OEO_00020139
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to contruct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "space requirement for construction"
+    
+    SubClassOf: 
+        OEO_00020136
+    
+    
+Class: OEO_00020140
+
+    
+Class: OEO_00020141
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "specific space requirement"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00020140
+    
+    
+Class: OEO_00020144
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
+        rdfs:label "rotor diameter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140001
+    
+    
+Class: OEO_00020147
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "conventional"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some OEO_00000150
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        OEO_00030004
+    
+    
+Class: OEO_00020148
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of an material entity that contains non-renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
+        rdfs:label "conventional energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00020149
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Update definition and axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1172
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
+        rdfs:label "fossil energy"
+    
+    EquivalentTo: 
+        OEO_00000007
+         and (OEO_00000530 some OEO_00020147)
+         and (OEO_00010121 some OEO_00000014)
+    
+    SubClassOf: 
+        OEO_00000007
+    
+    
+Class: OEO_00020196
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
+
+Fix spelling of label:
+https://github.com/OpenEnergyPlatform/ontology/pull/1196",
+        rdfs:label "fissile material entity"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00020197
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "tangential proper part"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000024>
+    
+    
+Class: OEO_00020198
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "surface"
+    
+    SubClassOf: 
+        OEO_00020197,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    
+Class: OEO_00020199
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
+        rdfs:label "solar radiation receiving surface"
+    
+    EquivalentTo: 
+        OEO_00020198
+         and (OEO_00010234 some OEO_00000384)
+    
+    SubClassOf: 
+        OEO_00020198
+    
+    
+Class: OEO_00020200
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+        rdfs:label "solar receiving object"
+    
+    EquivalentTo: 
+        OEO_00000061
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199)
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00020201
+
+    
+Class: OEO_00020202
+
+    
+Class: OEO_00020207
+
+    
+Class: OEO_00020208
+
+    
+Class: OEO_00020210
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "sirup"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
+        OEO_00000531 value OEO_00000256
+    
+    
+Class: OEO_00030000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "anthropogenic"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some 
+            (OEO_00000150 or OEO_00000331)
+    
+    
+Class: OEO_00030001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "biogenic"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some OEO_00000331
+    
+    DisjointWith: 
+        OEO_00030002
+    
+    
+Class: OEO_00030002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Update definition and add disjoint:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Shift part of the definition into an editor note:
+Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "fossil"
+    
+    SubClassOf: 
+        OEO_00030003,
+        OEO_00010121 some OEO_00000331
+    
+    DisjointWith: 
+        OEO_00030001
+    
+    
+Class: OEO_00030003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "geogenic"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some 
+            (OEO_00000150 or OEO_00000331)
+    
+    
+Class: OEO_00030004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
+include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "renewable"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some OEO_00000150
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        OEO_00020147
+    
+    
+Class: OEO_00030005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Make subclass of anthropogenic:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:label "synthetic"
+    
+    SubClassOf: 
+        OEO_00030000,
+        OEO_00010121 some OEO_00000331
+    
+    
+Class: OEO_00030015
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        OEO_00140164 some OEO_00030024
+    
+    
+Class: OEO_00030019
+
+    
+Class: OEO_00030024
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
+
+make subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123",
+        rdfs:label "energy system"
+    
+    SubClassOf: 
+        OEO_00030025
+    
+    
+Class: OEO_00030025
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493",
+        rdfs:label "supply system"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
+Class: OEO_00030026
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+add axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy production"
+    
+    SubClassOf: 
+        OEO_00240003,
+        OEO_00000533 some OEO_00140078,
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00030027
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy carrier mining"
+    
+    SubClassOf: 
+        OEO_00030026
+    
+    
+Class: OEO_00030028
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
+        rdfs:label "primary energy carrier harvest"
+    
+    SubClassOf: 
+        OEO_00030026
+    
+    
+Class: OEO_00030035
+
+    
+Class: OEO_00040011
+
+    
+Class: OEO_00050000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
+        rdfs:label "industrial process"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some 
+            (<http://purl.obolibrary.org/obo/BFO_0000027> or <http://purl.obolibrary.org/obo/BFO_0000030>)
+    
+    
+Class: OEO_00050001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
+
+Update definition and axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
+        rdfs:label "fuel-powered electricity generation"@en
+    
+    EquivalentTo: 
+        OEO_00240014
+         and (OEO_00000532 some OEO_00000099)
+    
+    SubClassOf: 
+        OEO_00240014,
+        OEO_00000500 some OEO_00000148,
+        OEO_00000533 some OEO_00000331,
+        OEO_00010234 some OEO_00000007,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
+        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
+    
+    
+Class: OEO_00050002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
+        rdfs:label "kilojoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
+        rdfs:label "megajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
+        rdfs:label "gigajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
+        rdfs:label "terajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050006
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
+        rdfs:label "petajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
+        rdfs:label "exajoule"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050008
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
+        rdfs:label "megawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
+        rdfs:label "terawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050010
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
+        rdfs:label "petawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
+        rdfs:label "gigawatt-hour"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00050016
+
+    SubClassOf: 
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00050017
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
+
+Gross inland energy consumption covers:
+  - consumption by the energy sector itself;
+  - distribution and transformation losses;
+  - final energy consumption by end users;
+  - 'statistical differences' (not already captured in the figures on primary energy consumption and final energy consumption).
+
+Gross inland energy consumption does not include energy (fuel oil) provided to international maritime bunkers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross inland consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary energy consumption including non-energy use of energy carriers"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "become a subclass of quantity value:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "gross inland energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00240019,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211)
+    
+    
+Class: OEO_00050018
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+        rdfs:label "primary energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00140039,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210),
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00050019
+
+    
+Class: OEO_00050020
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "steam-electric process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010234 some OEO_00000207,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
+    
+    
+Class: OEO_00090000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
+        rdfs:label "volumetric flow rate value"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000270>
+    
+    
+Class: OEO_00110000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "liquid water"@en
+    
+    SubClassOf: 
+        OEO_00000441,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000218,
+        OEO_00000531 value OEO_00000256
+    
+    
+Class: OEO_00110001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
+        rdfs:label "steam"@en
+    
+    SubClassOf: 
+        OEO_00000441,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000531 value OEO_00000182
+    
+    
+Class: OEO_00110002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "water flow"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000500 some OEO_00110003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00110000
+    
+    
+Class: OEO_00110003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
+        rdfs:label "water flow rate"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00140002 some OEO_00090000
+    
+    
+Class: OEO_00110004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "hydro energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010234 some OEO_00000218
+    
+    
+Class: OEO_00110005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+        rdfs:label "hydroelectric energy transformation"@en
+    
+    SubClassOf: 
+        OEO_00110004,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139
+    
+    
+Class: OEO_00140000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "hub height"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140001
+    
+    
+Class: OEO_00140001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "length value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
+    
+    
+Class: OEO_00140033
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "chemical reaction"@en
+    
+    SubClassOf: 
+        OEO_00000419
+    
+    
+Class: OEO_00140034
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "redox reaction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140035
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "oxidation"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140036
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "reduction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140037
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "electrochemical reaction"@en
+    
+    SubClassOf: 
+        OEO_00140033
+    
+    
+Class: OEO_00140038
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
+        rdfs:label "combustion"@en
+    
+    SubClassOf: 
+        OEO_00140034
+    
+    
+Class: OEO_00140039
+
+    
+Class: OEO_00140049
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "energy conversion efficiency"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003,
+        OEO_00140002 some OEO_00140050
+    
+    
+Class: OEO_00140050
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "efficiency value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00140051
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "coefficient of performance value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00020056 some OEO_00140052,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: OEO_00140052
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
+        rdfs:label "energy conversion performance"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003,
+        OEO_00140002 some OEO_00140051
+    
+    
+Class: OEO_00140056
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
+
+change: adjust definition to be based on parent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
+        rdfs:label "flow potential"@en
+    
+    SubClassOf: 
+        OEO_00290000
+    
+    
+Class: OEO_00140057
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "theoretical flow potential"@en
+    
+    SubClassOf: 
+        OEO_00140056
+    
+    
+Class: OEO_00140058
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "technological flow potential"@en
+    
+    SubClassOf: 
+        OEO_00140056
+    
+    
+Class: OEO_00140059
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "economic flow potential"@en
+    
+    SubClassOf: 
+        OEO_00140056
+    
+    
+Class: OEO_00140060
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "developable flow potential"@en
+    
+    SubClassOf: 
+        OEO_00140056
+    
+    
+Class: OEO_00140061
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "sustainable flow potential"@en
+    
+    SubClassOf: 
+        OEO_00140056
+    
+    
+Class: OEO_00140062
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
+
+change: adjust definition to be based on parent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
+        rdfs:label "stock potential"@en
+    
+    SubClassOf: 
+        OEO_00290000
+    
+    
+Class: OEO_00140063
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "theoretical stock potential"@en
+    
+    SubClassOf: 
+        OEO_00140062
+    
+    
+Class: OEO_00140064
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "technological stock potential"@en
+    
+    SubClassOf: 
+        OEO_00140062
+    
+    
+Class: OEO_00140065
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "economic stock potential"@en
+    
+    SubClassOf: 
+        OEO_00140062
+    
+    
+Class: OEO_00140066
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "developable stock potential"@en
+    
+    SubClassOf: 
+        OEO_00140062
+    
+    
+Class: OEO_00140067
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
+        rdfs:label "sustainable stock potential"@en
+    
+    SubClassOf: 
+        OEO_00140062
+    
+    
+Class: OEO_00140075
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "primary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140076
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "secondary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140077
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "final energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
+    
+Class: OEO_00140078
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "primary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00140079
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the disposition secondary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
+fix error in definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678",
+        rdfs:label "secondary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00140080
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
+        rdfs:label "final energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140077)
+    
+    SubClassOf: 
+        OEO_00020039
+    
+    
+Class: OEO_00140081
+
+    
+Class: OEO_00140082
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
+        rdfs:label "greenhouse gas emission value"@en
+    
+    SubClassOf: 
+        OEO_00140081,
+        OEO_00000502 some OEO_00000199
+    
+    
+Class: OEO_00140083
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
+        rdfs:label "carbon dioxide equivalent quantity"@en
+    
+    SubClassOf: 
+        OEO_00140082
+    
+    
+Class: OEO_00140091
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
+        rdfs:label "plutonium"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00140092
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
+        rdfs:label "thorium"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00140101
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
+
+subclass of energy transfer
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "heat transfer"@en
+    
+    SubClassOf: 
+        OEO_00020103,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010234 only OEO_00000207,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 only OEO_00000207
+    
+    
+Class: OEO_00140102
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "heat exchanger"@en
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000207,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000207,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101
+    
+    
+Class: OEO_00140104
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "natural ambient thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000056,
+        OEO_00000530 some OEO_00030004
+    
+    
+Class: OEO_00140105
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
+        rdfs:label "artificial ambient thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000056,
+        OEO_00000530 some OEO_00020147,
+        OEO_00000530 some OEO_00030000
+    
+    
+Class: OEO_00140106
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "ambient thermal energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00140101,
+        OEO_00010234 some OEO_00000056,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00140116
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
+        rdfs:label "fluid"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and ((OEO_00000531 value OEO_00000182) or (OEO_00000531 value OEO_00000256) or (OEO_00000531 value OEO_00000326))
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00140126
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "planned availability"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140127
+    
+    
+Class: OEO_00140127
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "share",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "fraction value"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00140128
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "block size"@en
+    
+    SubClassOf: 
+        OEO_00230002,
+        OEO_00020056 some OEO_00000334
+    
+    
+Class: OEO_00140129
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "unplanned availability"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140127
+    
+    
+Class: OEO_00140133
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "RE-share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780",
+        rdfs:label "RE-share"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00140002 some OEO_00140127
+    
+    
+Class: OEO_00140134
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
+        rdfs:label "hydrogen fuel cell"@en
+    
+    SubClassOf: 
+        OEO_00000016,
+        OEO_00000503 some OEO_00000220
+    
+    
+Class: OEO_00140135
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
+        rdfs:label "natural gas turbine"@en
+    
+    SubClassOf: 
+        OEO_00000185,
+        OEO_00000503 some OEO_00000292
+    
+    
+Class: OEO_00140144
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "full load hours"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000032>
+    
+    
+Class: OEO_00140159
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
+        rdfs:label "hydrocarbon"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
+    
+Class: OEO_00140160
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
+
+add axioms:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
+
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "syngas"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000220,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010001,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00140162
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
+        rdfs:label "power plant with electro motive generator"@en,
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010)
+    
+    SubClassOf: 
+        OEO_00000031
+    
+    
+Class: OEO_00160001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "frequency control"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00160002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "primary control"@en
+    
+    SubClassOf: 
+        OEO_00160001
+    
+    
+Class: OEO_00160003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "secondary control"@en
+    
+    SubClassOf: 
+        OEO_00160001
+    
+    
+Class: OEO_00160004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+        rdfs:label "tertiary control"@en
+    
+    SubClassOf: 
+        OEO_00160001
+    
+    
+Class: OEO_00230000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
+        rdfs:label "storage capacity"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00020056 some OEO_00000159
+    
+    
+Class: OEO_00230001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "power rating"@en
+    
+    SubClassOf: 
+        OEO_00010257,
+        OEO_00020056 some OEO_00000011,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: OEO_00230002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "declared net capacity"@en
+    
+    SubClassOf: 
+        OEO_00010257,
+        OEO_00020056 some 
+            (OEO_00000031 or OEO_00000334),
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
+    
+    
+Class: OEO_00230003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+extend to artificial objects:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+Make it subclass of power value and add unit axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
+
+use energy converting component in definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/993
+
+Make subclass of 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "nameplate capacity"@en
+    
+    SubClassOf: 
+        OEO_00010257,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00230020
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        rdfs:label "kinetic energy"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    
+Class: OEO_00230021
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
+pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
+add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+classify as material entity
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
+        rdfs:label "photon"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020040,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151
+    
+    
+Class: OEO_00240000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
+        rdfs:label "rotational energy"@en
+    
+    SubClassOf: 
+        OEO_00230020
+    
+    
+Class: OEO_00240003
+
+    
+Class: OEO_00240009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "combined heat and power generation"
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00010235 some OEO_00000139,
+        OEO_00010235 some OEO_00000207
+    
+    
+Class: OEO_00240010
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is a power generating unit that produces electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
+
+change produces energy axioms to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "combined heat and power generating unit"
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00010235 some OEO_00000139,
+        OEO_00010235 some OEO_00000207,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240009
+    
+    
+Class: OEO_00240011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is a power plant that has combined heat and power generating units as parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923",
+        rdfs:label "combined heat and power plant"
+    
+    SubClassOf: 
+        OEO_00000031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00240010
+    
+    
+Class: OEO_00240012
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+        rdfs:label "gross electricity generation"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00240013
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+        rdfs:label "net electricity generation"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00140002 some OEO_00050019
+    
+    
+Class: OEO_00240014
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+        rdfs:label "electricity generation process"
+    
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000139)
+    
+    SubClassOf: 
+        OEO_00020003,
+        OEO_00000500 some OEO_00240012,
+        OEO_00000500 some OEO_00240013,
+        OEO_00010235 some OEO_00000139
+    
+    
+Class: OEO_00240015
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
+        rdfs:label "liquid air production"
+    
+    SubClassOf: 
+        OEO_00240003,
+        OEO_00000532 some OEO_00000054,
+        OEO_00000533 some OEO_00000257
+    
+    
+Class: OEO_00240016
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
+
+make subclass of 'fraction value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
+        rdfs:label "net capacity factor"
+    
+    SubClassOf: 
+        OEO_00140127
+    
+    
+Class: OEO_00240018
+
+    Annotations: 
+        OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
+        rdfs:label "gross national electricity consumption"
+    
+    SubClassOf: 
+        OEO_00240019,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00050017
+    
+    
+Class: OEO_00240019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
+        rdfs:label "energy consumption value"
+    
+    SubClassOf: 
+        OEO_00050019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
+    
+    
+Class: OEO_00240026
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
+        rdfs:label "industrial material"
+    
+    EquivalentTo: 
+        (OEO_00240025 some OEO_00050000)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00240027
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "chemical substance"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00240025 some OEO_00050000,
+        OEO_00240025 some OEO_00140033,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240028
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "paper"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00240025 some OEO_00050000,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00240029
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "cement"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00240025 some OEO_00050000,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00240030
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "mineral"
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00240031
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "non-metallic mineral"
+    
+    SubClassOf: 
+        OEO_00240030,
+        OEO_00240025 some OEO_00050000,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240032
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "metal"
+    
+    SubClassOf: 
+        OEO_00000331
+    
+    
+Class: OEO_00240034
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "steel"
+    
+    SubClassOf: 
+        OEO_00240032,
+        OEO_00240025 some OEO_00050000,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
+        OEO_00000529 value OEO_00000390
+    
+    
+Class: OEO_00240035
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+        rdfs:label "non-ferrous metal"
+    
+    SubClassOf: 
+        OEO_00240032,
+        OEO_00240025 some OEO_00050000,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00260001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "ramping"@en
+    
+    SubClassOf: 
+        OEO_00030019
+    
+    
+Class: OEO_00260002
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "start-up speed"@en
+    
+    SubClassOf: 
+        OEO_00260001
+         and (OEO_00000502 some OEO_00260003)
+    
+    
+Class: OEO_00260003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+        rdfs:label "cold start"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+         and (OEO_00000500 some OEO_00260002)
+    
+    
+Class: OEO_00290000
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
+
+make subclass of 'maximum value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+        rdfs:label "potential"@en
+    
+    SubClassOf: 
+        OEO_00010256
+    
+    
+Class: OEO_00290001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
+        rdfs:label "slope"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
+    
+    
+Individual: OEO_00000182
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
         rdfs:label "gaseous"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000256>
+Individual: OEO_00000256
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has has no definite shape but a definite volume (at a given temperature and pressure).",
         rdfs:label "liquid"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000326>
+Individual: OEO_00000326
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000390>
+Individual: OEO_00000390
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000395>
+        OEO_00000395
     
     
 DisjointClasses: 
-    <http://openenergy-platform.org/ontology/oeo/OEO_00000074>,<http://openenergy-platform.org/ontology/oeo/OEO_00000263>,<http://openenergy-platform.org/ontology/oeo/OEO_00000292>,<http://openenergy-platform.org/ontology/oeo/OEO_00010215>,<http://openenergy-platform.org/ontology/oeo/OEO_00140160>
+    OEO_00000074,OEO_00000263,OEO_00000292,OEO_00010215,OEO_00140160
 
 DisjointClasses: 
-    <http://openenergy-platform.org/ontology/oeo/OEO_00000188>,<http://openenergy-platform.org/ontology/oeo/OEO_00000210>,<http://openenergy-platform.org/ontology/oeo/OEO_00000425>
+    OEO_00000188,OEO_00000210,OEO_00000425
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1,7 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
-Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: obda: <https://w3id.org/obda/vocabulary#>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -23,6 +20,33 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Shared module)"
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010037>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
+        rdfs:label "unique individual identifier"
+    
+    SubPropertyOf: 
+        dc:identifier
+    
+    
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00110012>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mathematical expression is an annotation property that describes the class with a mathematical formula in LaTeX syntax."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/987
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/990"@en,
+        rdfs:label "mathematical expression"@en
+    
+    
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
+
+    Annotations: 
+        rdfs:label "belongs to module"
+    
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -53,27 +77,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
-AnnotationProperty: OEO_00010037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
-        rdfs:label "unique individual identifier"
-    
-    SubPropertyOf: 
-        dc:identifier
-    
-    
-AnnotationProperty: OEO_00110012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mathematical expression is an annotation property that describes the class with a mathematical formula in LaTeX syntax."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/987
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/990"@en,
-        rdfs:label "mathematical expression"@en
-    
-    
 AnnotationProperty: dc:description
 
     
@@ -97,6 +100,551 @@ Datatype: rdf:PlainLiteral
     
 Datatype: xsd:string
 
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domain and range; move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "has process attribute"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
+
+    Annotations: 
+        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472",
+        rdfs:label "is used by"
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "process attribute of"
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant and another continuant it requires to function.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
+https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
+https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
+https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)",
+        rdfs:label "uses"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000505>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers sector"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000506>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has auther' some ('has role' some author) is necessary, because has author has the range has role some author (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an idependent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has author"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000507>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has client"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000508>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contact person"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000509>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
+        rdfs:label "has funding source"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Range: 
+        
+            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000510>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+
+improve definition:
+https://github.com/OpenEnergyPlatform/ontology/issues/1038
+https://github.com/OpenEnergyPlatform/ontology/pull/1042
+
+Relabel to `has organisation`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
+        rdfs:label "has organisation"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+rework
+issue https://github.com/OpenEnergyPlatform/ontology/issues/849
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has resolution"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000515>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has spatial resolution"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000516>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+fix def and add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has temporal resolution"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
+        rdfs:label "covers"
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000523>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers energy carrier"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000530>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant or energy (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
+
+extend range to energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985",
+        rdfs:label "has bearer"@en
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/RO_0000053>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
+",
+        rdfs:label "has information content entity"@en
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
+        rdfs:label "quantity value of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020179>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "economic value of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020180>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "has economic value"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020188>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a copyright licence.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "has copyright license"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020189>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information input of p iff: c is an input of p, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "information input of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002352>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020190>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information ouput of p iff: c is an output of p, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "information output of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002353>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "has quantity value"@en
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+    
+    Range: 
+        
+            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contributor"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information input"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140094>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information output"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+        rdfs:label "models"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -130,7 +678,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     InverseOf: 
-        OEO_00010231
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
@@ -142,13 +690,13 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000020>
     
     InverseOf: 
-        OEO_00010121
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
@@ -190,7 +738,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
     
     Domain: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -295,555 +843,10 @@ ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
         <http://purl.obolibrary.org/obo/UO_0000000>
     
     
-ObjectProperty: OEO_00000500
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domain and range; move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "has process attribute"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00030019
-    
-    InverseOf: 
-        OEO_00000502
-    
-    
-ObjectProperty: OEO_00000501
-
-    Annotations: 
-        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472",
-        rdfs:label "is used by"
-    
-    InverseOf: 
-        OEO_00000503
-    
-    
-ObjectProperty: OEO_00000502
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "process attribute of"
-    
-    Domain: 
-        OEO_00030019
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        OEO_00000500
-    
-    
-ObjectProperty: OEO_00000503
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant and another continuant it requires to function.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
-https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
-https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
-https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)",
-        rdfs:label "uses"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    InverseOf: 
-        OEO_00000501
-    
-    
-ObjectProperty: OEO_00000505
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers sector"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00000367
-    
-    
-ObjectProperty: OEO_00000506
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has auther' some ('has role' some author) is necessary, because has author has the range has role some author (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an idependent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has author"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
-    
-    
-ObjectProperty: OEO_00000507
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has client"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
-    
-    
-ObjectProperty: OEO_00000508
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contact person"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
-    
-    
-ObjectProperty: OEO_00000509
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
-        rdfs:label "has funding source"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001
-    
-    
-ObjectProperty: OEO_00000510
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
-
-improve definition:
-https://github.com/OpenEnergyPlatform/ontology/issues/1038
-https://github.com/OpenEnergyPlatform/ontology/pull/1042
-
-Relabel to `has organisation`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
-        rdfs:label "has organisation"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
-    
-    
-ObjectProperty: OEO_00000514
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-rework
-issue https://github.com/OpenEnergyPlatform/ontology/issues/849
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has resolution"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020121
-    
-    
-ObjectProperty: OEO_00000515
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has spatial resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020123
-    
-    
-ObjectProperty: OEO_00000516
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-fix def and add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has temporal resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020122
-    
-    
-ObjectProperty: OEO_00000522
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
-        rdfs:label "covers"
-    
-    
-ObjectProperty: OEO_00000523
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00020039
-    
-    
-ObjectProperty: OEO_00000530
-
-    
-ObjectProperty: OEO_00010121
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant or energy (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-extend range to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985",
-        rdfs:label "has bearer"@en
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    Range: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
-    
-    
-ObjectProperty: OEO_00010231
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-",
-        rdfs:label "has information content entity"@en
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    
-ObjectProperty: OEO_00020056
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
-        rdfs:label "quantity value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    InverseOf: 
-        OEO_00140002
-    
-    
-ObjectProperty: OEO_00020179
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "economic value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    
-ObjectProperty: OEO_00020180
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "has economic value"
-    
-    SubPropertyOf: 
-        OEO_00010231
-    
-    
-ObjectProperty: OEO_00020188
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a copyright licence.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "has copyright license"
-    
-    SubPropertyOf: 
-        OEO_00010231
-    
-    
-ObjectProperty: OEO_00020189
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information input of p iff: c is an input of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information input of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002352>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-ObjectProperty: OEO_00020190
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information ouput of p iff: c is an output of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information output of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-ObjectProperty: OEO_00040010
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-ObjectProperty: OEO_00140002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010231
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000350
-    
-    InverseOf: 
-        OEO_00020056
-    
-    
-ObjectProperty: OEO_00140008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contributor"@en
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-ObjectProperty: OEO_00140093
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information input"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-ObjectProperty: OEO_00140094
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information output"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-ObjectProperty: OEO_00140164
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "models"@en
-    
-    Domain: 
-        OEO_00000274
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: OEO_00140178
+DataProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140178>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
@@ -852,7 +855,1549 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/840",
         rdfs:label "has number"@en
     
     Domain: 
-        OEO_00000350
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
+        rdfs:label "agent"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
+subclasses
+https://github.com/OpenEnergyPlatform/ontology/pull/128
+relation to space requirement
+https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "artificial object"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>,
+        <http://purl.obolibrary.org/obo/RO_0002328> some <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
+        rdfs:label "author"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
+        rdfs:label "client"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
+        rdfs:label "contact person"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "emission factor"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
+fix grammar error:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
+adjust definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
+        rdfs:label "hardware"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000238>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "institution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000264>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+        rdfs:label "energy market model"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
+
+add axiom to model calculation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "model"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://purl.obolibrary.org/obo/BFO_0000004>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
+        rdfs:label "model calculation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140093> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140094> some <http://openenergy-platform.org/ontology/oeo/OEO_00030030>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "organisation role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+change definition and add comment with examples:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
+        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
+* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
+* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
+        rdfs:label "origin"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
+        rdfs:label "person"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+definition update and editor note:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000340>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "project"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
+
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
+        rdfs:label "quantity value",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "sector"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "transformation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000423>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "electricity transshipment model"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "vehicle",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
+        rdfs:label "emission quantity value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+make good a continuant:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "good"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00010117>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The role of a continuant over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+add relation to monetary price
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+update definition:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "good role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "passenger transport"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+             and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00010264>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010264>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "passenger"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010265>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "energy service demand for passenger-kilometre"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240024>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010266>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "energy service demand for ton-kilometre"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00240024>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some <http://openenergy-platform.org/ontology/oeo/OEO_00140005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
+add covers-relation (oeo-model)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+add axiom (study report)
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+add etitor note
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
+        rdfs:label "study"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000340>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000509> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00090001>),
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
+add etitor note
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
+        rdfs:label "study report"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000088>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000506> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000064>),
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/RO_0002353> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
+move to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "licence"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
+        rdfs:label "energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+moved to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission quantity value and emission certificate price
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission certificate"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00020154>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel commodity role"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+add alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
+subclass of good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+change axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "commodity"
+    
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>)
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel commodity"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "resolution"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
+add individuals
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "temporal resolution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
+        rdfs:label "spatial resolution"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+
+extend definition and add alternative term
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
+        rdfs:label "space requirement"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
+        rdfs:label "area per power unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020142>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "square kilometer"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000047>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020143>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "area value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://purl.obolibrary.org/obo/BFO_0000009>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000047>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020154>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to emission certificate
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission certificate price"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020155>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission value, add new parent class and relable
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "social cost of carbon emission"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020181>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020175>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "life time"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020176>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "construction time"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020177>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "decommissioning time"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020178>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "operational life time"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020175>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020181>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "social cost of emission"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "copyright license"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020186>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "data license"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020187>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "software license"
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020201>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "import"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020202>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "export"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020204>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electrical energy amount value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020205>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity import value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020204>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020206>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity export value"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020204>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity import"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020201>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020205>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity export"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020202>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020206>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030015>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "energy system model"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "process attribute"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
+added term in oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+deleted term in oeo-social:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
+        rdfs:label "organisation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "exogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020189> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "endogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020190> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030031>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "start time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030032>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "ending time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+change duration to time span (def, label, alternative term)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
+        rdfs:label "time span"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://purl.obolibrary.org/obo/BFO_0000038>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "monetary price"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00010117>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
+https://github.com/OpenEnergyPlatform/ontology/pull/640
+add comment and example
+https://github.com/OpenEnergyPlatform/ontology/pull/910
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
+        rdfs:label "currency"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+delete cost in oeo-social
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
+        rdfs:label "cost"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
+https://github.com/OpenEnergyPlatform/ontology/pull/644
+moved to oeo-shared and renamed
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+made subclass of good role
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "commodity role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+        rdfs:label "final energy consumption"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+moved to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "energy amount value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "funder"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "transport"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140004>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "international transport"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "freight transport"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "private transport"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "public transport"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
+        rdfs:label "sponsor"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "economic value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+        rdfs:label "consumption"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+        rdfs:label "demand"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000017>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+has quantity value axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to social cost of carbon
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission value"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00020181>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the process of combining various inputs in order to create an output that has value and can be used by other processes."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
+        rdfs:label "production"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240022>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
+        rdfs:label "protected area"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240024>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
+        rdfs:label "energy service demand"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140040>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000051>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240038>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
+        rdfs:label "personal living space"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -867,7 +2412,7 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
     SubClassOf: 
-        OEO_00140002 some OEO_00020143
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020143>
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -930,7 +2475,7 @@ issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090"
     
     SubClassOf: 
-        OEO_00020188 some OEO_00020185
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020188> some <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
     
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
@@ -943,7 +2488,7 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912"
     
     SubClassOf: 
-        OEO_00000514 some OEO_00020121
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000514> some <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
     
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
@@ -994,1503 +2539,58 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
         rdfs:comment "The original term from UO had neither an alternative term nor has_exact_synonym. It was added for OEO purposes to include the Eurostat spellings."@en
     
     
-Class: OEO_00000051
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020161>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
-        rdfs:label "agent"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00000061
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
-subclasses
-https://github.com/OpenEnergyPlatform/ontology/pull/128
-relation to space requirement
-https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>,
-        <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
-    
-    
-Class: OEO_00000064
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
-        rdfs:label "author"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00000087
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
-        rdfs:label "client"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00000107
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
-        rdfs:label "contact person"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00000147
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000500 some OEO_00000148
-    
-    
-Class: OEO_00000148
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission factor"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00000502 some <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000150
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
-fix grammar error:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
-adjust definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00000530 some OEO_00000316
-    
-    
-Class: OEO_00000151
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: OEO_00000206
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00000238
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        OEO_00030022
-    
-    
-Class: OEO_00000264
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "energy market model"
-    
-    SubClassOf: 
-        OEO_00000274
-    
-    
-Class: OEO_00000274
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
-
-add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "model"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some <http://purl.obolibrary.org/obo/BFO_0000004>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000275
-    
-    
-Class: OEO_00000275
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
-        rdfs:label "model calculation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140093 some OEO_00030029,
-        OEO_00140094 some OEO_00030030,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
-    
-    
-Class: OEO_00000315
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        OEO_00000323
-    
-    
-Class: OEO_00000316
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-change definition and add comment with examples:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
-* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
-* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
-    
-Class: OEO_00000323
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
-        rdfs:label "person"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    DisjointWith: 
-        OEO_00000315
-    
-    
-Class: OEO_00000331
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-definition update and editor note:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>,
-        OEO_00000530 some OEO_00000316
-    
-    
-Class: OEO_00000340
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "project"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00000350
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
-
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00000367
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: OEO_00000419
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "transformation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-Class: OEO_00000423
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "electricity transshipment model"
-    
-    SubClassOf: 
-        OEO_00000274
-    
-    
-Class: OEO_00010023
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
-    
-    SubClassOf: 
-        OEO_00000061
-    
-    
-Class: OEO_00010079
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
-        rdfs:label "emission quantity value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
-    
-    
-Class: OEO_00010116
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-make good a continuant:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "good"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-Class: OEO_00010117
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The role of a continuant over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-add relation to monetary price
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-update definition:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "good role"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00020180 some OEO_00040003
-    
-    
-Class: OEO_00010263
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
-    
-    
-Class: OEO_00010264
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        OEO_00000051,
-        OEO_00010121 some OEO_00000323
-    
-    
-Class: OEO_00010265
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
-    
-    
-Class: OEO_00010266
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
-    
-    
-Class: OEO_00020011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add covers-relation (oeo-model)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-add axiom (study report)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study"@en
-    
-    SubClassOf: 
-        OEO_00000340,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
-        OEO_00000509 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001),
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020012
-    
-    
-Class: OEO_00020012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study report"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000088>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000506 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064),
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002353> some OEO_00020011
-    
-    
-Class: OEO_00020015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
-move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "licence"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00020039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
-        rdfs:label "energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: OEO_00020063
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
-    
-    
-Class: OEO_00020066
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity role"
-    
-    SubClassOf: 
-        OEO_00040011
-    
-    
-Class: OEO_00020067
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
-subclass of good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-change axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "commodity"
-    
-    EquivalentTo: 
-        OEO_00010116
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-    
-    SubClassOf: 
-        OEO_00010116
-    
-    
-Class: OEO_00020068
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066
-    
-    SubClassOf: 
-        OEO_00020067
-    
-    
-Class: OEO_00020121
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "resolution"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: OEO_00020122
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-add individuals
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "temporal resolution"
-    
-    SubClassOf: 
-        OEO_00020121
-    
-    DisjointWith: 
-        OEO_00020123
-    
-    
-Class: OEO_00020123
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
-        rdfs:label "spatial resolution"
-    
-    SubClassOf: 
-        OEO_00020121
-    
-    DisjointWith: 
-        OEO_00020122
-    
-    
-Class: OEO_00020136
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-
-extend definition and add alternative term
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "space requirement"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
-    
-Class: OEO_00020140
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
-        rdfs:label "area per power unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00020142
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "square kilometer"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000047>
-    
-    
-Class: OEO_00020143
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "area value"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
-    
-    
-Class: OEO_00020154
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to emission certificate
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate price"
-    
-    SubClassOf: 
-        OEO_00040003,
-        OEO_00020179 some OEO_00020063
-    
-    
-Class: OEO_00020155
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission value, add new parent class and relable
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of carbon emission"
-    
-    SubClassOf: 
-        OEO_00020181,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
-Class: OEO_00020175
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "life time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
-    
-Class: OEO_00020176
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "construction time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
-    
-Class: OEO_00020177
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "decommissioning time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
-    
-Class: OEO_00020178
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "operational life time"
-    
-    SubClassOf: 
-        OEO_00020175
-    
-    
-Class: OEO_00020181
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of emission"
-    
-    SubClassOf: 
-        OEO_00040009,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
-Class: OEO_00020185
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "copyright license"
-    
-    SubClassOf: 
-        OEO_00020015
-    
-    
-Class: OEO_00020186
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "data license"
-    
-    SubClassOf: 
-        OEO_00020015
-    
-    
-Class: OEO_00020187
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "software license"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        OEO_00020185
-    
-    
-Class: OEO_00020201
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "import"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00020202
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "export"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00020204
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy amount value"
-    
-    SubClassOf: 
-        OEO_00050019
-    
-    
-Class: OEO_00020205
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020207
-    
-    
-Class: OEO_00020206
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020208
-    
-    
-Class: OEO_00020207
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import"
-    
-    SubClassOf: 
-        OEO_00020201,
-        OEO_00140002 some OEO_00020205
-    
-    
-Class: OEO_00020208
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export"
-    
-    SubClassOf: 
-        OEO_00020202,
-        OEO_00140002 some OEO_00020206
-    
-    
-Class: OEO_00030015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        OEO_00000274
-    
-    
-Class: OEO_00030019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    
-Class: OEO_00030022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
-added term in oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-deleted term in oeo-social:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
-        rdfs:label "organisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
-    
-    
-Class: OEO_00030029
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "exogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020189 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
-    
-    
-Class: OEO_00030030
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "endogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020190 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
-    
-    
-Class: OEO_00030031
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "start time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: OEO_00030032
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "ending time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: OEO_00030035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-change duration to time span (def, label, alternative term)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
-        rdfs:label "time span"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
-    
-    
-Class: OEO_00040003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "monetary price"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00020179 some OEO_00010117,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00040004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
-https://github.com/OpenEnergyPlatform/ontology/pull/640
-add comment and example
-https://github.com/OpenEnergyPlatform/ontology/pull/910
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
-        rdfs:label "currency"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00040009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-delete cost in oeo-social
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
-        rdfs:label "cost"@en
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00040011
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
-https://github.com/OpenEnergyPlatform/ontology/pull/644
-moved to oeo-shared and renamed
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-made subclass of good role
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "commodity role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
-    
-    SubClassOf: 
-        OEO_00010117
-    
-    
-Class: OEO_00050016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
-        rdfs:label "final energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00140039
-    
-    
-Class: OEO_00050019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-moved to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "energy amount value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: OEO_00090001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "funder"@en
-    
-    SubClassOf: 
-        OEO_00140009
-    
-    
-Class: OEO_00140003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "transport"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140004
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "international transport"@en
-    
-    SubClassOf: 
-        OEO_00140003
-    
-    
-Class: OEO_00140005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "freight transport"@en
-    
-    SubClassOf: 
-        OEO_00140003
-    
-    
-Class: OEO_00140006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "private transport"
-    
-    SubClassOf: 
-        OEO_00010263
-    
-    
-Class: OEO_00140007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "public transport"
-    
-    SubClassOf: 
-        OEO_00010263
-    
-    
-Class: OEO_00140009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
-        rdfs:label "sponsor"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00140012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "economic value"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
-    
-Class: OEO_00140039
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "consumption"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140040
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "demand"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000017>
-    
-    
-Class: OEO_00140081
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-has quantity value axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to social cost of carbon
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00020180 some OEO_00020181,
-        OEO_00140002 some OEO_00010079
-    
-    
-Class: OEO_00240003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the process of combining various inputs in order to create an output that has value and can be used by other processes."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
-        rdfs:label "production"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00240022
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
-        rdfs:label "protected area"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
-    
-Class: OEO_00240024
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
-        rdfs:label "energy service demand"
-    
-    SubClassOf: 
-        OEO_00140040,
-        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
-    
-    
-Class: OEO_00240038
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "personal living space"
-    
-    SubClassOf: 
-        OEO_00020136
-    
-    
-Individual: OEO_00020161
-
-    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
         rdfs:label "annual"
     
     Types: 
-        OEO_00020122
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
     
     
-Individual: OEO_00020162
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020162>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
         rdfs:label "weekly"
     
     Types: 
-        OEO_00020122
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
     
     
-Individual: OEO_00020163
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020163>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
         rdfs:label "daily"
     
     Types: 
-        OEO_00020122
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
     
     
-Individual: OEO_00020164
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020164>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
         rdfs:label "hourly"
     
     Types: 
-        OEO_00020122
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
     
     
-Individual: OEO_00020165
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020165>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
         rdfs:label "monthly"
     
     Types: 
-        OEO_00020122
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1,3 +1,4 @@
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -20,33 +21,6 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Shared module)"
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010037>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
-        rdfs:label "unique individual identifier"
-    
-    SubPropertyOf: 
-        dc:identifier
-    
-    
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00110012>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mathematical expression is an annotation property that describes the class with a mathematical formula in LaTeX syntax."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/987
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/990"@en,
-        rdfs:label "mathematical expression"@en
-    
-    
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
-
-    Annotations: 
-        rdfs:label "belongs to module"
-    
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -77,6 +51,33 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
+AnnotationProperty: OEO_00010037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
+        rdfs:label "unique individual identifier"
+    
+    SubPropertyOf: 
+        dc:identifier
+    
+    
+AnnotationProperty: OEO_00110012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mathematical expression is an annotation property that describes the class with a mathematical formula in LaTeX syntax."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/987
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/990"@en,
+        rdfs:label "mathematical expression"@en
+    
+    
+AnnotationProperty: OEO_00269001
+
+    Annotations: 
+        rdfs:label "belongs to module"
+    
+    
 AnnotationProperty: dc:description
 
     
@@ -100,551 +101,6 @@ Datatype: rdf:PlainLiteral
     
 Datatype: xsd:string
 
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domain and range; move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "has process attribute"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
-
-    Annotations: 
-        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472",
-        rdfs:label "is used by"
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000502>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "process attribute of"
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant and another continuant it requires to function.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
-https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
-https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
-https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)",
-        rdfs:label "uses"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000501>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000505>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers sector"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000506>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has auther' some ('has role' some author) is necessary, because has author has the range has role some author (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an idependent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has author"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000507>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has client"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000508>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contact person"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000509>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
-        rdfs:label "has funding source"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000510>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
-
-improve definition:
-https://github.com/OpenEnergyPlatform/ontology/issues/1038
-https://github.com/OpenEnergyPlatform/ontology/pull/1042
-
-Relabel to `has organisation`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
-        rdfs:label "has organisation"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-rework
-issue https://github.com/OpenEnergyPlatform/ontology/issues/849
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has resolution"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000515>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has spatial resolution"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000516>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-fix def and add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has temporal resolution"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
-        rdfs:label "covers"
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000523>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000530>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant or energy (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-extend range to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985",
-        rdfs:label "has bearer"@en
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-",
-        rdfs:label "has information content entity"@en
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
-        rdfs:label "quantity value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020179>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "economic value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020180>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "has economic value"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020188>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a copyright licence.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "has copyright license"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020189>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information input of p iff: c is an input of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information input of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002352>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020190>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information ouput of p iff: c is an output of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information output of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contributor"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274> or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140093>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information input"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140094>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information output"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "models"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -678,7 +134,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+        OEO_00010231
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
@@ -690,13 +146,13 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000020>
     
     InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
+        OEO_00010121
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
@@ -738,7 +194,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
     
     Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://purl.obolibrary.org/obo/BFO_0000004>
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -843,10 +299,555 @@ ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
         <http://purl.obolibrary.org/obo/UO_0000000>
     
     
+ObjectProperty: OEO_00000500
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domain and range; move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "has process attribute"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00030019
+    
+    InverseOf: 
+        OEO_00000502
+    
+    
+ObjectProperty: OEO_00000501
+
+    Annotations: 
+        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472",
+        rdfs:label "is used by"
+    
+    InverseOf: 
+        OEO_00000503
+    
+    
+ObjectProperty: OEO_00000502
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "process attribute of"
+    
+    Domain: 
+        OEO_00030019
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        OEO_00000500
+    
+    
+ObjectProperty: OEO_00000503
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant and another continuant it requires to function.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
+https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
+https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
+https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)",
+        rdfs:label "uses"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    InverseOf: 
+        OEO_00000501
+    
+    
+ObjectProperty: OEO_00000505
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers sector"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Domain: 
+        OEO_00020011
+    
+    Range: 
+        OEO_00000367
+    
+    
+ObjectProperty: OEO_00000506
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has auther' some ('has role' some author) is necessary, because has author has the range has role some author (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an idependent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has author"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
+    
+    
+ObjectProperty: OEO_00000507
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has client"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
+    
+    
+ObjectProperty: OEO_00000508
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contact person"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
+    
+    
+ObjectProperty: OEO_00000509
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
+        rdfs:label "has funding source"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Range: 
+        
+            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001
+    
+    
+ObjectProperty: OEO_00000510
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+
+improve definition:
+https://github.com/OpenEnergyPlatform/ontology/issues/1038
+https://github.com/OpenEnergyPlatform/ontology/pull/1042
+
+Relabel to `has organisation`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
+        rdfs:label "has organisation"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
+    
+ObjectProperty: OEO_00000514
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+rework
+issue https://github.com/OpenEnergyPlatform/ontology/issues/849
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has resolution"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020121
+    
+    
+ObjectProperty: OEO_00000515
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has spatial resolution"
+    
+    SubPropertyOf: 
+        OEO_00000514
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020123
+    
+    
+ObjectProperty: OEO_00000516
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+fix def and add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "has temporal resolution"
+    
+    SubPropertyOf: 
+        OEO_00000514
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020122
+    
+    
+ObjectProperty: OEO_00000522
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
+        rdfs:label "covers"
+    
+    
+ObjectProperty: OEO_00000523
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers energy carrier"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Domain: 
+        OEO_00020011
+    
+    Range: 
+        OEO_00020039
+    
+    
+ObjectProperty: OEO_00000530
+
+    
+ObjectProperty: OEO_00010121
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant or energy (the dependent) and an independent continuant (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
+
+extend range to energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985",
+        rdfs:label "has bearer"@en
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
+    Range: 
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/RO_0000053>
+    
+    
+ObjectProperty: OEO_00010231
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
+",
+        rdfs:label "has information content entity"@en
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    
+ObjectProperty: OEO_00020056
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
+        rdfs:label "quantity value of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    InverseOf: 
+        OEO_00140002
+    
+    
+ObjectProperty: OEO_00020179
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "economic value of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    
+ObjectProperty: OEO_00020180
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "has economic value"
+    
+    SubPropertyOf: 
+        OEO_00010231
+    
+    
+ObjectProperty: OEO_00020188
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a copyright licence.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "has copyright license"
+    
+    SubPropertyOf: 
+        OEO_00010231
+    
+    
+ObjectProperty: OEO_00020189
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information input of p iff: c is an input of p, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "information input of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002352>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+ObjectProperty: OEO_00020190
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information ouput of p iff: c is an output of p, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "information output of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002353>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+ObjectProperty: OEO_00040010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+ObjectProperty: OEO_00140002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+        rdfs:label "has quantity value"@en
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00010231
+    
+    Range: 
+        
+            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        OEO_00000350
+    
+    InverseOf: 
+        OEO_00020056
+    
+    
+ObjectProperty: OEO_00140008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contributor"@en
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+ObjectProperty: OEO_00140093
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information input"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: OEO_00140094
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information output"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+ObjectProperty: OEO_00140164
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+        rdfs:label "models"@en
+    
+    Domain: 
+        OEO_00000274
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140178>
+DataProperty: OEO_00140178
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
@@ -855,1549 +856,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/840",
         rdfs:label "has number"@en
     
     Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
-        rdfs:label "agent"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
-subclasses
-https://github.com/OpenEnergyPlatform/ontology/pull/128
-relation to space requirement
-https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>,
-        <http://purl.obolibrary.org/obo/RO_0002328> some <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
-        rdfs:label "author"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
-        rdfs:label "client"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
-        rdfs:label "contact person"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000500> some <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000148>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission factor"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000150>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
-fix grammar error:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
-adjust definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000151>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000206>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000238>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000264>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market."^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "energy market model"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
-
-add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "model"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://purl.obolibrary.org/obo/BFO_0000004>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
-        rdfs:label "model calculation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140093> some <http://openenergy-platform.org/ontology/oeo/OEO_00030029>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140094> some <http://openenergy-platform.org/ontology/oeo/OEO_00030030>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-change definition and add comment with examples:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
-* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
-* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000150> or <http://openenergy-platform.org/ontology/oeo/OEO_00000331>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
-        rdfs:label "person"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000331>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-definition update and editor note:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000530> some <http://openenergy-platform.org/ontology/oeo/OEO_00000316>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000340>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "project"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
-
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000419>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "transformation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000423>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "electricity transshipment model"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010023>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
-        rdfs:label "vehicle",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
-        rdfs:label "emission quantity value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-make good a continuant:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "good"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00010117>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The role of a continuant over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-add relation to monetary price
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-update definition:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "good role"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010023>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00010264>))
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010264>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010265>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240024>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010266>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00240024>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some <http://openenergy-platform.org/ontology/oeo/OEO_00140005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add covers-relation (oeo-model)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-add axiom (study report)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000340>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000509> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00090001>),
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study report"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000088>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000506> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000064>),
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002353> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
-move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "licence"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
-        rdfs:label "energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some <http://openenergy-platform.org/ontology/oeo/OEO_00000151>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00020154>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity role"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
-subclass of good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-change axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "commodity"
-    
-    EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>)
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "resolution"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-add individuals
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "temporal resolution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020123>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
-        rdfs:label "spatial resolution"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-
-extend definition and add alternative term
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "space requirement"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020140>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
-        rdfs:label "area per power unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020142>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "square kilometer"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000047>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020143>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "area value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://purl.obolibrary.org/obo/BFO_0000009>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000047>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020154>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to emission certificate
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate price"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020155>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission value, add new parent class and relable
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of carbon emission"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020181>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020175>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "life time"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020176>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "construction time"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020177>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "decommissioning time"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020178>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "operational life time"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020175>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020181>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of emission"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "copyright license"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020186>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "data license"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020187>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "software license"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020201>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "import"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020202>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "export"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020204>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy amount value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020205>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020204>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020206>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export value"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020204>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020207>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020201>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020205>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020208>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020202>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020206>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030015>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
-added term in oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-deleted term in oeo-social:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
-        rdfs:label "organisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "exogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020189> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "endogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020190> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030031>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "start time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030032>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "ending time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-change duration to time span (def, label, alternative term)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
-        rdfs:label "time span"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://purl.obolibrary.org/obo/BFO_0000038>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "monetary price"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020179> some <http://openenergy-platform.org/ontology/oeo/OEO_00010117>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
-https://github.com/OpenEnergyPlatform/ontology/pull/640
-add comment and example
-https://github.com/OpenEnergyPlatform/ontology/pull/910
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
-        rdfs:label "currency"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-delete cost in oeo-social
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
-        rdfs:label "cost"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
-https://github.com/OpenEnergyPlatform/ontology/pull/644
-moved to oeo-shared and renamed
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-made subclass of good role
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "commodity role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
-        rdfs:label "final energy consumption"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050019>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-moved to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "energy amount value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000111>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "funder"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "transport"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140004>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "international transport"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "freight transport"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "private transport"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "public transport"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010263>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
-        rdfs:label "sponsor"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "economic value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140039>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "consumption"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "demand"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000017>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140081>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-has quantity value axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to social cost of carbon
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030019>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000502> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00020181>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the process of combining various inputs in order to create an output that has value and can be used by other processes."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
-        rdfs:label "production"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240022>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
-        rdfs:label "protected area"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240024>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
-        rdfs:label "energy service demand"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140040>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000051>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240038>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "personal living space"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020136>
+        OEO_00000350
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -2412,7 +871,7 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00020143>
+        OEO_00140002 some OEO_00020143
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -2475,7 +934,7 @@ issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020188> some <http://openenergy-platform.org/ontology/oeo/OEO_00020185>
+        OEO_00020188 some OEO_00020185
     
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
@@ -2488,7 +947,7 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912"
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000514> some <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+        OEO_00000514 some OEO_00020121
     
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
@@ -2539,58 +998,1600 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
         rdfs:comment "The original term from UO had neither an alternative term nor has_exact_synonym. It was added for OEO purposes to include the Eurostat spellings."@en
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020161>
+Class: OEO_00000051
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
+        rdfs:label "agent"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00000061
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
+subclasses
+https://github.com/OpenEnergyPlatform/ontology/pull/128
+relation to space requirement
+https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "artificial object"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>,
+        <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
+    
+    
+Class: OEO_00000064
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
+        rdfs:label "author"
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00000087
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
+        rdfs:label "client"
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00000107
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
+        rdfs:label "contact person"
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00000147
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000500 some OEO_00000148
+    
+    
+Class: OEO_00000148
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "emission factor"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147,
+        OEO_00000502 some <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000150
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
+fix grammar error:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
+adjust definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00000530 some OEO_00000316
+    
+    
+Class: OEO_00000151
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00000206
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
+        rdfs:label "hardware"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00000238
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "institution"
+    
+    SubClassOf: 
+        OEO_00030022
+    
+    
+Class: OEO_00000264
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market."^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+        rdfs:label "energy market model"
+    
+    SubClassOf: 
+        OEO_00000274
+    
+    
+Class: OEO_00000274
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
+
+add axiom to model calculation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "model"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        OEO_00140164 some <http://purl.obolibrary.org/obo/BFO_0000004>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000275
+    
+    
+Class: OEO_00000275
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
+        rdfs:label "model calculation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00140093 some OEO_00030029,
+        OEO_00140094 some OEO_00030030,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
+    
+    
+Class: OEO_00000315
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "organisation role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    DisjointWith: 
+        OEO_00000323
+    
+    
+Class: OEO_00000316
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+change definition and add comment with examples:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
+        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
+* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
+* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
+        rdfs:label "origin"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some 
+            (OEO_00000150 or OEO_00000331)
+    
+    
+Class: OEO_00000323
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
+        rdfs:label "person"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>
+    
+    DisjointWith: 
+        OEO_00000315
+    
+    
+Class: OEO_00000331
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+definition update and editor note:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>,
+        OEO_00000530 some OEO_00000316
+    
+    
+Class: OEO_00000340
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "project"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00000350
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
+
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
+        rdfs:label "quantity value",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00000367
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+        rdfs:label "sector"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: OEO_00000419
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+        rdfs:label "transformation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+Class: OEO_00000423
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "electricity transshipment model"
+    
+    SubClassOf: 
+        OEO_00000274
+    
+    
+Class: OEO_00010023
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+        rdfs:label "vehicle",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00010079
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
+        rdfs:label "emission quantity value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
+    
+    
+Class: OEO_00010116
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+make good a continuant:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "good"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+Class: OEO_00010117
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The role of a continuant over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+add relation to monetary price
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+update definition:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "good role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00020180 some OEO_00040003
+    
+    
+Class: OEO_00010263
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "passenger transport"
+    
+    SubClassOf: 
+        OEO_00140003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000323
+             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
+    
+    
+Class: OEO_00010264
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "passenger"
+    
+    SubClassOf: 
+        OEO_00000051,
+        OEO_00010121 some OEO_00000323
+    
+    
+Class: OEO_00010265
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "energy service demand for passenger-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
+    
+    
+Class: OEO_00010266
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "energy service demand for ton-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
+    
+    
+Class: OEO_00020011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
+add covers-relation (oeo-model)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+add axiom (study report)
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+add etitor note
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
+        rdfs:label "study"@en
+    
+    SubClassOf: 
+        OEO_00000340,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
+        OEO_00000509 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001),
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020012
+    
+    
+Class: OEO_00020012
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
+add etitor note
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
+        rdfs:label "study report"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000088>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        OEO_00000506 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064),
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/RO_0002353> some OEO_00020011
+    
+    
+Class: OEO_00020015
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
+move to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "licence"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00020039
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
+        rdfs:label "energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00020063
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+moved to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission quantity value and emission certificate price
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission certificate"
+    
+    SubClassOf: 
+        OEO_00020015,
+        OEO_00020180 some OEO_00020154,
+        OEO_00140002 some OEO_00010079
+    
+    
+Class: OEO_00020066
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel commodity role"
+    
+    SubClassOf: 
+        OEO_00040011
+    
+    
+Class: OEO_00020067
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+add alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
+subclass of good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+change axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+        rdfs:label "commodity"
+    
+    EquivalentTo: 
+        OEO_00010116
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
+    
+    SubClassOf: 
+        OEO_00010116
+    
+    
+Class: OEO_00020068
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel commodity"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066
+    
+    SubClassOf: 
+        OEO_00020067
+    
+    
+Class: OEO_00020121
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "resolution"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00020122
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
+add individuals
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+        rdfs:label "temporal resolution"
+    
+    SubClassOf: 
+        OEO_00020121
+    
+    DisjointWith: 
+        OEO_00020123
+    
+    
+Class: OEO_00020123
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
+        rdfs:label "spatial resolution"
+    
+    SubClassOf: 
+        OEO_00020121
+    
+    DisjointWith: 
+        OEO_00020122
+    
+    
+Class: OEO_00020136
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+
+extend definition and add alternative term
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
+        rdfs:label "space requirement"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
+Class: OEO_00020140
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
+        rdfs:label "area per power unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00020142
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "square kilometer"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000047>
+    
+    
+Class: OEO_00020143
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
+        rdfs:label "area value"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
+    
+    
+Class: OEO_00020154
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to emission certificate
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission certificate price"
+    
+    SubClassOf: 
+        OEO_00040003,
+        OEO_00020179 some OEO_00020063
+    
+    
+Class: OEO_00020155
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission value, add new parent class and relable
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "social cost of carbon emission"
+    
+    SubClassOf: 
+        OEO_00020181,
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
+    
+Class: OEO_00020175
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "life time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020176
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "construction time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020177
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "decommissioning time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020178
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
+        rdfs:label "operational life time"
+    
+    SubClassOf: 
+        OEO_00020175
+    
+    
+Class: OEO_00020181
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "social cost of emission"
+    
+    SubClassOf: 
+        OEO_00040009,
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
+    
+Class: OEO_00020185
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "copyright license"
+    
+    SubClassOf: 
+        OEO_00020015
+    
+    
+Class: OEO_00020186
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "data license"
+    
+    SubClassOf: 
+        OEO_00020015
+    
+    
+Class: OEO_00020187
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+        rdfs:label "software license"
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
+        OEO_00020185
+    
+    
+Class: OEO_00020201
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "import"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00020202
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "export"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00020204
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electrical energy amount value"
+    
+    SubClassOf: 
+        OEO_00050019
+    
+    
+Class: OEO_00020205
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity import value"
+    
+    SubClassOf: 
+        OEO_00020204,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020207
+    
+    
+Class: OEO_00020206
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity export value"
+    
+    SubClassOf: 
+        OEO_00020204,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020208
+    
+    
+Class: OEO_00020207
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity import"
+    
+    SubClassOf: 
+        OEO_00020201,
+        OEO_00140002 some OEO_00020205
+    
+    
+Class: OEO_00020208
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "electricity export"
+    
+    SubClassOf: 
+        OEO_00020202,
+        OEO_00140002 some OEO_00020206
+    
+    
+Class: OEO_00030015
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "energy system model"@en
+    
+    SubClassOf: 
+        OEO_00000274
+    
+    
+Class: OEO_00030019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+        rdfs:label "process attribute"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    
+Class: OEO_00030022
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
+added term in oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+deleted term in oeo-social:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
+        rdfs:label "organisation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
+    
+Class: OEO_00030029
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "exogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (OEO_00020189 some OEO_00000275)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+    
+    
+Class: OEO_00030030
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
+        rdfs:label "endogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (OEO_00020190 some OEO_00000275)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+    
+    
+Class: OEO_00030031
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "start time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00030032
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
+        rdfs:label "ending time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: OEO_00030035
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+change duration to time span (def, label, alternative term)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
+        rdfs:label "time span"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
+    
+    
+Class: OEO_00040003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "monetary price"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
+    
+    SubClassOf: 
+        OEO_00140012,
+        OEO_00020179 some OEO_00010117,
+        OEO_00040010 some OEO_00040004
+    
+    
+Class: OEO_00040004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
+https://github.com/OpenEnergyPlatform/ontology/pull/640
+add comment and example
+https://github.com/OpenEnergyPlatform/ontology/pull/910
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
+        rdfs:label "currency"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00040009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+delete cost in oeo-social
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
+        rdfs:label "cost"@en
+    
+    SubClassOf: 
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
+    
+    
+Class: OEO_00040011
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
+https://github.com/OpenEnergyPlatform/ontology/pull/644
+moved to oeo-shared and renamed
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+made subclass of good role
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "commodity role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
+    
+    SubClassOf: 
+        OEO_00010117
+    
+    
+Class: OEO_00050016
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+        rdfs:label "final energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00140039
+    
+    
+Class: OEO_00050019
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+moved to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+        rdfs:label "energy amount value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00090001
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "funder"@en
+    
+    SubClassOf: 
+        OEO_00140009
+    
+    
+Class: OEO_00140003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "transport"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140004
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "international transport"@en
+    
+    SubClassOf: 
+        OEO_00140003
+    
+    
+Class: OEO_00140005
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+        rdfs:label "freight transport"@en
+    
+    SubClassOf: 
+        OEO_00140003
+    
+    
+Class: OEO_00140006
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "private transport"
+    
+    SubClassOf: 
+        OEO_00010263
+    
+    
+Class: OEO_00140007
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
+        rdfs:label "public transport"
+    
+    SubClassOf: 
+        OEO_00010263
+    
+    
+Class: OEO_00140009
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
+        rdfs:label "sponsor"@en
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00140012
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "economic value"@en
+    
+    SubClassOf: 
+        OEO_00000350
+    
+    
+Class: OEO_00140039
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+        rdfs:label "consumption"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140040
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+        rdfs:label "demand"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000017>
+    
+    
+Class: OEO_00140081
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+has quantity value axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to social cost of carbon
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+        rdfs:label "emission value"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147,
+        OEO_00020180 some OEO_00020181,
+        OEO_00140002 some OEO_00010079
+    
+    
+Class: OEO_00240003
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the process of combining various inputs in order to create an output that has value and can be used by other processes."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
+        rdfs:label "production"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00240022
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
+        rdfs:label "protected area"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
+Class: OEO_00240024
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
+        rdfs:label "energy service demand"
+    
+    SubClassOf: 
+        OEO_00140040,
+        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
+    
+    
+Class: OEO_00240038
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
+        rdfs:label "personal living space"
+    
+    SubClassOf: 
+        OEO_00020136
+    
+    
+Individual: OEO_00020161
+
+    Annotations: 
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
         rdfs:label "annual"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+        OEO_00020122
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020162>
+Individual: OEO_00020162
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
         rdfs:label "weekly"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+        OEO_00020122
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020163>
+Individual: OEO_00020163
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
         rdfs:label "daily"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+        OEO_00020122
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020164>
+Individual: OEO_00020164
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
         rdfs:label "hourly"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+        OEO_00020122
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00020165>
+Individual: OEO_00020165
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
         rdfs:label "monthly"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020122>
+        OEO_00020122
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -63,6 +63,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         dc:identifier
     
     
+AnnotationProperty: OEO_00040001
+
+    Annotations: 
+        rdfs:label "belongs to module"
+    
+    
 AnnotationProperty: OEO_00110012
 
     Annotations: 
@@ -70,12 +76,6 @@ AnnotationProperty: OEO_00110012
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/987
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/990"@en,
         rdfs:label "mathematical expression"@en
-    
-    
-AnnotationProperty: OEO_00269001
-
-    Annotations: 
-        rdfs:label "belongs to module"
     
     
 AnnotationProperty: dc:description
@@ -1001,7 +1001,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
 Class: OEO_00000051
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
@@ -1014,7 +1014,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
 Class: OEO_00000061
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
@@ -1032,7 +1032,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00000064
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
         rdfs:label "author"
     
@@ -1043,7 +1043,7 @@ Class: OEO_00000064
 Class: OEO_00000087
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
         rdfs:label "client"
     
@@ -1054,7 +1054,7 @@ Class: OEO_00000087
 Class: OEO_00000107
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
         rdfs:label "contact person"
     
@@ -1065,7 +1065,7 @@ Class: OEO_00000107
 Class: OEO_00000147
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing byproducts from human activity (e.g. production, distribution or consumption) into the environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -1081,7 +1081,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00000148
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
@@ -1098,7 +1098,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00000150
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
@@ -1132,7 +1132,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000151
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
@@ -1154,7 +1154,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
 Class: OEO_00000206
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
@@ -1167,7 +1167,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
 Class: OEO_00000238
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
@@ -1180,7 +1180,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
 Class: OEO_00000264
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market."^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
@@ -1193,7 +1193,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
 Class: OEO_00000274
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
@@ -1217,7 +1217,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000275
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
@@ -1238,7 +1238,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
 Class: OEO_00000315
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1255,7 +1255,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00000316
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -1289,7 +1289,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
 Class: OEO_00000323
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
         rdfs:label "person"
     
@@ -1303,7 +1303,7 @@ Class: OEO_00000323
 Class: OEO_00000331
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
@@ -1331,7 +1331,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
 Class: OEO_00000340
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
@@ -1347,7 +1347,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
 Class: OEO_00000350
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
@@ -1372,7 +1372,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000367
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
@@ -1387,7 +1387,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
 Class: OEO_00000419
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
@@ -1406,7 +1406,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
 Class: OEO_00000423
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
@@ -1419,7 +1419,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
 Class: OEO_00010023
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
@@ -1436,7 +1436,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010079
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
@@ -1450,7 +1450,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
 Class: OEO_00010116
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
@@ -1472,7 +1472,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
 Class: OEO_00010117
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The role of a continuant over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
@@ -1492,7 +1492,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
 Class: OEO_00010263
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
@@ -1509,7 +1509,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00010264
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
@@ -1523,7 +1523,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00010265
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
@@ -1537,7 +1537,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00010266
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
@@ -1551,7 +1551,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00020011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
@@ -1581,7 +1581,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
 Class: OEO_00020012
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
@@ -1605,7 +1605,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
 Class: OEO_00020015
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
@@ -1621,7 +1621,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
 Class: OEO_00020039
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
@@ -1643,7 +1643,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
 Class: OEO_00020063
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
@@ -1662,7 +1662,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020066
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/748",
@@ -1675,7 +1675,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00020067
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
@@ -1698,7 +1698,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
 Class: OEO_00020068
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
@@ -1714,7 +1714,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00020121
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
@@ -1727,7 +1727,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
 Class: OEO_00020122
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
@@ -1745,7 +1745,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
 Class: OEO_00020123
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
@@ -1761,7 +1761,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
 Class: OEO_00020136
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
@@ -1779,7 +1779,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
 Class: OEO_00020140
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
@@ -1792,7 +1792,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
 Class: OEO_00020142
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
         <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
         <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
@@ -1807,7 +1807,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020143
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -1822,7 +1822,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020154
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1839,7 +1839,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020155
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1857,7 +1857,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020175
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
@@ -1871,7 +1871,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
 Class: OEO_00020176
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
@@ -1885,7 +1885,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
 Class: OEO_00020177
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
@@ -1899,7 +1899,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
 Class: OEO_00020178
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
@@ -1912,7 +1912,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
 Class: OEO_00020181
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
@@ -1927,7 +1927,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020185
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
@@ -1941,7 +1941,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
 Class: OEO_00020186
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
@@ -1954,7 +1954,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
 Class: OEO_00020187
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
@@ -1971,7 +1971,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
 Class: OEO_00020201
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -1985,7 +1985,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020202
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -1999,7 +1999,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020204
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
@@ -2012,7 +2012,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020205
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
@@ -2026,7 +2026,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020206
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
@@ -2040,7 +2040,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020207
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -2055,7 +2055,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00020208
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -2070,7 +2070,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00030015
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
@@ -2083,7 +2083,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
 Class: OEO_00030019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
@@ -2096,7 +2096,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
 Class: OEO_00030022
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
@@ -2116,7 +2116,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
 Class: OEO_00030029
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
@@ -2141,7 +2141,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00030030
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
@@ -2165,7 +2165,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00030031
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
@@ -2178,7 +2178,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030032
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
@@ -2191,7 +2191,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
 Class: OEO_00030035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -2209,7 +2209,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
 Class: OEO_00040003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
@@ -2230,7 +2230,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00040004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
@@ -2251,7 +2251,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00040009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
@@ -2271,7 +2271,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
 Class: OEO_00040011
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
@@ -2290,7 +2290,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
 Class: OEO_00050016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
@@ -2303,7 +2303,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
 Class: OEO_00050019
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
@@ -2321,7 +2321,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
 Class: OEO_00090001
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
@@ -2334,7 +2334,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
 Class: OEO_00140003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
@@ -2351,7 +2351,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00140004
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
@@ -2364,7 +2364,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
 Class: OEO_00140005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
@@ -2377,7 +2377,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
 Class: OEO_00140006
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -2394,7 +2394,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00140007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -2411,7 +2411,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
 Class: OEO_00140009
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
@@ -2424,7 +2424,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
 Class: OEO_00140012
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
@@ -2439,7 +2439,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00140039
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
@@ -2452,7 +2452,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
 Class: OEO_00140040
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
@@ -2465,7 +2465,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
 Class: OEO_00140081
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -2489,7 +2489,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00240003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the process of combining various inputs in order to create an output that has value and can be used by other processes."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
@@ -2502,7 +2502,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
 Class: OEO_00240022
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
@@ -2515,7 +2515,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
 Class: OEO_00240024
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
@@ -2530,7 +2530,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
 Class: OEO_00240038
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
@@ -2543,7 +2543,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
 Individual: OEO_00020161
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
         rdfs:label "annual"
     
@@ -2554,7 +2554,7 @@ Individual: OEO_00020161
 Individual: OEO_00020162
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
         rdfs:label "weekly"
     
@@ -2565,7 +2565,7 @@ Individual: OEO_00020162
 Individual: OEO_00020163
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
         rdfs:label "daily"
     
@@ -2576,7 +2576,7 @@ Individual: OEO_00020163
 Individual: OEO_00020164
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
         rdfs:label "hourly"
     
@@ -2587,7 +2587,7 @@ Individual: OEO_00020164
 Individual: OEO_00020165
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
         rdfs:label "monthly"
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1,4 +1,5 @@
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
+Prefix: oeo: <http://openenergy-platform.org/ontology/oeo/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -7,7 +8,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social/>
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social.omn>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
 
@@ -16,12 +17,6 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (social module)"
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010037>
-
-    
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
-
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -58,6 +53,12 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:identifier
 
     
+AnnotationProperty: oeo:OEO_00010037
+
+    
+AnnotationProperty: oeo:OEO_00269001
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -74,205 +75,6 @@ Datatype: rdf:PlainLiteral
 
     
 Datatype: xsd:string
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000504>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
-
-domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-
-adapt domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "is defined by"
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000505>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000506>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000507>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000508>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000509>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000510>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010119>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
-        rdfs:label "guides"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000056>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010128>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
-        rdfs:label "governs"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140150> or <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010232>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
-        rdfs:label "has memo item"
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020070>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-change range: 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/791
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842
-
-add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "is traded at"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010116> or <http://openenergy-platform.org/ontology/oeo/OEO_00020067> or <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020071>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020071>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-add domain and range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "trades"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010116> or <http://openenergy-platform.org/ontology/oeo/OEO_00020067> or <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020070>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
-
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140017>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
-        rdfs:label "member of"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140018>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
-        rdfs:label "has member"@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-    
-    Range: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-    
-    
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -296,1575 +98,207 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
-ObjectProperty: owl:topObjectProperty
+ObjectProperty: oeo:OEO_00000503
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000045>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "producer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000105>
+ObjectProperty: oeo:OEO_00000504
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
-        rdfs:label "consumer"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
+
+domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+
+adapt domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "is defined by"
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000431>
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
+ObjectProperty: oeo:OEO_00000505
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+ObjectProperty: oeo:OEO_00000506
 
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1015"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "energy demand sector"
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000145>
+ObjectProperty: oeo:OEO_00000507
 
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "electricity sector"
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+ObjectProperty: oeo:OEO_00000508
+
     
+ObjectProperty: oeo:OEO_00000509
+
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+ObjectProperty: oeo:OEO_00000510
+
+    
+ObjectProperty: oeo:OEO_00000522
+
+    
+ObjectProperty: oeo:OEO_00010119
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "energy transformation sector"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+        rdfs:label "guides"@en
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000056>
+    
+    Domain: 
+        oeo:OEO_00140151
+    
+    Range: 
+        oeo:OEO_00140149
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000213>
+ObjectProperty: oeo:OEO_00010121
+
+    
+ObjectProperty: oeo:OEO_00010128
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "heating and cooling sector"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
+        rdfs:label "governs"@en
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    Domain: 
+        oeo:OEO_00140150 or oeo:OEO_00140151
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000214>
+ObjectProperty: oeo:OEO_00010231
+
+    
+ObjectProperty: oeo:OEO_00010232
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "household sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "industry sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000238>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000264>
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00020065>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000329>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
-        rdfs:label "political party"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000341>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
-        rdfs:label "prosumer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000379>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
-        rdfs:label "software developer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000405>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "trading, commerce and service sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "commercial sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "transport sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000431>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
-        rdfs:label "user"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010034>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "building sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "agriculture, forestry and land use sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "waste and wastewater sector"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
-        rdfs:label "common reporting format"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010082>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
-        rdfs:label "trade"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010083>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-update definition and improve axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019",
-        rdfs:label "market participant"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010082>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010115>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "economy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010123>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
-        rdfs:label "effort sharing"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
-        rdfs:label "Annual Emission Allocation"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010136>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
-        rdfs:label "distribution"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010212>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
-        rdfs:label "decarbonisation pathway"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
-        rdfs:label "memo item"@en
+        rdfs:label "has memo item"
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    SubPropertyOf: 
+        oeo:OEO_00010231
+    
+    Domain: 
+        oeo:OEO_00000367
+    
+    Range: 
+        oeo:OEO_00010227
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
+ObjectProperty: oeo:OEO_00020056
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020060>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel market exchange"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020065>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020071> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00020066>)
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020064>
+ObjectProperty: oeo:OEO_00020070
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "EU allowance"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020065>
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "energy market exchange"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
+change range: 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/791
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842
 
+add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "is traded at"
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "product"
+    SubPropertyOf: 
+        owl:topObjectProperty
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020070> some <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
-
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020070> some <http://openenergy-platform.org/ontology/oeo/OEO_00020060>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
+    Domain: 
         
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019"
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00010082>
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010083>))
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
+        oeo:OEO_00010116 or oeo:OEO_00020067 or oeo:OEO_00140124
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
+    
+    InverseOf: 
+        oeo:OEO_00020071
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020075>
+ObjectProperty: oeo:OEO_00020071
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
-        rdfs:label "emission market exchange"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020069>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020071> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020076>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
-        rdfs:label "markup"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020077>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
-        rdfs:label "markdown"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020108>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:comment "Feed-in tariffs provide cost-based compensation to renewable energy producers, leading to price certainty and long-term contracts that help finance energy transformation units, e.g. power plants",
-        rdfs:label "feed-in tariff"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020109>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "market premium"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020110>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "levy"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020111>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "capacity premium"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020109>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020112>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "tax"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020110>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020113>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:label "inflation rate"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020114>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:comment "The ratio at which one can exchange one currency for another can differ over time therefore it is necessary to specify a time point when referring to an exchange rate.",
-        rdfs:label "exchange rate"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020115>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        <http://purl.org/dc/terms/source> "https://www.oecd.org/sdd/prices-ppp/purchasingpowerparities-frequentlyaskedquestionsfaqs.htm#FAQ1",
-        rdfs:label "purchasing power parity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020116>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:label "system cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020117>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:comment "has unit some \"currency per energy unit\"",
-        rdfs:label "electricity price"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020124>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "due"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020125>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "remuneration"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020126>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "fee"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020127>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:comment "Since over the lifetime of an energy transformation unit different costs exhibit different relevance or vary over time, the LCOE differ over the course of the lifetime.",
-        rdfs:label "levelised cost of electricity"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020128>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add term
-https://github.com/OpenEnergyPlatform/ontology/issues/908
-https://github.com/OpenEnergyPlatform/ontology/pull/929",
-        rdfs:label "market revenue"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020145>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
-        rdfs:label "variable cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020146>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
-        rdfs:label "variable production cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020145>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020156>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "carbon tax"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020112>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "investment",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "FIBO definition of investment relates to property only: https://spec.edmcouncil.org/fibo/ontology?searchBoxQuery=investment, 
-
-Gabler on Investition: langfristige Bindung finanzieller Mittel in materiellen oder in immateriellen Vermögensgegenständen (https://wirtschaftslexikon.gabler.de/definition/investition-39454)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "investment cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020168>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "oemof-Model: https://oemof-solph.readthedocs.io/en/latest/_modules/oemof/solph/options.html?highlight=fix%20costs
-
-Fixe Kosten: Kosten, die von der jeweils betrachteten Einflussgröße bzw. Entscheidung unabhängig sind, d.h. Kosten, die sich nicht mit der jeweils betrachteten Einflussgröße ändern. (https://wirtschaftslexikon.gabler.de/definition/fixe-kosten-33359)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "fixed cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020169>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "equipment cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020170>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "site development cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "installation cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020171>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "grid connection cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020172>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "property cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020173>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "decommissioning cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020174>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "delivery cost"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisational energy producer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000045>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:comment "They may be privately or publicly owned.",
-        rdfs:label "energy autoproducer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030018>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
-        rdfs:label "main activity energy producer"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639
-
-https://github.com/OpenEnergyPlatform/ontology/issues/677
-https://github.com/OpenEnergyPlatform/ontology/pull/740
-
-change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/377
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/641
-
-Make trader subclass of market participant:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-https://github.com/OpenEnergyPlatform/ontology/pull/745",
-        rdfs:label "trader"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Trader"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010083>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040006>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "request"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040007>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "price request"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040006>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040008>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "marginal cost"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090002>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "public funder"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090003>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "private funder"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140013>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
-alternative term:
-https://github.com/OpenEnergyPlatform/ontology/issues/675
-https://github.com/OpenEnergyPlatform/ontology/pull/676",
-        rdfs:label "gross domestic product"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140023>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563
-alternative term:
-https://github.com/OpenEnergyPlatform/ontology/issues/675
-https://github.com/OpenEnergyPlatform/ontology/pull/676",
-        rdfs:label "gross value added"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
-
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140109>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
-        rdfs:label "contract"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140117>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "delivery time"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140118>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "delivery time point"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140119>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "sender"@en
+add domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "trades"
     
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    SubPropertyOf: 
+        owl:topObjectProperty
     
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140120>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "receiver"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140121>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "bid"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140122>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "award"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140123>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:comment "The transfer is typically defined in a contract.",
-        rdfs:label "provider"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "service"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140125>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:comment "This duration is often contractually fixed and regular.",
-        rdfs:label "delivery interval"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140130>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "power plant operator"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140131>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "conventional trader"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140136>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
-        rdfs:label "dispatch assignment"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140137>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
-        rdfs:label "power plant portfolio"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140140>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "demand trader"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140141>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "merit order"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140143>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "direct marketer"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140146>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
-        rdfs:label "energy demand"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
-        rdfs:label "transformative measure"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
-        rdfs:label "policy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
-        rdfs:label "policy instrument"@en
+    Domain: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
+    Range: 
         
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010119> some <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
+        oeo:OEO_00010116 or oeo:OEO_00020067 or oeo:OEO_00140124
+    
+    InverseOf: 
+        oeo:OEO_00020070
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140171>
+ObjectProperty: oeo:OEO_00040010
+
+    
+ObjectProperty: oeo:OEO_00140008
+
+    
+ObjectProperty: oeo:OEO_00140017
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
-        rdfs:label "email address"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
+        rdfs:label "member of"@en
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
+    Domain: 
+        oeo:OEO_00000323
+    
+    Range: 
+        oeo:OEO_00030022
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+ObjectProperty: oeo:OEO_00140018
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "population"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
+        rdfs:label "has member"@en
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
+    SubPropertyOf: 
+        owl:topObjectProperty
     
+    Domain: 
+        oeo:OEO_00030022
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230014>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "urban population"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230015>
+    Range: 
+        oeo:OEO_00000323
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230015>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
-https://github.com/OpenEnergyPlatform/ontology/issues/479
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "rural population"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
-    
-    DisjointWith: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230014>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230016>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "labour force"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230017>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
-https://github.com/OpenEnergyPlatform/ontology/issues/479
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "working age population"@en
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
+ObjectProperty: oeo:OEO_00140164
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240021>
+ObjectProperty: owl:topObjectProperty
 
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
-        rdfs:label "discount rate"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000187>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240036>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
-        rdfs:label "import price"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-    
-    
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240037>
-
-    Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
-        rdfs:label "export price"
-    
-    SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
@@ -1950,10 +384,1577 @@ Class: <http://purl.obolibrary.org/obo/UO_0000190>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000160>
+Class: oeo:OEO_00000045
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "producer"
+    
+    SubClassOf: 
+        oeo:OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some oeo:OEO_00240003
+    
+    
+Class: oeo:OEO_00000051
+
+    
+Class: oeo:OEO_00000064
+
+    
+Class: oeo:OEO_00000087
+
+    
+Class: oeo:OEO_00000105
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
+        rdfs:label "consumer"
+    
+    SubClassOf: 
+        oeo:OEO_00000431
+    
+    
+Class: oeo:OEO_00000107
+
+    
+Class: oeo:OEO_00000128
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1015"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "energy demand sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00000145
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "electricity sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000158
+    
+    
+Class: oeo:OEO_00000158
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "energy transformation sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00000213
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "heating and cooling sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000128
+    
+    
+Class: oeo:OEO_00000214
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "household sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000128
+    
+    
+Class: oeo:OEO_00000227
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "industry sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00000238
+
+    
+Class: oeo:OEO_00000264
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        oeo:OEO_00140164 some oeo:OEO_00020065
+    
+    
+Class: oeo:OEO_00000315
+
+    
+Class: oeo:OEO_00000323
+
+    
+Class: oeo:OEO_00000329
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
+        rdfs:label "political party"
+    
+    SubClassOf: 
+        oeo:OEO_00030022
+    
+    
+Class: oeo:OEO_00000341
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
+        rdfs:label "prosumer"
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00000350
+
+    
+Class: oeo:OEO_00000367
+
+    
+Class: oeo:OEO_00000368
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
+        rdfs:label "sector division"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: oeo:OEO_00000379
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
+        rdfs:label "software developer"
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00000405
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "trading, commerce and service sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "commercial sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000128
+    
+    
+Class: oeo:OEO_00000422
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "transport sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000128
+    
+    
+Class: oeo:OEO_00000431
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
+        rdfs:label "user"
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00010034
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "building sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000128
+    
+    
+Class: oeo:OEO_00010035
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "agriculture, forestry and land use sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00010036
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "waste and wastewater sector"
+    
+    SubClassOf: 
+        oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00010055
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
+        rdfs:label "common reporting format"
+    
+    SubClassOf: 
+        oeo:OEO_00000368
+    
+    
+Class: oeo:OEO_00010079
+
+    SubClassOf: 
+        oeo:OEO_00020056 some oeo:OEO_00020063
+    
+    
+Class: oeo:OEO_00010082
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
+        rdfs:label "trade"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00040011
+    
+    
+Class: oeo:OEO_00010083
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+update definition and improve axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019",
+        rdfs:label "market participant"@en
+    
+    SubClassOf: 
+        oeo:OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some oeo:OEO_00010082
+    
+    
+Class: oeo:OEO_00010115
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "economy"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
+Class: oeo:OEO_00010116
+
+    
+Class: oeo:OEO_00010117
+
+    
+Class: oeo:OEO_00010123
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
+        rdfs:label "effort sharing"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140151,
+        oeo:OEO_00000503 some oeo:OEO_00020063
+    
+    
+Class: oeo:OEO_00010126
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
+        rdfs:label "Annual Emission Allocation"@en
+    
+    SubClassOf: 
+        oeo:OEO_00020063
+    
+    
+Class: oeo:OEO_00010136
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
+        rdfs:label "distribution"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: oeo:OEO_00010212
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
+        rdfs:label "decarbonisation pathway"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140150
+    
+    
+Class: oeo:OEO_00010227
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "memo item"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some oeo:OEO_00000367
+    
+    
+Class: oeo:OEO_00020015
+
+    
+Class: oeo:OEO_00020060
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel market exchange"
+    
+    SubClassOf: 
+        oeo:OEO_00020065,
+        oeo:OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00020066)
+    
+    
+Class: oeo:OEO_00020063
+
+    
+Class: oeo:OEO_00020064
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "EU allowance"
+    
+    SubClassOf: 
+        oeo:OEO_00020063
+    
+    
+Class: oeo:OEO_00020065
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "energy market exchange"
+    
+    SubClassOf: 
+        oeo:OEO_00020069
+    
+    
+Class: oeo:OEO_00020066
+
+    
+Class: oeo:OEO_00020067
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "product"
+    
+    SubClassOf: 
+        oeo:OEO_00020070 some oeo:OEO_00020069
+    
+    
+Class: oeo:OEO_00020068
+
+    SubClassOf: 
+        oeo:OEO_00020070 some oeo:OEO_00020060
+    
+    
+Class: oeo:OEO_00020069
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
+    
+    SubClassOf: 
+        oeo:OEO_00030022,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019"
+        <http://purl.obolibrary.org/obo/RO_0000056> some 
+            (oeo:OEO_00010082
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00010083))
+    
+    
+Class: oeo:OEO_00020075
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
+        rdfs:label "emission market exchange"
+    
+    SubClassOf: 
+        oeo:OEO_00020069,
+        oeo:OEO_00020071 some oeo:OEO_00020063
+    
+    
+Class: oeo:OEO_00020076
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        rdfs:label "markup"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020077
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        rdfs:label "markdown"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020108
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:comment "Feed-in tariffs provide cost-based compensation to renewable energy producers, leading to price certainty and long-term contracts that help finance energy transformation units, e.g. power plants",
+        rdfs:label "feed-in tariff"
+    
+    SubClassOf: 
+        oeo:OEO_00140151
+    
+    
+Class: oeo:OEO_00020109
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "market premium"
+    
+    SubClassOf: 
+        oeo:OEO_00140151
+    
+    
+Class: oeo:OEO_00020110
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "levy"
+    
+    SubClassOf: 
+        oeo:OEO_00140151
+    
+    
+Class: oeo:OEO_00020111
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "capacity premium"
+    
+    SubClassOf: 
+        oeo:OEO_00020109
+    
+    
+Class: oeo:OEO_00020112
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "tax"
+    
+    SubClassOf: 
+        oeo:OEO_00020110
+    
+    
+Class: oeo:OEO_00020113
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:label "inflation rate"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: oeo:OEO_00020114
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:comment "The ratio at which one can exchange one currency for another can differ over time therefore it is necessary to specify a time point when referring to an exchange rate.",
+        rdfs:label "exchange rate"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: oeo:OEO_00020115
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        <http://purl.org/dc/terms/source> "https://www.oecd.org/sdd/prices-ppp/purchasingpowerparities-frequentlyaskedquestionsfaqs.htm#FAQ1",
+        rdfs:label "purchasing power parity"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: oeo:OEO_00020116
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:label "system cost"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00020117
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:comment "has unit some \"currency per energy unit\"",
+        rdfs:label "electricity price"
+    
+    SubClassOf: 
+        oeo:OEO_00040003
+    
+    
+Class: oeo:OEO_00020124
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "due"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020125
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "remuneration"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020126
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "fee"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020127
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:comment "Since over the lifetime of an energy transformation unit different costs exhibit different relevance or vary over time, the LCOE differ over the course of the lifetime.",
+        rdfs:label "levelised cost of electricity"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00020128
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add term
+https://github.com/OpenEnergyPlatform/ontology/issues/908
+https://github.com/OpenEnergyPlatform/ontology/pull/929",
+        rdfs:label "market revenue"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some oeo:OEO_00040004
+    
+    
+Class: oeo:OEO_00020145
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
+        rdfs:label "variable cost"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00020146
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
+        rdfs:label "variable production cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020145
+    
+    
+Class: oeo:OEO_00020156
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "carbon tax"
+    
+    SubClassOf: 
+        oeo:OEO_00020112
+    
+    
+Class: oeo:OEO_00020167
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "investment",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "FIBO definition of investment relates to property only: https://spec.edmcouncil.org/fibo/ontology?searchBoxQuery=investment, 
+
+Gabler on Investition: langfristige Bindung finanzieller Mittel in materiellen oder in immateriellen Vermögensgegenständen (https://wirtschaftslexikon.gabler.de/definition/investition-39454)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "investment cost"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00020168
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "oemof-Model: https://oemof-solph.readthedocs.io/en/latest/_modules/oemof/solph/options.html?highlight=fix%20costs
+
+Fixe Kosten: Kosten, die von der jeweils betrachteten Einflussgröße bzw. Entscheidung unabhängig sind, d.h. Kosten, die sich nicht mit der jeweils betrachteten Einflussgröße ändern. (https://wirtschaftslexikon.gabler.de/definition/fixe-kosten-33359)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "fixed cost"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00020169
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "equipment cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020167
+    
+    
+Class: oeo:OEO_00020170
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "site development cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "installation cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020167
+    
+    
+Class: oeo:OEO_00020171
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "grid connection cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020167
+    
+    
+Class: oeo:OEO_00020172
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "property cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020167
+    
+    
+Class: oeo:OEO_00020173
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "decommissioning cost"
+    
+    SubClassOf: 
+        oeo:OEO_00020167
+    
+    
+Class: oeo:OEO_00020174
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "delivery cost"
+    
+    SubClassOf: 
+        oeo:OEO_00040009
+    
+    
+Class: oeo:OEO_00030016
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "organisational energy producer"
+    
+    SubClassOf: 
+        oeo:OEO_00030022,
+        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00000045
+    
+    
+Class: oeo:OEO_00030017
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:comment "They may be privately or publicly owned.",
+        rdfs:label "energy autoproducer"
+    
+    SubClassOf: 
+        oeo:OEO_00030016
+    
+    
+Class: oeo:OEO_00030018
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
+        rdfs:label "main activity energy producer"
+    
+    SubClassOf: 
+        oeo:OEO_00030016
+    
+    
+Class: oeo:OEO_00030022
+
+    
+Class: oeo:OEO_00030035
+
+    
+Class: oeo:OEO_00040002
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
+https://github.com/OpenEnergyPlatform/ontology/pull/639
+
+https://github.com/OpenEnergyPlatform/ontology/issues/677
+https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+change label to market exchange role
+https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: oeo:OEO_00040003
+
+    
+Class: oeo:OEO_00040004
+
+    
+Class: oeo:OEO_00040005
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/377
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/641
+
+Make trader subclass of market participant:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+https://github.com/OpenEnergyPlatform/ontology/pull/745",
+        rdfs:label "trader"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Trader"
+    
+    SubClassOf: 
+        oeo:OEO_00010083
+    
+    
+Class: oeo:OEO_00040006
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "request"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: oeo:OEO_00040007
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "price request"@en
+    
+    SubClassOf: 
+        oeo:OEO_00040006
+    
+    
+Class: oeo:OEO_00040008
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "marginal cost"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140012
+    
+    
+Class: oeo:OEO_00040009
+
+    
+Class: oeo:OEO_00040011
+
+    
+Class: oeo:OEO_00090001
+
+    
+Class: oeo:OEO_00090002
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "public funder"@en
+    
+    SubClassOf: 
+        oeo:OEO_00090001
+    
+    
+Class: oeo:OEO_00090003
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "private funder"@en
+    
+    SubClassOf: 
+        oeo:OEO_00090001
+    
+    
+Class: oeo:OEO_00140009
+
+    
+Class: oeo:OEO_00140012
+
+    
+Class: oeo:OEO_00140013
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
+alternative term:
+https://github.com/OpenEnergyPlatform/ontology/issues/675
+https://github.com/OpenEnergyPlatform/ontology/pull/676",
+        rdfs:label "gross domestic product"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140012
+    
+    
+Class: oeo:OEO_00140023
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563
+alternative term:
+https://github.com/OpenEnergyPlatform/ontology/issues/675
+https://github.com/OpenEnergyPlatform/ontology/pull/676",
+        rdfs:label "gross value added"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140012
+    
+    
+Class: oeo:OEO_00140040
+
+    
+Class: oeo:OEO_00140109
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
+        rdfs:label "contract"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: oeo:OEO_00140117
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "delivery time"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>
+    
+    
+Class: oeo:OEO_00140118
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "delivery time point"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: oeo:OEO_00140119
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "sender"@en
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00140120
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "receiver"@en
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00140121
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "bid"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: oeo:OEO_00140122
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "award"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: oeo:OEO_00140123
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:comment "The transfer is typically defined in a contract.",
+        rdfs:label "provider"@en
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00140124
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "service"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: oeo:OEO_00140125
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:comment "This duration is often contractually fixed and regular.",
+        rdfs:label "delivery interval"@en
+    
+    SubClassOf: 
+        oeo:OEO_00030035
+    
+    
+Class: oeo:OEO_00140130
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "power plant operator"@en
+    
+    SubClassOf: 
+        oeo:OEO_00000051
+    
+    
+Class: oeo:OEO_00140131
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "conventional trader"@en
+    
+    SubClassOf: 
+        oeo:OEO_00040005
+    
+    
+Class: oeo:OEO_00140136
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
+        rdfs:label "dispatch assignment"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>
+    
+    
+Class: oeo:OEO_00140137
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
+        rdfs:label "power plant portfolio"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: oeo:OEO_00140140
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "demand trader"@en
+    
+    SubClassOf: 
+        oeo:OEO_00040005
+    
+    
+Class: oeo:OEO_00140141
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "merit order"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>
+    
+    
+Class: oeo:OEO_00140143
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "direct marketer"@en
+    
+    SubClassOf: 
+        oeo:OEO_00040005
+    
+    
+Class: oeo:OEO_00140146
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
+        rdfs:label "energy demand"@en
+    
+    SubClassOf: 
+        oeo:OEO_00140040
+    
+    
+Class: oeo:OEO_00140149
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
+        rdfs:label "transformative measure"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: oeo:OEO_00140150
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+        rdfs:label "policy"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        oeo:OEO_00010121 some oeo:OEO_00030022,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some oeo:OEO_00140151
+    
+    
+Class: oeo:OEO_00140151
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
+        rdfs:label "policy instrument"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
+        oeo:OEO_00010119 some oeo:OEO_00140149
+    
+    
+Class: oeo:OEO_00140171
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
+        rdfs:label "email address"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: oeo:OEO_00230013
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "population"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: oeo:OEO_00230014
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "urban population"@en
+    
+    SubClassOf: 
+        oeo:OEO_00230013
+    
+    DisjointWith: 
+        oeo:OEO_00230015
+    
+    
+Class: oeo:OEO_00230015
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
+https://github.com/OpenEnergyPlatform/ontology/issues/479
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "rural population"@en
+    
+    SubClassOf: 
+        oeo:OEO_00230013
+    
+    DisjointWith: 
+        oeo:OEO_00230014
+    
+    
+Class: oeo:OEO_00230016
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "labour force"@en
+    
+    SubClassOf: 
+        oeo:OEO_00230013
+    
+    
+Class: oeo:OEO_00230017
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
+https://github.com/OpenEnergyPlatform/ontology/issues/479
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "working age population"@en
+    
+    SubClassOf: 
+        oeo:OEO_00230013
+    
+    
+Class: oeo:OEO_00240003
+
+    
+Class: oeo:OEO_00240021
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
+        rdfs:label "discount rate"
+    
+    SubClassOf: 
+        oeo:OEO_00140012,
+        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
+    
+    
+Class: oeo:OEO_00240036
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
+        rdfs:label "import price"
+    
+    SubClassOf: 
+        oeo:OEO_00040003
+    
+    
+Class: oeo:OEO_00240037
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
+        rdfs:label "export price"
+    
+    SubClassOf: 
+        oeo:OEO_00040003
+    
+    
+Individual: oeo:OEO_00000160
+
+    Annotations: 
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
@@ -1962,13 +1963,13 @@ The energy balance expresses all forms of energy in a common accounting unit. Th
         rdfs:label "eurostat energy balances"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000193>
+Individual: oeo:OEO_00000193
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
@@ -2000,42 +2001,42 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
         rdfs:label "german energy balances"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+Individual: oeo:OEO_00000242
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 2006) is a version of the common reporting format that was used for national greenhouse gas inventories since the year 2015. It implements the 2006 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 2006)"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
+        oeo:OEO_00010055
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000504  oeo:OEO_00000242
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000243>
+Individual: oeo:OEO_00000243
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 1996) is a version of the common reporting format that was used for national greenhouse gas inventories until the year 2014. It implements the Revised 1996 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 1996)"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
+        oeo:OEO_00010055
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000291>
+Individual: oeo:OEO_00000291
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
@@ -2043,26 +2044,26 @@ NACE is a four-digit classification providing the framework for collecting and p
         rdfs:label "nace_ sectors"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000355>
+Individual: oeo:OEO_00000355
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
         rdfs:label "renewable_ energy_ directive_ sectors"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
+Individual: oeo:OEO_00010038
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) energy is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All GHG emissions arising from combustion and fugitive releases of fuels. Emissions from the non-energy uses of fuels are generally not included here, but reported under Industrial Processes and Product Use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2071,22 +2072,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): energy"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010041>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010044>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010041,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010042,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010043,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010044
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
+Individual: oeo:OEO_00010039
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the intentional oxidation of materials within an apparatus that is designed to raise heat and provide it either as heat or as mechanical work to a process or for use away from the apparatus.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2095,18 +2096,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
+Individual: oeo:OEO_00010040
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industry' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises emissions from fuels combusted by the fuel extraction or energy-producing industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2119,21 +2120,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): energy industry"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+        oeo:OEO_00000158
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010158>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010159>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010160>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010158,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010159,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010160
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010041>
+Individual: oeo:OEO_00010041
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.2",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.2",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacturing industries and construction' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion of fuels in industry. Also includes combustion for the generation of electricity and heat for own use in these industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2142,18 +2143,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): manufacturing industries and construction"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+Individual: oeo:OEO_00010042
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the combustion and evaporation of fuel for all transport activity (excluding military transport), regardless of the sector, specifiedby sub-categories below. Emissions from fuel sold to any air or marine vessel engaged in international transport (1 A 3 a i and 1 A 3 d i) should as far as possible be excluded from the totals and subtotals in this category and should be reported separately.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2162,18 +2163,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): transport"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
+Individual: oeo:OEO_00010043
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.4",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion - other sectors' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion activities as described below, including combustion for the generation of electricity and heat for own use in these sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2182,20 +2183,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other sectors"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+        oeo:OEO_00000128
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010052>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010052,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010053
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010044>
+Individual: oeo:OEO_00010044
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.5",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.5",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All remaining emissions from fuel combustion that are not specified elsewhere. Include emissions from fuel delivered to the military in the country and delivered to the military of other countries that are not engaged in multilateral operations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2204,18 +2205,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+Individual: oeo:OEO_00010046
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industrial processes and product use' (IPPU) is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 It covers greenhouse gas emissions occurring from industrial processes, from the use of greenhouse gases in products, and from non-energy uses of fossil fuel carbon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "IPPU",
@@ -2229,25 +2230,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010164>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010166>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010167>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010169>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010170>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010171>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010172>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010173>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010164,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010166,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010167,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010169,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010170,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010171,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010172,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010173
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+Individual: oeo:OEO_00010047
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -2258,27 +2259,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010179>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010180>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010181>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010182>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010183>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010184>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010185>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010186>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010187>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010188>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010179,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010180,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010181,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010182,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010183,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010184,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010185,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010186,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010187,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010188
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+Individual: oeo:OEO_00010048
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry' (LULUCF) is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LULUCF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -2290,28 +2291,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010189>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010190>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010192>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010193>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010194>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010195>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010196>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010189,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010190,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010192,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010193,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010194,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010195,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010196
     
     SameAs: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010071>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010135>
+        oeo:OEO_00010071,
+        oeo:OEO_00010135
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+Individual: oeo:OEO_00010049
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2), methane (CH4) and nitrous oxide (N2O) emissions from following categories: Solid waste disposal, Biological treatment of solid waste, 
 Incineration and open burning of waste, Wastewater treatment and discharge.",
@@ -2325,39 +2326,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010174>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010175>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010176>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010177>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010178>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010174,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010175,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010176,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010177,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010178
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
+Individual: oeo:OEO_00010050
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 6",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 6",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): other"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000504  oeo:OEO_00000242
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010052>
+Individual: oeo:OEO_00010052
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.a",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.4.a",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'commercial and institutional' is a commercial sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in commercial and institutional buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 1.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2366,18 +2367,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): commercial and institutional"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000405>
+        oeo:OEO_00000405
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
+Individual: oeo:OEO_00010053
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.b",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.4.b",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'residential' is a household sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All emissions from fuel combustion in households.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2386,18 +2387,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): residential"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000214>
+        oeo:OEO_00000214
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010054>
+Individual: oeo:OEO_00010054
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.c",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.4.c",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture, forestry and fishing' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in agriculture, forestry, fishing and fishing industries such as fish farms.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2406,31 +2407,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): agriculture, forestry and fishing"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+        oeo:OEO_00000128
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010056>
+Individual: oeo:OEO_00010056
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector division"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
+Individual: oeo:OEO_00010057
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.B",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fugitive emissions from fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of solid fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2439,20 +2440,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): fugitive emissions from fuels"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010161>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010162>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010161,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010162
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
+Individual: oeo:OEO_00010058
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.C",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.C",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2461,21 +2462,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): CO2 transport and storage"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010229>
+        oeo:OEO_00010229
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010059>
+Individual: oeo:OEO_00010059
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.a",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.a",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2484,21 +2485,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic aviation"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
+        oeo:OEO_00010201
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010060>
+Individual: oeo:OEO_00010060
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.b",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.b",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'road transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2507,18 +2508,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): road transportation"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010061>
+Individual: oeo:OEO_00010061
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.c",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.c",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'railways' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from railway transport for both freight and passenger traffic routes.",
@@ -2527,18 +2528,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): railways"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
+Individual: oeo:OEO_00010062
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.d",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.d",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2547,21 +2548,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic navigation"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
+        oeo:OEO_00010202
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010063>
+Individual: oeo:OEO_00010063
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.e",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.e",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other transportation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2570,18 +2571,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): other transportation"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010064>
+Individual: oeo:OEO_00010064
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.e.i",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.3.e.i",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'pipeline transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2594,17 +2595,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1122",
         rdfs:label "CRF sector (IPCC 2006): pipeline transport"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010063>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010063
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010065>
+Individual: oeo:OEO_00010065
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
@@ -2615,19 +2616,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector energy industry"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+        oeo:OEO_00000158
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010064>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010057,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010064
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010066>
+Individual: oeo:OEO_00010066
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
@@ -2638,19 +2639,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector industry"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010041>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010041,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010058
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010067>
+Individual: oeo:OEO_00010067
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)
@@ -2665,19 +2666,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1198",
         rdfs:label "KSG sector buildings"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010034>
+        oeo:OEO_00010034
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010044>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010052>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010044,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010052,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010053
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010068>
+Individual: oeo:OEO_00010068
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
 - CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
@@ -2689,20 +2690,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector transport"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010059>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010060>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010061>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010059,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010060,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010061,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010062
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010069>
+Individual: oeo:OEO_00010069
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
@@ -2712,18 +2713,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector agriculture"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010054>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010054
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010070>
+Individual: oeo:OEO_00010070
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
@@ -2733,18 +2734,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector waste management and other"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
+     oeo:OEO_00000504  oeo:OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010071>
+Individual: oeo:OEO_00010071
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
@@ -2753,19 +2754,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector land use, land-use change and forestry"
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>
+     oeo:OEO_00000504  oeo:OEO_00010056
     
     SameAs: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+        oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010122>
+Individual: oeo:OEO_00010122
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The European Union Emissions Trading System (EU ETS) is a policy instrument that implements an emissions trading system covering the European Union, Norway, Iceland and Liechtenstein.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EU ETS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2777,21 +2778,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "European Union Emissions Trading System"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00020064>
+        oeo:OEO_00140151,
+        oeo:OEO_00000503 some oeo:OEO_00020064
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>,
-     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010132>,
-     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010133>,
-     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010205>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
+     oeo:OEO_00010128  oeo:OEO_00010131,
+     oeo:OEO_00010128  oeo:OEO_00010132,
+     oeo:OEO_00010128  oeo:OEO_00010133,
+     oeo:OEO_00010128  oeo:OEO_00010205,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010124>
+Individual: oeo:OEO_00010124
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Decision (ESD) is the European effort sharing for the years 2013-2020. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons and sulphur hexafluoride. Emission quantities under the ESD are calculated using global warming potentials from the Fourth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESD",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2799,17 +2800,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Decision"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010123>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
+        oeo:OEO_00010123,
+        oeo:OEO_00000503 some oeo:OEO_00010126
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010125>
+Individual: oeo:OEO_00010125
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Regulation (ESR) is the European effort sharing for the years 2021-2030. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons, sulphur hexafluoride and nitrogen trifluoride. Emission quantities under the ESR are calculated using global warming potentials from the Fifth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESR",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2817,135 +2818,135 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Regulation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010123>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
+        oeo:OEO_00010123,
+        oeo:OEO_00000503 some oeo:OEO_00010126
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
+Individual: oeo:OEO_00010129
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU climate policy is the policy of the European Union for reducing greenhouse gas emissions. It uses the EU emission sector division.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU climate policy"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
+        oeo:OEO_00140150
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
+     oeo:OEO_00000503  oeo:OEO_00010130
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
+Individual: oeo:OEO_00010130
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector division is used in the EU climate policy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector division"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
+     oeo:OEO_00000504  oeo:OEO_00010129
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
+Individual: oeo:OEO_00010131
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS is a sector defined by the EU emission sector division that covers greenhouse gas emissions that are regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
+     oeo:OEO_00000504  oeo:OEO_00010130
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010132>
+Individual: oeo:OEO_00010132
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS stationary"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
+     oeo:OEO_00000504  oeo:OEO_00010130,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010131
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010133>
+Individual: oeo:OEO_00010133
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS aviation is a transport sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS aviation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+        oeo:OEO_00000422
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
+     oeo:OEO_00000504  oeo:OEO_00010130,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010131
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010134>
+Individual: oeo:OEO_00010134
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector effort sharing is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the Effort Sharing Decision and the Effort Sharing Regulation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: effort sharing"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
+     oeo:OEO_00000504  oeo:OEO_00010130
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010135>
+Individual: oeo:OEO_00010135
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: LULUCF"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
+     oeo:OEO_00000504  oeo:OEO_00010130
     
     SameAs: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+        oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010158>
+Individual: oeo:OEO_00010158
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.a",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.1.a",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'public electricity and heat production' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Sum of emissions from main activity producers of electricity generation, combined heat and power generation, and heat plants.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2954,18 +2955,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): public electricity and heat production"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+        oeo:OEO_00000158
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010159>
+Individual: oeo:OEO_00010159
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.b",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.1.b",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'petroleum refining' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion activities supporting the refining of petroleum products including on-site combustion for the generation of electricity and heat for own use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2974,18 +2975,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): petroleum refining"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+        oeo:OEO_00000158
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010160>
+Individual: oeo:OEO_00010160
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.c",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.A.1.c",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacture of solid fuels and other energy industries' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from fuel use during the manufacture of secondary and tertiary products from solid fuels including production of charcoal.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2994,18 +2995,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+        oeo:OEO_00000158
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010161>
+Individual: oeo:OEO_00010161
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B.1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.B.1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3014,18 +3015,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid fuels"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010057
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010162>
+Individual: oeo:OEO_00010162
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B.2",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.B.2",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'oil and natural gas' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises fugitive emissions from all oil and natural gas activities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3034,17 +3035,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): oil and natural gas"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010057
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010163>
+Individual: oeo:OEO_00010163
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GovReg sector division is a sector division defined in Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32020R1208&from=EN#d1e32-98-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3056,17 +3057,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "GovReg sector division"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000503  oeo:OEO_00000242
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010164>
+Individual: oeo:OEO_00010164
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.A",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.A",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'mineral industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related carbon dioxide (CO2) emissions resulting from the use of carbonate raw materials in the production and use of a variety of mineral industry products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 2.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3075,18 +3076,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): mineral industry"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010165>
+Individual: oeo:OEO_00010165
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.A.1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.A.1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related emissions from the production of various types of cement (ISIC: D2694).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3095,18 +3096,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cement production"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010164>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010164
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010166>
+Individual: oeo:OEO_00010166
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.B",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.B",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'chemical industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of various inorganic and organic chemicals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3115,18 +3116,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): chemical industry"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010167>
+Individual: oeo:OEO_00010167
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.C",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.C",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'metal industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of metals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 4.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3135,18 +3136,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): metal industry"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010168>
+Individual: oeo:OEO_00010168
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.C.1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.C.1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide is the predominant gas emitted from the production of iron and steel. The sources of the carbon dioxide emissions include that from carbon-containing reducing agents such as coke and pulverized coal, and, from minerals such as limestone and dolomite added.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3155,18 +3156,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): iron and steel production"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010167>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010167
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010169>
+Individual: oeo:OEO_00010169
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.D",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.D",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'non-energy products from fuels and solvent use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 The use of oil products and coal-derived oils primarily intended for purposes other than combustion",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3175,18 +3176,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): non-energy products from fuels and solvent use"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010170>
+Individual: oeo:OEO_00010170
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.E",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.E",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'electronics industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Several advanced electronics manufacturing processes utilise fluorinated compounds (FCs) for plasma etching intricate patterns, cleaning reactor chambers, and temperature control. The specific electronic industry sectors include semiconductor, thin-film-transistor flat panel display (TFT-FPD), and photovoltaic (PV) manufacturing (collectively termed ‘electronics industry’).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 6.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3195,18 +3196,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): electronics industry"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010171>
+Individual: oeo:OEO_00010171
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.F",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.F",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'product uses as substitutes for ozone depleting substances' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Hydrofluorocarbons (HFCs) and, to a very limited extent, perfluorocarbons (PFCs), are serving as alternatives to ozone depleting substances (ODS) being phased out under the Montreal Protocol.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 7.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3215,18 +3216,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): product uses as substitutes for ozone depleting substances"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010172>
+Individual: oeo:OEO_00010172
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.G",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.G",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other product manufacture and use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
 (PFCs) from the manufacture and use of electrical equipment and a number of other products. It also includes emissions of nitrous oxide (N2O) from several products.",
@@ -3234,36 +3235,36 @@ Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
         rdfs:label "CRF sector (IPCC 2006): other product manufacture and use"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010173>
+Individual: oeo:OEO_00010173
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.H",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 2.H",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'industrial processes and product use - other' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use - other"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+        oeo:OEO_00000227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010174>
+Individual: oeo:OEO_00010174
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.A",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5.A",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid waste disposal' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic microbial decomposition of organic matter in solid waste disposal sites.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3272,18 +3273,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid waste disposal"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010175>
+Individual: oeo:OEO_00010175
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.B",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5.B",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'biological treatment of solid waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Solid waste composting and other biological treatment. Emissions from biogas facilities (anaerobic digestion) with energy production are reported in the Energy Sector (1A4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3292,18 +3293,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): biological treatment of solid waste"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010176>
+Individual: oeo:OEO_00010176
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.C",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5.C",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'incineration and open burning of waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Incineration of waste and open burning waste, not including waste-to-energy facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3312,18 +3313,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): incineration and open burning of waste"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010177>
+Individual: oeo:OEO_00010177
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.D",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5.D",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste water treatment and discharge' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic decomposition of organic matter by bacteria in sewage facilities and from food processing and other industrial facilities during wastewater treatment. N2O is also produced by bacteria
 (denitrification and nitrification) in wastewater treatment and discharge.",
@@ -3333,18 +3334,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste water treatment and discharge"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010178>
+Individual: oeo:OEO_00010178
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.E",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 5.E",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste - other' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3352,18 +3353,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste - other"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+        oeo:OEO_00010036
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010179>
+Individual: oeo:OEO_00010179
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.A",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.A",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'enteric fermentation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane emissions from herbivores as a by-product of enteric fermentation (a digestive process by which carbohydrates are broken down by micro-organisms into simple molecules for absorption into the bloodstream). Ruminant animals (e.g., cattle, sheep) are major sources with moderate amounts produced from non-ruminant animals (e.g., pigs, horses).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3372,18 +3373,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): enteric fermentation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010180>
+Individual: oeo:OEO_00010180
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.B",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.B",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manure management' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane and nitrous oxide emissions from the decomposition of manure under low oxygen or anaerobic conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3392,18 +3393,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manure management"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010181>
+Individual: oeo:OEO_00010181
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.C",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.C",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'rice cultivation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane (CH4) emissions from anaerobic decomposition of organic material in flooded rice fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3412,54 +3413,54 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): rice cultivation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010182>
+Individual: oeo:OEO_00010182
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.D",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.D",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agricultural soils' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agricultural soils"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010183>
+Individual: oeo:OEO_00010183
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.E",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.E",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'prescribed burning of savannas' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): prescribed burning of savannas"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010184>
+Individual: oeo:OEO_00010184
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.F",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.F",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'field burning of agricultural residues' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from urea application",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3468,18 +3469,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): field burning of agricultural residues"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010185>
+Individual: oeo:OEO_00010185
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.G",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.G",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'liming' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from the use of lime in agricultural soils, managed forest soils or lakes.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3488,72 +3489,72 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): liming"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010186>
+Individual: oeo:OEO_00010186
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.H",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.H",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'urea application' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): urea application"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010187>
+Individual: oeo:OEO_00010187
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.I",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.I",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other carbon-containing fertilizers' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other carbon-containing fertilizers"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010188>
+Individual: oeo:OEO_00010188
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.J",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 3.J",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture - other"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010189>
+Individual: oeo:OEO_00010189
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.A",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.A",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'forest land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from lands with woody vegetation consistent with thresholds used to define forest land in the national GHG inventory, sub-divided into managed and unmanaged, and possibly also by climatic region, soil type and vegetation type as appropriate. It also includes systems with vegetation that currently fall below, but are expected to later exceed, the threshold values used by a country to define the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3562,18 +3563,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): forest land"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010190>
+Individual: oeo:OEO_00010190
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.B",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.B",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cropland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from arable and tillage land, rice fields, and agro-forestry systems where vegetation falls below the thresholds used for the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3582,18 +3583,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cropland"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010191>
+Individual: oeo:OEO_00010191
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.C",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.C",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'grassland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from rangelands and pasture land that is not considered cropland. It also includes systems with woody vegetation that fall below the threshold values used in the forest land category and are not expected to exceed them, without human intervention. The category also includes all grassland from wild lands to recreational areas as well as agricultural and silvi-pastural systems, subdivided into managed and unmanaged, consistent with national definitions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3602,18 +3603,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): grassland"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010192>
+Individual: oeo:OEO_00010192
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.D",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.D",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'wetlands' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from land that is covered or saturated by water for all or part of the year (e.g., peatland) and that does not fall into the forest land, cropland, grassland or settlements categories. The category can be subdivided into managed and unmanaged according to national definitions. It includes reservoirs as a managed sub-division and natural rivers and lakes as unmanaged sub-divisions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3622,18 +3623,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): wetlands"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010193>
+Individual: oeo:OEO_00010193
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.E",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.E",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'settlements' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from all developed land, including transportation infrastructure and human settlements of any size, unless they are already included under other categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3642,18 +3643,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): settlements"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010194>
+Individual: oeo:OEO_00010194
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.F",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.F",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from bare soil, rock, ice, and all unmanaged land areas that do not fall into any of the other five categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3662,18 +3663,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other land"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010195>
+Individual: oeo:OEO_00010195
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.G",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.G",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'harvested wood products' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories
 CO2 net emissions or removals resulting from Harvest Wood Products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3682,35 +3683,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): harvested wood products"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010196>
+Individual: oeo:OEO_00010196
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.H",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 4.H",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry - other"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+        oeo:OEO_00010035
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010197>
+Individual: oeo:OEO_00010197
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions excluding LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA) https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3720,21 +3721,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions excluding LULUCF"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010198>
+Individual: oeo:OEO_00010198
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions including LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; land use, land-use change and forestry; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3744,71 +3745,71 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions including LULUCF"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010048,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010199>
+Individual: oeo:OEO_00010199
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.D",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) international bunkers is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international bunkers and multilateral operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers and multilateral operations"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010203>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010203
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
+Individual: oeo:OEO_00010200
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.D.1",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010202
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
+Individual: oeo:OEO_00010201
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1.a",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.D.1.a",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3816,26 +3817,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international aviation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010200
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010059>
+        oeo:OEO_00010059
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
+Individual: oeo:OEO_00010202
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1.b",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.D.1.b",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3843,26 +3844,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): maritime navigation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010200
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
+        oeo:OEO_00010062
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010203>
+Individual: oeo:OEO_00010203
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.2",
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00010037 "CRF 1.D.2",
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'multilateral operation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used for aviation and waterborne navigation in multilateral operations pursuant to the Charter of the United Nations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3871,22 +3872,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): multilateral operations"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010199>
+     oeo:OEO_00000504  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010199
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010204>
+Individual: oeo:OEO_00010204
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3894,39 +3895,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector division"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+        oeo:OEO_00000368
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000503  oeo:OEO_00000242
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010205>
+Individual: oeo:OEO_00010205
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector: M.International aviation in the EU ETS"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
+        oeo:OEO_00000422,
+        oeo:OEO_00010232 some oeo:OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010204>,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010133>,
-      not  <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010163>
+     oeo:OEO_00000504  oeo:OEO_00010204,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010133,
+      not  oeo:OEO_00000504  oeo:OEO_00010163
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010206>
+Individual: oeo:OEO_00010206
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3934,18 +3935,18 @@ Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010206>
         rdfs:label "total emissions excluding LULUCF and including international bunkers"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010197>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
+     oeo:OEO_00000503  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010197,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010207>
+Individual: oeo:OEO_00010207
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3953,18 +3954,18 @@ Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010207>
         rdfs:label "total emissions including LULUCF and including international bunkers"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010198>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
+     oeo:OEO_00000503  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010198,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010208>
+Individual: oeo:OEO_00010208
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2020 emission target of the European Union.",
         
@@ -3975,18 +3976,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions excluding LULUCF and including international aviation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010197>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
+     oeo:OEO_00000503  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010197,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010209>
+Individual: oeo:OEO_00010209
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2030 emission target as specified in the Nationally Determined Contribution (NDC) of the European Union .",
         
@@ -3997,18 +3998,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions including LULUCF and including international aviation"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+        oeo:OEO_00000367
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010198>,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
+     oeo:OEO_00000503  oeo:OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010198,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010228>
+Individual: oeo:OEO_00010228
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4016,17 +4017,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 emissions from biomass"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00000367,
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000504  oeo:OEO_00000242
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010229>
+Individual: oeo:OEO_00010229
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4034,20 +4035,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 captured"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00000367,
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000504  oeo:OEO_00000242
     
     DifferentFrom: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
+        oeo:OEO_00010058
     
     
-Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010230>
+Individual: oeo:OEO_00010230
 
     Annotations: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4055,13 +4056,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): indirect CO2"@en
     
     Types: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
-        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+        oeo:OEO_00000367,
+        oeo:OEO_00010232 some oeo:OEO_00010227
     
     Facts:  
-     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
+     oeo:OEO_00000504  oeo:OEO_00000242
     
     
 DisjointClasses: 
-    <http://openenergy-platform.org/ontology/oeo/OEO_00000145>,<http://openenergy-platform.org/ontology/oeo/OEO_00000213>,<http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+    oeo:OEO_00000145,oeo:OEO_00000213,oeo:OEO_00000422
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -47,7 +47,7 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: OEO_00010037
 
     
-AnnotationProperty: OEO_00269001
+AnnotationProperty: OEO_00040001
 
     
 AnnotationProperty: dc:contributor
@@ -387,7 +387,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0010006>
 Class: OEO_00000045
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -413,7 +413,7 @@ Class: OEO_00000087
 Class: OEO_00000105
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
         rdfs:label "consumer"
     
@@ -427,7 +427,7 @@ Class: OEO_00000107
 Class: OEO_00000128
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
@@ -444,7 +444,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000145
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
@@ -457,7 +457,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000158
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
@@ -472,7 +472,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000213
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -486,7 +486,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000214
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -500,7 +500,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000227
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
@@ -531,7 +531,7 @@ Class: OEO_00000323
 Class: OEO_00000329
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
         rdfs:label "political party"
     
@@ -542,7 +542,7 @@ Class: OEO_00000329
 Class: OEO_00000341
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
         rdfs:label "prosumer"
     
@@ -559,7 +559,7 @@ Class: OEO_00000367
 Class: OEO_00000368
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
         rdfs:label "sector division"
@@ -571,7 +571,7 @@ Class: OEO_00000368
 Class: OEO_00000379
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
         rdfs:label "software developer"
     
@@ -582,7 +582,7 @@ Class: OEO_00000379
 Class: OEO_00000405
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
@@ -598,7 +598,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000422
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -612,7 +612,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00000431
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
         rdfs:label "user"
     
@@ -623,7 +623,7 @@ Class: OEO_00000431
 Class: OEO_00010034
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
@@ -636,7 +636,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00010035
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -650,7 +650,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00010036
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
@@ -663,7 +663,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
 Class: OEO_00010055
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -683,7 +683,7 @@ Class: OEO_00010079
 Class: OEO_00010082
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
@@ -697,7 +697,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
 Class: OEO_00010083
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
@@ -715,7 +715,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1019",
 Class: OEO_00010115
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
@@ -734,7 +734,7 @@ Class: OEO_00010117
 Class: OEO_00010123
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -748,7 +748,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Class: OEO_00010126
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -762,7 +762,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Class: OEO_00010136
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
@@ -775,7 +775,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
 Class: OEO_00010212
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
@@ -788,7 +788,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
 Class: OEO_00010227
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
@@ -805,7 +805,7 @@ Class: OEO_00020015
 Class: OEO_00020060
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
@@ -823,7 +823,7 @@ Class: OEO_00020063
 Class: OEO_00020064
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
@@ -837,7 +837,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
 Class: OEO_00020065
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
@@ -868,7 +868,7 @@ Class: OEO_00020068
 Class: OEO_00020069
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
         rdfs:label "market exchange"
@@ -889,7 +889,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1019"
 Class: OEO_00020075
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
@@ -903,7 +903,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
 Class: OEO_00020076
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
@@ -917,7 +917,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/800",
 Class: OEO_00020077
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
@@ -931,7 +931,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/800",
 Class: OEO_00020108
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
@@ -946,7 +946,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020109
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
@@ -960,7 +960,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020110
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
@@ -974,7 +974,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020111
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
@@ -988,7 +988,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020112
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
@@ -1002,7 +1002,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020113
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
 https://github.com/OpenEnergyPlatform/ontology/pull/910",
@@ -1016,7 +1016,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020114
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
@@ -1033,7 +1033,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020115
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
@@ -1049,7 +1049,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020116
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
@@ -1062,7 +1062,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020117
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
@@ -1077,7 +1077,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020124
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1091,7 +1091,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020125
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1105,7 +1105,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020126
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1119,7 +1119,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020127
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
@@ -1134,7 +1134,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020128
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add term
 https://github.com/OpenEnergyPlatform/ontology/issues/908
@@ -1149,7 +1149,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/929",
 Class: OEO_00020145
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1163,7 +1163,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
 Class: OEO_00020146
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1177,7 +1177,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
 Class: OEO_00020156
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1191,7 +1191,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00020167
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
@@ -1210,7 +1210,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020168
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
@@ -1228,7 +1228,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020169
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1241,7 +1241,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020170
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
@@ -1257,7 +1257,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020171
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1270,7 +1270,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020172
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1284,7 +1284,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020173
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1297,7 +1297,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020174
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1310,7 +1310,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00030016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
@@ -1326,7 +1326,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1341,7 +1341,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030018
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1362,7 +1362,7 @@ Class: OEO_00030035
 Class: OEO_00040002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market",
@@ -1391,7 +1391,7 @@ Class: OEO_00040004
 Class: OEO_00040005
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
@@ -1411,7 +1411,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/745",
 Class: OEO_00040006
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1425,7 +1425,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
 Class: OEO_00040007
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
 https://github.com/OpenEnergyPlatform/ontology/pull/642",
@@ -1438,7 +1438,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
 Class: OEO_00040008
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1461,7 +1461,7 @@ Class: OEO_00090001
 Class: OEO_00090002
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
@@ -1474,7 +1474,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
 Class: OEO_00090003
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
@@ -1493,7 +1493,7 @@ Class: OEO_00140012
 Class: OEO_00140013
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
@@ -1510,7 +1510,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
 Class: OEO_00140023
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
@@ -1530,7 +1530,7 @@ Class: OEO_00140040
 Class: OEO_00140109
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1544,7 +1544,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
 Class: OEO_00140117
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1557,7 +1557,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140118
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1570,7 +1570,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140119
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1583,7 +1583,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140120
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1596,7 +1596,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140121
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1609,7 +1609,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140122
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1622,7 +1622,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140123
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1637,7 +1637,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140124
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1651,7 +1651,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140125
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1665,7 +1665,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140130
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1678,7 +1678,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140131
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1691,7 +1691,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140136
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1704,7 +1704,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
 Class: OEO_00140137
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1717,7 +1717,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
 Class: OEO_00140140
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1730,7 +1730,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140141
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1743,7 +1743,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140143
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1756,7 +1756,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140146
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
@@ -1769,7 +1769,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
 Class: OEO_00140149
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
@@ -1782,7 +1782,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
 Class: OEO_00140150
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
@@ -1801,7 +1801,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
 Class: OEO_00140151
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
@@ -1818,7 +1818,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
 Class: OEO_00140171
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
@@ -1831,7 +1831,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
 Class: OEO_00230013
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -1845,7 +1845,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230014
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -1863,7 +1863,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230015
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -1881,7 +1881,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230016
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
@@ -1897,7 +1897,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230017
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
 https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -1914,7 +1914,7 @@ Class: OEO_00240003
 Class: OEO_00240021
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
@@ -1928,7 +1928,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
 Class: OEO_00240036
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
@@ -1941,7 +1941,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
 Class: OEO_00240037
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
@@ -1954,7 +1954,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
 Individual: OEO_00000160
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
@@ -1969,7 +1969,7 @@ The energy balance expresses all forms of energy in a common accounting unit. Th
 Individual: OEO_00000193
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
@@ -2007,7 +2007,7 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
 Individual: OEO_00000242
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 2006) is a version of the common reporting format that was used for national greenhouse gas inventories since the year 2015. It implements the 2006 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
@@ -2023,7 +2023,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
 Individual: OEO_00000243
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 1996) is a version of the common reporting format that was used for national greenhouse gas inventories until the year 2014. It implements the Revised 1996 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
@@ -2036,7 +2036,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
 Individual: OEO_00000291
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
@@ -2050,7 +2050,7 @@ NACE is a four-digit classification providing the framework for collecting and p
 Individual: OEO_00000355
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
         rdfs:label "renewable_ energy_ directive_ sectors"
@@ -2063,7 +2063,7 @@ Individual: OEO_00010038
 
     Annotations: 
         OEO_00010037 "CRF 1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) energy is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All GHG emissions arising from combustion and fugitive releases of fuels. Emissions from the non-energy uses of fuels are generally not included here, but reported under Industrial Processes and Product Use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2087,7 +2087,7 @@ Individual: OEO_00010039
 
     Annotations: 
         OEO_00010037 "CRF 1.A",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the intentional oxidation of materials within an apparatus that is designed to raise heat and provide it either as heat or as mechanical work to a process or for use away from the apparatus.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2107,7 +2107,7 @@ Individual: OEO_00010040
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industry' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises emissions from fuels combusted by the fuel extraction or energy-producing industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2134,7 +2134,7 @@ Individual: OEO_00010041
 
     Annotations: 
         OEO_00010037 "CRF 1.A.2",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacturing industries and construction' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion of fuels in industry. Also includes combustion for the generation of electricity and heat for own use in these industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2154,7 +2154,7 @@ Individual: OEO_00010042
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the combustion and evaporation of fuel for all transport activity (excluding military transport), regardless of the sector, specifiedby sub-categories below. Emissions from fuel sold to any air or marine vessel engaged in international transport (1 A 3 a i and 1 A 3 d i) should as far as possible be excluded from the totals and subtotals in this category and should be reported separately.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2174,7 +2174,7 @@ Individual: OEO_00010043
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion - other sectors' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion activities as described below, including combustion for the generation of electricity and heat for own use in these sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2196,7 +2196,7 @@ Individual: OEO_00010044
 
     Annotations: 
         OEO_00010037 "CRF 1.A.5",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All remaining emissions from fuel combustion that are not specified elsewhere. Include emissions from fuel delivered to the military in the country and delivered to the military of other countries that are not engaged in multilateral operations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2216,7 +2216,7 @@ Individual: OEO_00010046
 
     Annotations: 
         OEO_00010037 "CRF 2",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industrial processes and product use' (IPPU) is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 It covers greenhouse gas emissions occurring from industrial processes, from the use of greenhouse gases in products, and from non-energy uses of fossil fuel carbon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "IPPU",
@@ -2248,7 +2248,7 @@ Individual: OEO_00010047
 
     Annotations: 
         OEO_00010037 "CRF 3",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -2279,7 +2279,7 @@ Individual: OEO_00010048
 
     Annotations: 
         OEO_00010037 "CRF 4",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry' (LULUCF) is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LULUCF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -2312,7 +2312,7 @@ Individual: OEO_00010049
 
     Annotations: 
         OEO_00010037 "CRF 5",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2), methane (CH4) and nitrous oxide (N2O) emissions from following categories: Solid waste disposal, Biological treatment of solid waste, 
 Incineration and open burning of waste, Wastewater treatment and discharge.",
@@ -2341,7 +2341,7 @@ Individual: OEO_00010050
 
     Annotations: 
         OEO_00010037 "CRF 6",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
@@ -2358,7 +2358,7 @@ Individual: OEO_00010052
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.a",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'commercial and institutional' is a commercial sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in commercial and institutional buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 1.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2378,7 +2378,7 @@ Individual: OEO_00010053
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.b",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'residential' is a household sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All emissions from fuel combustion in households.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2398,7 +2398,7 @@ Individual: OEO_00010054
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.c",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture, forestry and fishing' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in agriculture, forestry, fishing and fishing industries such as fish farms.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2417,7 +2417,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
 Individual: OEO_00010056
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
@@ -2431,7 +2431,7 @@ Individual: OEO_00010057
 
     Annotations: 
         OEO_00010037 "CRF 1.B",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fugitive emissions from fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of solid fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2453,7 +2453,7 @@ Individual: OEO_00010058
 
     Annotations: 
         OEO_00010037 "CRF 1.C",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2476,7 +2476,7 @@ Individual: OEO_00010059
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.a",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2499,7 +2499,7 @@ Individual: OEO_00010060
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.b",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'road transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2519,7 +2519,7 @@ Individual: OEO_00010061
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.c",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'railways' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from railway transport for both freight and passenger traffic routes.",
@@ -2539,7 +2539,7 @@ Individual: OEO_00010062
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.d",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2562,7 +2562,7 @@ Individual: OEO_00010063
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.e",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other transportation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2582,7 +2582,7 @@ Individual: OEO_00010064
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.e.i",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'pipeline transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2605,7 +2605,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1122",
 Individual: OEO_00010065
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
@@ -2628,7 +2628,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010066
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
@@ -2651,7 +2651,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010067
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)
@@ -2678,7 +2678,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1198",
 Individual: OEO_00010068
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
 - CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
@@ -2703,7 +2703,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010069
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
@@ -2724,7 +2724,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010070
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
@@ -2745,7 +2745,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010071
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
@@ -2766,7 +2766,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
 Individual: OEO_00010122
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The European Union Emissions Trading System (EU ETS) is a policy instrument that implements an emissions trading system covering the European Union, Norway, Iceland and Liechtenstein.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EU ETS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2792,7 +2792,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
 Individual: OEO_00010124
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Decision (ESD) is the European effort sharing for the years 2013-2020. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons and sulphur hexafluoride. Emission quantities under the ESD are calculated using global warming potentials from the Fourth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESD",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2810,7 +2810,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010125
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Regulation (ESR) is the European effort sharing for the years 2021-2030. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons, sulphur hexafluoride and nitrogen trifluoride. Emission quantities under the ESR are calculated using global warming potentials from the Fifth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESR",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2828,7 +2828,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010129
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU climate policy is the policy of the European Union for reducing greenhouse gas emissions. It uses the EU emission sector division.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2844,7 +2844,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010130
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector division is used in the EU climate policy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2860,7 +2860,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010131
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS is a sector defined by the EU emission sector division that covers greenhouse gas emissions that are regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2876,7 +2876,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010132
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2893,7 +2893,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010133
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS aviation is a transport sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2910,7 +2910,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010134
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector effort sharing is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the Effort Sharing Decision and the Effort Sharing Regulation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2926,7 +2926,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010135
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -2946,7 +2946,7 @@ Individual: OEO_00010158
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.a",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'public electricity and heat production' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Sum of emissions from main activity producers of electricity generation, combined heat and power generation, and heat plants.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2966,7 +2966,7 @@ Individual: OEO_00010159
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.b",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'petroleum refining' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion activities supporting the refining of petroleum products including on-site combustion for the generation of electricity and heat for own use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2986,7 +2986,7 @@ Individual: OEO_00010160
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.c",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacture of solid fuels and other energy industries' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from fuel use during the manufacture of secondary and tertiary products from solid fuels including production of charcoal.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3006,7 +3006,7 @@ Individual: OEO_00010161
 
     Annotations: 
         OEO_00010037 "CRF 1.B.1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3026,7 +3026,7 @@ Individual: OEO_00010162
 
     Annotations: 
         OEO_00010037 "CRF 1.B.2",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'oil and natural gas' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises fugitive emissions from all oil and natural gas activities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3045,7 +3045,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
 Individual: OEO_00010163
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GovReg sector division is a sector division defined in Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32020R1208&from=EN#d1e32-98-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3067,7 +3067,7 @@ Individual: OEO_00010164
 
     Annotations: 
         OEO_00010037 "CRF 2.A",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'mineral industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related carbon dioxide (CO2) emissions resulting from the use of carbonate raw materials in the production and use of a variety of mineral industry products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 2.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3087,7 +3087,7 @@ Individual: OEO_00010165
 
     Annotations: 
         OEO_00010037 "CRF 2.A.1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related emissions from the production of various types of cement (ISIC: D2694).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3107,7 +3107,7 @@ Individual: OEO_00010166
 
     Annotations: 
         OEO_00010037 "CRF 2.B",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'chemical industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of various inorganic and organic chemicals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3127,7 +3127,7 @@ Individual: OEO_00010167
 
     Annotations: 
         OEO_00010037 "CRF 2.C",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'metal industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of metals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 4.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3147,7 +3147,7 @@ Individual: OEO_00010168
 
     Annotations: 
         OEO_00010037 "CRF 2.C.1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide is the predominant gas emitted from the production of iron and steel. The sources of the carbon dioxide emissions include that from carbon-containing reducing agents such as coke and pulverized coal, and, from minerals such as limestone and dolomite added.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3167,7 +3167,7 @@ Individual: OEO_00010169
 
     Annotations: 
         OEO_00010037 "CRF 2.D",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'non-energy products from fuels and solvent use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 The use of oil products and coal-derived oils primarily intended for purposes other than combustion",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3187,7 +3187,7 @@ Individual: OEO_00010170
 
     Annotations: 
         OEO_00010037 "CRF 2.E",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'electronics industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Several advanced electronics manufacturing processes utilise fluorinated compounds (FCs) for plasma etching intricate patterns, cleaning reactor chambers, and temperature control. The specific electronic industry sectors include semiconductor, thin-film-transistor flat panel display (TFT-FPD), and photovoltaic (PV) manufacturing (collectively termed ‘electronics industry’).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 6.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3207,7 +3207,7 @@ Individual: OEO_00010171
 
     Annotations: 
         OEO_00010037 "CRF 2.F",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'product uses as substitutes for ozone depleting substances' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Hydrofluorocarbons (HFCs) and, to a very limited extent, perfluorocarbons (PFCs), are serving as alternatives to ozone depleting substances (ODS) being phased out under the Montreal Protocol.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 7.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3227,7 +3227,7 @@ Individual: OEO_00010172
 
     Annotations: 
         OEO_00010037 "CRF 2.G",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other product manufacture and use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
 (PFCs) from the manufacture and use of electrical equipment and a number of other products. It also includes emissions of nitrous oxide (N2O) from several products.",
@@ -3246,7 +3246,7 @@ Individual: OEO_00010173
 
     Annotations: 
         OEO_00010037 "CRF 2.H",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'industrial processes and product use - other' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3264,7 +3264,7 @@ Individual: OEO_00010174
 
     Annotations: 
         OEO_00010037 "CRF 5.A",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid waste disposal' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic microbial decomposition of organic matter in solid waste disposal sites.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3284,7 +3284,7 @@ Individual: OEO_00010175
 
     Annotations: 
         OEO_00010037 "CRF 5.B",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'biological treatment of solid waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Solid waste composting and other biological treatment. Emissions from biogas facilities (anaerobic digestion) with energy production are reported in the Energy Sector (1A4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3304,7 +3304,7 @@ Individual: OEO_00010176
 
     Annotations: 
         OEO_00010037 "CRF 5.C",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'incineration and open burning of waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Incineration of waste and open burning waste, not including waste-to-energy facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3324,7 +3324,7 @@ Individual: OEO_00010177
 
     Annotations: 
         OEO_00010037 "CRF 5.D",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste water treatment and discharge' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic decomposition of organic matter by bacteria in sewage facilities and from food processing and other industrial facilities during wastewater treatment. N2O is also produced by bacteria
 (denitrification and nitrification) in wastewater treatment and discharge.",
@@ -3345,7 +3345,7 @@ Individual: OEO_00010178
 
     Annotations: 
         OEO_00010037 "CRF 5.E",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste - other' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3364,7 +3364,7 @@ Individual: OEO_00010179
 
     Annotations: 
         OEO_00010037 "CRF 3.A",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'enteric fermentation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane emissions from herbivores as a by-product of enteric fermentation (a digestive process by which carbohydrates are broken down by micro-organisms into simple molecules for absorption into the bloodstream). Ruminant animals (e.g., cattle, sheep) are major sources with moderate amounts produced from non-ruminant animals (e.g., pigs, horses).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3384,7 +3384,7 @@ Individual: OEO_00010180
 
     Annotations: 
         OEO_00010037 "CRF 3.B",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manure management' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane and nitrous oxide emissions from the decomposition of manure under low oxygen or anaerobic conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3404,7 +3404,7 @@ Individual: OEO_00010181
 
     Annotations: 
         OEO_00010037 "CRF 3.C",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'rice cultivation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane (CH4) emissions from anaerobic decomposition of organic material in flooded rice fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3424,7 +3424,7 @@ Individual: OEO_00010182
 
     Annotations: 
         OEO_00010037 "CRF 3.D",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agricultural soils' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3442,7 +3442,7 @@ Individual: OEO_00010183
 
     Annotations: 
         OEO_00010037 "CRF 3.E",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'prescribed burning of savannas' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3460,7 +3460,7 @@ Individual: OEO_00010184
 
     Annotations: 
         OEO_00010037 "CRF 3.F",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'field burning of agricultural residues' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from urea application",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3480,7 +3480,7 @@ Individual: OEO_00010185
 
     Annotations: 
         OEO_00010037 "CRF 3.G",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'liming' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from the use of lime in agricultural soils, managed forest soils or lakes.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3500,7 +3500,7 @@ Individual: OEO_00010186
 
     Annotations: 
         OEO_00010037 "CRF 3.H",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'urea application' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3518,7 +3518,7 @@ Individual: OEO_00010187
 
     Annotations: 
         OEO_00010037 "CRF 3.I",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other carbon-containing fertilizers' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3536,7 +3536,7 @@ Individual: OEO_00010188
 
     Annotations: 
         OEO_00010037 "CRF 3.J",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3554,7 +3554,7 @@ Individual: OEO_00010189
 
     Annotations: 
         OEO_00010037 "CRF 4.A",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'forest land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from lands with woody vegetation consistent with thresholds used to define forest land in the national GHG inventory, sub-divided into managed and unmanaged, and possibly also by climatic region, soil type and vegetation type as appropriate. It also includes systems with vegetation that currently fall below, but are expected to later exceed, the threshold values used by a country to define the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3574,7 +3574,7 @@ Individual: OEO_00010190
 
     Annotations: 
         OEO_00010037 "CRF 4.B",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cropland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from arable and tillage land, rice fields, and agro-forestry systems where vegetation falls below the thresholds used for the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3594,7 +3594,7 @@ Individual: OEO_00010191
 
     Annotations: 
         OEO_00010037 "CRF 4.C",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'grassland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from rangelands and pasture land that is not considered cropland. It also includes systems with woody vegetation that fall below the threshold values used in the forest land category and are not expected to exceed them, without human intervention. The category also includes all grassland from wild lands to recreational areas as well as agricultural and silvi-pastural systems, subdivided into managed and unmanaged, consistent with national definitions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3614,7 +3614,7 @@ Individual: OEO_00010192
 
     Annotations: 
         OEO_00010037 "CRF 4.D",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'wetlands' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from land that is covered or saturated by water for all or part of the year (e.g., peatland) and that does not fall into the forest land, cropland, grassland or settlements categories. The category can be subdivided into managed and unmanaged according to national definitions. It includes reservoirs as a managed sub-division and natural rivers and lakes as unmanaged sub-divisions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3634,7 +3634,7 @@ Individual: OEO_00010193
 
     Annotations: 
         OEO_00010037 "CRF 4.E",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'settlements' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from all developed land, including transportation infrastructure and human settlements of any size, unless they are already included under other categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3654,7 +3654,7 @@ Individual: OEO_00010194
 
     Annotations: 
         OEO_00010037 "CRF 4.F",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from bare soil, rock, ice, and all unmanaged land areas that do not fall into any of the other five categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3674,7 +3674,7 @@ Individual: OEO_00010195
 
     Annotations: 
         OEO_00010037 "CRF 4.G",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'harvested wood products' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories
 CO2 net emissions or removals resulting from Harvest Wood Products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3694,7 +3694,7 @@ Individual: OEO_00010196
 
     Annotations: 
         OEO_00010037 "CRF 4.H",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
@@ -3711,7 +3711,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
 Individual: OEO_00010197
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions excluding LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA) https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3735,7 +3735,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
 Individual: OEO_00010198
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions including LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; land use, land-use change and forestry; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3761,7 +3761,7 @@ Individual: OEO_00010199
 
     Annotations: 
         OEO_00010037 "CRF 1.D",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) international bunkers is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international bunkers and multilateral operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
@@ -3785,7 +3785,7 @@ Individual: OEO_00010200
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
@@ -3809,7 +3809,7 @@ Individual: OEO_00010201
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1.a",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3836,7 +3836,7 @@ Individual: OEO_00010202
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1.b",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3863,7 +3863,7 @@ Individual: OEO_00010203
 
     Annotations: 
         OEO_00010037 "CRF 1.D.2",
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'multilateral operation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used for aviation and waterborne navigation in multilateral operations pursuant to the Charter of the United Nations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3887,7 +3887,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
 Individual: OEO_00010204
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3904,7 +3904,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
 Individual: OEO_00010205
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
@@ -3927,7 +3927,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
 Individual: OEO_00010206
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3946,7 +3946,7 @@ Individual: OEO_00010206
 Individual: OEO_00010207
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3965,7 +3965,7 @@ Individual: OEO_00010207
 Individual: OEO_00010208
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2020 emission target of the European Union.",
         
@@ -3987,7 +3987,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
 Individual: OEO_00010209
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2030 emission target as specified in the Nationally Determined Contribution (NDC) of the European Union .",
         
@@ -4009,7 +4009,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
 Individual: OEO_00010228
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4027,7 +4027,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
 Individual: OEO_00010229
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4048,7 +4048,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
 Individual: OEO_00010230
 
     Annotations: 
-        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1,5 +1,5 @@
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: oeo: <http://openenergy-platform.org/ontology/oeo/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -8,7 +8,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social.omn>
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-social/>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
 
@@ -44,6 +44,12 @@ AnnotationProperty: <http://purl.org/dc/terms/source>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
+AnnotationProperty: OEO_00010037
+
+    
+AnnotationProperty: OEO_00269001
+
+    
 AnnotationProperty: dc:contributor
 
     
@@ -51,12 +57,6 @@ AnnotationProperty: dc:description
 
     
 AnnotationProperty: dc:identifier
-
-    
-AnnotationProperty: oeo:OEO_00010037
-
-    
-AnnotationProperty: oeo:OEO_00269001
 
     
 AnnotationProperty: rdfs:comment
@@ -98,10 +98,10 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
-ObjectProperty: oeo:OEO_00000503
+ObjectProperty: OEO_00000503
 
     
-ObjectProperty: oeo:OEO_00000504
+ObjectProperty: OEO_00000504
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
@@ -121,28 +121,28 @@ issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
         <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
-ObjectProperty: oeo:OEO_00000505
+ObjectProperty: OEO_00000505
 
     
-ObjectProperty: oeo:OEO_00000506
+ObjectProperty: OEO_00000506
 
     
-ObjectProperty: oeo:OEO_00000507
+ObjectProperty: OEO_00000507
 
     
-ObjectProperty: oeo:OEO_00000508
+ObjectProperty: OEO_00000508
 
     
-ObjectProperty: oeo:OEO_00000509
+ObjectProperty: OEO_00000509
 
     
-ObjectProperty: oeo:OEO_00000510
+ObjectProperty: OEO_00000510
 
     
-ObjectProperty: oeo:OEO_00000522
+ObjectProperty: OEO_00000522
 
     
-ObjectProperty: oeo:OEO_00010119
+ObjectProperty: OEO_00010119
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
@@ -154,16 +154,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
         <http://purl.obolibrary.org/obo/RO_0000056>
     
     Domain: 
-        oeo:OEO_00140151
+        OEO_00140151
     
     Range: 
-        oeo:OEO_00140149
+        OEO_00140149
     
     
-ObjectProperty: oeo:OEO_00010121
+ObjectProperty: OEO_00010121
 
     
-ObjectProperty: oeo:OEO_00010128
+ObjectProperty: OEO_00010128
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
@@ -172,13 +172,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
         rdfs:label "governs"@en
     
     Domain: 
-        oeo:OEO_00140150 or oeo:OEO_00140151
+        OEO_00140150 or OEO_00140151
     
     
-ObjectProperty: oeo:OEO_00010231
+ObjectProperty: OEO_00010231
 
     
-ObjectProperty: oeo:OEO_00010232
+ObjectProperty: OEO_00010232
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
@@ -187,19 +187,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "has memo item"
     
     SubPropertyOf: 
-        oeo:OEO_00010231
+        OEO_00010231
     
     Domain: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Range: 
-        oeo:OEO_00010227
+        OEO_00010227
     
     
-ObjectProperty: oeo:OEO_00020056
+ObjectProperty: OEO_00020056
 
     
-ObjectProperty: oeo:OEO_00020070
+ObjectProperty: OEO_00020070
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
@@ -220,16 +220,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
     Domain: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
-        oeo:OEO_00010116 or oeo:OEO_00020067 or oeo:OEO_00140124
+        OEO_00010116 or OEO_00020067 or OEO_00140124
     
     Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
     
     InverseOf: 
-        oeo:OEO_00020071
+        OEO_00020071
     
     
-ObjectProperty: oeo:OEO_00020071
+ObjectProperty: OEO_00020071
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
@@ -244,24 +244,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
         owl:topObjectProperty
     
     Domain: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
     
     Range: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
-        oeo:OEO_00010116 or oeo:OEO_00020067 or oeo:OEO_00140124
+        OEO_00010116 or OEO_00020067 or OEO_00140124
     
     InverseOf: 
-        oeo:OEO_00020070
+        OEO_00020070
     
     
-ObjectProperty: oeo:OEO_00040010
+ObjectProperty: OEO_00040010
 
     
-ObjectProperty: oeo:OEO_00140008
+ObjectProperty: OEO_00140008
 
     
-ObjectProperty: oeo:OEO_00140017
+ObjectProperty: OEO_00140017
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
@@ -270,13 +270,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
         rdfs:label "member of"@en
     
     Domain: 
-        oeo:OEO_00000323
+        OEO_00000323
     
     Range: 
-        oeo:OEO_00030022
+        OEO_00030022
     
     
-ObjectProperty: oeo:OEO_00140018
+ObjectProperty: OEO_00140018
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
@@ -288,13 +288,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
         owl:topObjectProperty
     
     Domain: 
-        oeo:OEO_00030022
+        OEO_00030022
     
     Range: 
-        oeo:OEO_00000323
+        OEO_00000323
     
     
-ObjectProperty: oeo:OEO_00140164
+ObjectProperty: OEO_00140164
 
     
 ObjectProperty: owl:topObjectProperty
@@ -384,10 +384,10 @@ Class: <http://purl.obolibrary.org/obo/UO_0000190>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: oeo:OEO_00000045
+Class: OEO_00000045
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -397,37 +397,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "producer"
     
     SubClassOf: 
-        oeo:OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some oeo:OEO_00240003
+        OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240003
     
     
-Class: oeo:OEO_00000051
+Class: OEO_00000051
 
     
-Class: oeo:OEO_00000064
+Class: OEO_00000064
 
     
-Class: oeo:OEO_00000087
+Class: OEO_00000087
 
     
-Class: oeo:OEO_00000105
+Class: OEO_00000105
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
         rdfs:label "consumer"
     
     SubClassOf: 
-        oeo:OEO_00000431
+        OEO_00000431
     
     
-Class: oeo:OEO_00000107
+Class: OEO_00000107
 
     
-Class: oeo:OEO_00000128
+Class: OEO_00000128
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
@@ -438,26 +438,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "energy demand sector"
     
     SubClassOf: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     
-Class: oeo:OEO_00000145
+Class: OEO_00000145
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "electricity sector"
     
     SubClassOf: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     
-Class: oeo:OEO_00000158
+Class: OEO_00000158
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
@@ -466,13 +466,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "energy transformation sector"
     
     SubClassOf: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     
-Class: oeo:OEO_00000213
+Class: OEO_00000213
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -480,13 +480,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "heating and cooling sector"
     
     SubClassOf: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     
-Class: oeo:OEO_00000214
+Class: OEO_00000214
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -494,72 +494,72 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "household sector"
     
     SubClassOf: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     
-Class: oeo:OEO_00000227
+Class: OEO_00000227
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "industry sector"
     
     SubClassOf: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     
-Class: oeo:OEO_00000238
+Class: OEO_00000238
 
     
-Class: oeo:OEO_00000264
+Class: OEO_00000264
 
     SubClassOf: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        oeo:OEO_00140164 some oeo:OEO_00020065
+        OEO_00140164 some OEO_00020065
     
     
-Class: oeo:OEO_00000315
+Class: OEO_00000315
 
     
-Class: oeo:OEO_00000323
+Class: OEO_00000323
 
     
-Class: oeo:OEO_00000329
+Class: OEO_00000329
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
         rdfs:label "political party"
     
     SubClassOf: 
-        oeo:OEO_00030022
+        OEO_00030022
     
     
-Class: oeo:OEO_00000341
+Class: OEO_00000341
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
         rdfs:label "prosumer"
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00000350
+Class: OEO_00000350
 
     
-Class: oeo:OEO_00000367
+Class: OEO_00000367
 
     
-Class: oeo:OEO_00000368
+Class: OEO_00000368
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
         rdfs:label "sector division"
@@ -568,21 +568,21 @@ Class: oeo:OEO_00000368
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: oeo:OEO_00000379
+Class: OEO_00000379
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
         rdfs:label "software developer"
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00000405
+Class: OEO_00000405
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
@@ -592,13 +592,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "commercial sector"
     
     SubClassOf: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     
-Class: oeo:OEO_00000422
+Class: OEO_00000422
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -606,37 +606,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "transport sector"
     
     SubClassOf: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     
-Class: oeo:OEO_00000431
+Class: OEO_00000431
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
         rdfs:label "user"
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00010034
+Class: OEO_00010034
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "building sector"
     
     SubClassOf: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     
-Class: oeo:OEO_00010035
+Class: OEO_00010035
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -644,26 +644,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "agriculture, forestry and land use sector"
     
     SubClassOf: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     
-Class: oeo:OEO_00010036
+Class: OEO_00010036
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         rdfs:label "waste and wastewater sector"
     
     SubClassOf: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     
-Class: oeo:OEO_00010055
+Class: OEO_00010055
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -671,19 +671,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "common reporting format"
     
     SubClassOf: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Class: oeo:OEO_00010079
+Class: OEO_00010079
 
     SubClassOf: 
-        oeo:OEO_00020056 some oeo:OEO_00020063
+        OEO_00020056 some OEO_00020063
     
     
-Class: oeo:OEO_00010082
+Class: OEO_00010082
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
@@ -691,13 +691,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00040011
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00040011
     
     
-Class: oeo:OEO_00010083
+Class: OEO_00010083
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
@@ -708,14 +708,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1019",
         rdfs:label "market participant"@en
     
     SubClassOf: 
-        oeo:OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some oeo:OEO_00010082
+        OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
     
     
-Class: oeo:OEO_00010115
+Class: OEO_00010115
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
@@ -725,30 +725,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
         <http://purl.obolibrary.org/obo/RO_0002577>
     
     
-Class: oeo:OEO_00010116
+Class: OEO_00010116
 
     
-Class: oeo:OEO_00010117
+Class: OEO_00010117
 
     
-Class: oeo:OEO_00010123
+Class: OEO_00010123
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "effort sharing"@en
     
     SubClassOf: 
-        oeo:OEO_00140151,
-        oeo:OEO_00000503 some oeo:OEO_00020063
+        OEO_00140151,
+        OEO_00000503 some OEO_00020063
     
     
-Class: oeo:OEO_00010126
+Class: OEO_00010126
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -756,13 +756,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Annual Emission Allocation"@en
     
     SubClassOf: 
-        oeo:OEO_00020063
+        OEO_00020063
     
     
-Class: oeo:OEO_00010136
+Class: OEO_00010136
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
@@ -772,23 +772,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: oeo:OEO_00010212
+Class: OEO_00010212
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
         rdfs:label "decarbonisation pathway"@en
     
     SubClassOf: 
-        oeo:OEO_00140150
+        OEO_00140150
     
     
-Class: oeo:OEO_00010227
+Class: OEO_00010227
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
@@ -796,16 +796,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some oeo:OEO_00000367
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
     
     
-Class: oeo:OEO_00020015
+Class: OEO_00020015
 
     
-Class: oeo:OEO_00020060
+Class: OEO_00020060
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
@@ -813,17 +813,17 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
         rdfs:label "fuel market exchange"
     
     SubClassOf: 
-        oeo:OEO_00020065,
-        oeo:OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00020066)
+        OEO_00020065,
+        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
     
     
-Class: oeo:OEO_00020063
+Class: OEO_00020063
 
     
-Class: oeo:OEO_00020064
+Class: OEO_00020064
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
@@ -831,107 +831,107 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         rdfs:label "EU allowance"
     
     SubClassOf: 
-        oeo:OEO_00020063
+        OEO_00020063
     
     
-Class: oeo:OEO_00020065
+Class: OEO_00020065
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
         rdfs:label "energy market exchange"
     
     SubClassOf: 
-        oeo:OEO_00020069
+        OEO_00020069
     
     
-Class: oeo:OEO_00020066
+Class: OEO_00020066
 
     
-Class: oeo:OEO_00020067
+Class: OEO_00020067
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000118> "product"
     
     SubClassOf: 
-        oeo:OEO_00020070 some oeo:OEO_00020069
+        OEO_00020070 some OEO_00020069
     
     
-Class: oeo:OEO_00020068
+Class: OEO_00020068
 
     SubClassOf: 
-        oeo:OEO_00020070 some oeo:OEO_00020060
+        OEO_00020070 some OEO_00020060
     
     
-Class: oeo:OEO_00020069
+Class: OEO_00020069
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
         rdfs:label "market exchange"
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00040002
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
     
     SubClassOf: 
-        oeo:OEO_00030022,
+        OEO_00030022,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
 https://github.com/OpenEnergyPlatform/ontology/pull/1019"
         <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (oeo:OEO_00010082
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00010083))
+            (OEO_00010082
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
     
     
-Class: oeo:OEO_00020075
+Class: OEO_00020075
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
         rdfs:label "emission market exchange"
     
     SubClassOf: 
-        oeo:OEO_00020069,
-        oeo:OEO_00020071 some oeo:OEO_00020063
+        OEO_00020069,
+        OEO_00020071 some OEO_00020063
     
     
-Class: oeo:OEO_00020076
+Class: OEO_00020076
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
         rdfs:label "markup"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020077
+Class: OEO_00020077
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
         rdfs:label "markdown"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020108
+Class: OEO_00020108
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
@@ -940,13 +940,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
         rdfs:label "feed-in tariff"
     
     SubClassOf: 
-        oeo:OEO_00140151
+        OEO_00140151
     
     
-Class: oeo:OEO_00020109
+Class: OEO_00020109
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
@@ -954,13 +954,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
         rdfs:label "market premium"
     
     SubClassOf: 
-        oeo:OEO_00140151
+        OEO_00140151
     
     
-Class: oeo:OEO_00020110
+Class: OEO_00020110
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
@@ -968,13 +968,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
         rdfs:label "levy"
     
     SubClassOf: 
-        oeo:OEO_00140151
+        OEO_00140151
     
     
-Class: oeo:OEO_00020111
+Class: OEO_00020111
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
@@ -982,13 +982,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
         rdfs:label "capacity premium"
     
     SubClassOf: 
-        oeo:OEO_00020109
+        OEO_00020109
     
     
-Class: oeo:OEO_00020112
+Class: OEO_00020112
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
@@ -996,27 +996,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
         rdfs:label "tax"
     
     SubClassOf: 
-        oeo:OEO_00020110
+        OEO_00020110
     
     
-Class: oeo:OEO_00020113
+Class: OEO_00020113
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
 https://github.com/OpenEnergyPlatform/ontology/pull/910",
         rdfs:label "inflation rate"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+        OEO_00140012,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
     
     
-Class: oeo:OEO_00020114
+Class: OEO_00020114
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
@@ -1026,14 +1026,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
         rdfs:label "exchange rate"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+        OEO_00140012,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
     
     
-Class: oeo:OEO_00020115
+Class: OEO_00020115
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
@@ -1042,27 +1042,27 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
         rdfs:label "purchasing power parity"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+        OEO_00140012,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
     
     
-Class: oeo:OEO_00020116
+Class: OEO_00020116
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
         rdfs:label "system cost"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00020117
+Class: OEO_00020117
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
@@ -1071,55 +1071,55 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
         rdfs:label "electricity price"
     
     SubClassOf: 
-        oeo:OEO_00040003
+        OEO_00040003
     
     
-Class: oeo:OEO_00020124
+Class: OEO_00020124
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
         rdfs:label "due"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020125
+Class: OEO_00020125
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
         rdfs:label "remuneration"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020126
+Class: OEO_00020126
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
         rdfs:label "fee"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020127
+Class: OEO_00020127
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
@@ -1128,13 +1128,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
         rdfs:label "levelised cost of electricity"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00020128
+Class: OEO_00020128
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add term
 https://github.com/OpenEnergyPlatform/ontology/issues/908
@@ -1142,14 +1142,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/929",
         rdfs:label "market revenue"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some oeo:OEO_00040004
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
-Class: oeo:OEO_00020145
+Class: OEO_00020145
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1157,13 +1157,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
         rdfs:label "variable cost"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00020146
+Class: OEO_00020146
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1171,13 +1171,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
         rdfs:label "variable production cost"
     
     SubClassOf: 
-        oeo:OEO_00020145
+        OEO_00020145
     
     
-Class: oeo:OEO_00020156
+Class: OEO_00020156
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1185,13 +1185,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
         rdfs:label "carbon tax"
     
     SubClassOf: 
-        oeo:OEO_00020112
+        OEO_00020112
     
     
-Class: oeo:OEO_00020167
+Class: OEO_00020167
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
@@ -1204,13 +1204,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "investment cost"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00020168
+Class: OEO_00020168
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
@@ -1222,26 +1222,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "fixed cost"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00020169
+Class: OEO_00020169
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "equipment cost"
     
     SubClassOf: 
-        oeo:OEO_00020167
+        OEO_00020167
     
     
-Class: oeo:OEO_00020170
+Class: OEO_00020170
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
@@ -1251,26 +1251,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "installation cost"
     
     SubClassOf: 
-        oeo:OEO_00020167
+        OEO_00020167
     
     
-Class: oeo:OEO_00020171
+Class: OEO_00020171
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "grid connection cost"
     
     SubClassOf: 
-        oeo:OEO_00020167
+        OEO_00020167
     
     
-Class: oeo:OEO_00020172
+Class: OEO_00020172
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1278,39 +1278,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "property cost"
     
     SubClassOf: 
-        oeo:OEO_00020167
+        OEO_00020167
     
     
-Class: oeo:OEO_00020173
+Class: OEO_00020173
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "decommissioning cost"
     
     SubClassOf: 
-        oeo:OEO_00020167
+        OEO_00020167
     
     
-Class: oeo:OEO_00020174
+Class: OEO_00020174
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
         rdfs:label "delivery cost"
     
     SubClassOf: 
-        oeo:OEO_00040009
+        OEO_00040009
     
     
-Class: oeo:OEO_00030016
+Class: OEO_00030016
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
@@ -1319,14 +1319,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "organisational energy producer"
     
     SubClassOf: 
-        oeo:OEO_00030022,
-        <http://purl.obolibrary.org/obo/RO_0000087> some oeo:OEO_00000045
+        OEO_00030022,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000045
     
     
-Class: oeo:OEO_00030017
+Class: OEO_00030017
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1335,13 +1335,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "energy autoproducer"
     
     SubClassOf: 
-        oeo:OEO_00030016
+        OEO_00030016
     
     
-Class: oeo:OEO_00030018
+Class: OEO_00030018
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1350,19 +1350,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
         rdfs:label "main activity energy producer"
     
     SubClassOf: 
-        oeo:OEO_00030016
+        OEO_00030016
     
     
-Class: oeo:OEO_00030022
+Class: OEO_00030022
 
     
-Class: oeo:OEO_00030035
+Class: OEO_00030035
 
     
-Class: oeo:OEO_00040002
+Class: OEO_00040002
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market",
@@ -1382,16 +1382,16 @@ https://github.com/OpenEnergyPlatform/ontology/pull/748",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: oeo:OEO_00040003
+Class: OEO_00040003
 
     
-Class: oeo:OEO_00040004
+Class: OEO_00040004
 
     
-Class: oeo:OEO_00040005
+Class: OEO_00040005
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
@@ -1405,13 +1405,13 @@ https://github.com/OpenEnergyPlatform/ontology/pull/745",
         rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Trader"
     
     SubClassOf: 
-        oeo:OEO_00010083
+        OEO_00010083
     
     
-Class: oeo:OEO_00040006
+Class: OEO_00040006
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1422,23 +1422,23 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: oeo:OEO_00040007
+Class: OEO_00040007
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
 https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "price request"@en
     
     SubClassOf: 
-        oeo:OEO_00040006
+        OEO_00040006
     
     
-Class: oeo:OEO_00040008
+Class: OEO_00040008
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1446,54 +1446,54 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "marginal cost"@en
     
     SubClassOf: 
-        oeo:OEO_00140012
+        OEO_00140012
     
     
-Class: oeo:OEO_00040009
+Class: OEO_00040009
 
     
-Class: oeo:OEO_00040011
+Class: OEO_00040011
 
     
-Class: oeo:OEO_00090001
+Class: OEO_00090001
 
     
-Class: oeo:OEO_00090002
+Class: OEO_00090002
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
         rdfs:label "public funder"@en
     
     SubClassOf: 
-        oeo:OEO_00090001
+        OEO_00090001
     
     
-Class: oeo:OEO_00090003
+Class: OEO_00090003
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
         rdfs:label "private funder"@en
     
     SubClassOf: 
-        oeo:OEO_00090001
+        OEO_00090001
     
     
-Class: oeo:OEO_00140009
+Class: OEO_00140009
 
     
-Class: oeo:OEO_00140012
+Class: OEO_00140012
 
     
-Class: oeo:OEO_00140013
+Class: OEO_00140013
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
@@ -1504,13 +1504,13 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
         rdfs:label "gross domestic product"@en
     
     SubClassOf: 
-        oeo:OEO_00140012
+        OEO_00140012
     
     
-Class: oeo:OEO_00140023
+Class: OEO_00140023
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
@@ -1521,16 +1521,16 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
         rdfs:label "gross value added"@en
     
     SubClassOf: 
-        oeo:OEO_00140012
+        OEO_00140012
     
     
-Class: oeo:OEO_00140040
+Class: OEO_00140040
 
     
-Class: oeo:OEO_00140109
+Class: OEO_00140109
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1541,10 +1541,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: oeo:OEO_00140117
+Class: OEO_00140117
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1554,10 +1554,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         <http://purl.obolibrary.org/obo/BFO_0000038>
     
     
-Class: oeo:OEO_00140118
+Class: OEO_00140118
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1567,36 +1567,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
-Class: oeo:OEO_00140119
+Class: OEO_00140119
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         rdfs:label "sender"@en
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00140120
+Class: OEO_00140120
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         rdfs:label "receiver"@en
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00140121
+Class: OEO_00140121
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1606,10 +1606,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: oeo:OEO_00140122
+Class: OEO_00140122
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1619,10 +1619,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
-Class: oeo:OEO_00140123
+Class: OEO_00140123
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1631,13 +1631,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         rdfs:label "provider"@en
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00140124
+Class: OEO_00140124
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1648,10 +1648,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: oeo:OEO_00140125
+Class: OEO_00140125
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1659,39 +1659,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
         rdfs:label "delivery interval"@en
     
     SubClassOf: 
-        oeo:OEO_00030035
+        OEO_00030035
     
     
-Class: oeo:OEO_00140130
+Class: OEO_00140130
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
         rdfs:label "power plant operator"@en
     
     SubClassOf: 
-        oeo:OEO_00000051
+        OEO_00000051
     
     
-Class: oeo:OEO_00140131
+Class: OEO_00140131
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
         rdfs:label "conventional trader"@en
     
     SubClassOf: 
-        oeo:OEO_00040005
+        OEO_00040005
     
     
-Class: oeo:OEO_00140136
+Class: OEO_00140136
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1701,10 +1701,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
         <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
-Class: oeo:OEO_00140137
+Class: OEO_00140137
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1714,23 +1714,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: oeo:OEO_00140140
+Class: OEO_00140140
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         rdfs:label "demand trader"@en
     
     SubClassOf: 
-        oeo:OEO_00040005
+        OEO_00040005
     
     
-Class: oeo:OEO_00140141
+Class: OEO_00140141
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -1740,36 +1740,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
-Class: oeo:OEO_00140143
+Class: OEO_00140143
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         rdfs:label "direct marketer"@en
     
     SubClassOf: 
-        oeo:OEO_00040005
+        OEO_00040005
     
     
-Class: oeo:OEO_00140146
+Class: OEO_00140146
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
         rdfs:label "energy demand"@en
     
     SubClassOf: 
-        oeo:OEO_00140040
+        OEO_00140040
     
     
-Class: oeo:OEO_00140149
+Class: OEO_00140149
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
@@ -1779,10 +1779,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: oeo:OEO_00140150
+Class: OEO_00140150
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
@@ -1794,14 +1794,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000020>,
-        oeo:OEO_00010121 some oeo:OEO_00030022,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some oeo:OEO_00140151
+        OEO_00010121 some OEO_00030022,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140151
     
     
-Class: oeo:OEO_00140151
+Class: OEO_00140151
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
@@ -1812,13 +1812,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        oeo:OEO_00010119 some oeo:OEO_00140149
+        OEO_00010119 some OEO_00140149
     
     
-Class: oeo:OEO_00140171
+Class: OEO_00140171
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
@@ -1828,10 +1828,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: oeo:OEO_00230013
+Class: OEO_00230013
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -1842,10 +1842,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
-Class: oeo:OEO_00230014
+Class: OEO_00230014
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -1854,16 +1854,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
         rdfs:label "urban population"@en
     
     SubClassOf: 
-        oeo:OEO_00230013
+        OEO_00230013
     
     DisjointWith: 
-        oeo:OEO_00230015
+        OEO_00230015
     
     
-Class: oeo:OEO_00230015
+Class: OEO_00230015
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -1872,16 +1872,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
         rdfs:label "rural population"@en
     
     SubClassOf: 
-        oeo:OEO_00230013
+        OEO_00230013
     
     DisjointWith: 
-        oeo:OEO_00230014
+        OEO_00230014
     
     
-Class: oeo:OEO_00230016
+Class: OEO_00230016
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
@@ -1891,13 +1891,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
         rdfs:label "labour force"@en
     
     SubClassOf: 
-        oeo:OEO_00230013
+        OEO_00230013
     
     
-Class: oeo:OEO_00230017
+Class: OEO_00230017
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
 https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -1905,56 +1905,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
         rdfs:label "working age population"@en
     
     SubClassOf: 
-        oeo:OEO_00230013
+        OEO_00230013
     
     
-Class: oeo:OEO_00240003
+Class: OEO_00240003
 
     
-Class: oeo:OEO_00240021
+Class: OEO_00240021
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
         rdfs:label "discount rate"
     
     SubClassOf: 
-        oeo:OEO_00140012,
-        oeo:OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
+        OEO_00140012,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
     
     
-Class: oeo:OEO_00240036
+Class: OEO_00240036
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
         rdfs:label "import price"
     
     SubClassOf: 
-        oeo:OEO_00040003
+        OEO_00040003
     
     
-Class: oeo:OEO_00240037
+Class: OEO_00240037
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
         rdfs:label "export price"
     
     SubClassOf: 
-        oeo:OEO_00040003
+        OEO_00040003
     
     
-Individual: oeo:OEO_00000160
+Individual: OEO_00000160
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
@@ -1963,13 +1963,13 @@ The energy balance expresses all forms of energy in a common accounting unit. Th
         rdfs:label "eurostat energy balances"
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Individual: oeo:OEO_00000193
+Individual: OEO_00000193
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
@@ -2001,42 +2001,42 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
         rdfs:label "german energy balances"
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Individual: oeo:OEO_00000242
+Individual: OEO_00000242
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 2006) is a version of the common reporting format that was used for national greenhouse gas inventories since the year 2015. It implements the 2006 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 2006)"
     
     Types: 
-        oeo:OEO_00010055
+        OEO_00010055
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242
+     OEO_00000504  OEO_00000242
     
     
-Individual: oeo:OEO_00000243
+Individual: OEO_00000243
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 1996) is a version of the common reporting format that was used for national greenhouse gas inventories until the year 2014. It implements the Revised 1996 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 1996)"
     
     Types: 
-        oeo:OEO_00010055
+        OEO_00010055
     
     
-Individual: oeo:OEO_00000291
+Individual: OEO_00000291
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
@@ -2044,26 +2044,26 @@ NACE is a four-digit classification providing the framework for collecting and p
         rdfs:label "nace_ sectors"
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Individual: oeo:OEO_00000355
+Individual: OEO_00000355
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
         rdfs:label "renewable_ energy_ directive_ sectors"
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Individual: oeo:OEO_00010038
+Individual: OEO_00010038
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) energy is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All GHG emissions arising from combustion and fugitive releases of fuels. Emissions from the non-energy uses of fuels are generally not included here, but reported under Industrial Processes and Product Use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2072,22 +2072,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): energy"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010040,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010041,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010042,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010043,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010044
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010041,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010042,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010043,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010044
     
     
-Individual: oeo:OEO_00010039
+Individual: OEO_00010039
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the intentional oxidation of materials within an apparatus that is designed to raise heat and provide it either as heat or as mechanical work to a process or for use away from the apparatus.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2096,18 +2096,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
     
     
-Individual: oeo:OEO_00010040
+Individual: OEO_00010040
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industry' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises emissions from fuels combusted by the fuel extraction or energy-producing industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2120,21 +2120,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): energy industry"
     
     Types: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010158,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010159,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010160
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010158,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010159,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010160
     
     
-Individual: oeo:OEO_00010041
+Individual: OEO_00010041
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.2",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.2",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacturing industries and construction' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion of fuels in industry. Also includes combustion for the generation of electricity and heat for own use in these industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2143,18 +2143,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): manufacturing industries and construction"
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
     
     
-Individual: oeo:OEO_00010042
+Individual: OEO_00010042
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the combustion and evaporation of fuel for all transport activity (excluding military transport), regardless of the sector, specifiedby sub-categories below. Emissions from fuel sold to any air or marine vessel engaged in international transport (1 A 3 a i and 1 A 3 d i) should as far as possible be excluded from the totals and subtotals in this category and should be reported separately.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2163,18 +2163,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): transport"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
     
     
-Individual: oeo:OEO_00010043
+Individual: OEO_00010043
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.4",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.4",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion - other sectors' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion activities as described below, including combustion for the generation of electricity and heat for own use in these sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2183,20 +2183,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other sectors"
     
     Types: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010052,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010053
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010052,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010053
     
     
-Individual: oeo:OEO_00010044
+Individual: OEO_00010044
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.5",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.5",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All remaining emissions from fuel combustion that are not specified elsewhere. Include emissions from fuel delivered to the military in the country and delivered to the military of other countries that are not engaged in multilateral operations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2205,18 +2205,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010039
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
     
     
-Individual: oeo:OEO_00010046
+Individual: OEO_00010046
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industrial processes and product use' (IPPU) is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 It covers greenhouse gas emissions occurring from industrial processes, from the use of greenhouse gases in products, and from non-energy uses of fossil fuel carbon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "IPPU",
@@ -2230,25 +2230,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use"
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010164,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010166,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010167,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010169,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010170,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010171,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010172,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010173
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010164,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010166,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010167,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010169,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010170,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010171,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010172,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010173
     
     
-Individual: oeo:OEO_00010047
+Individual: OEO_00010047
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -2259,27 +2259,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture"
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010179,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010180,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010181,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010182,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010183,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010184,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010185,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010186,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010187,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010188
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010179,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010180,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010181,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010182,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010183,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010184,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010185,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010186,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010187,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010188
     
     
-Individual: oeo:OEO_00010048
+Individual: OEO_00010048
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry' (LULUCF) is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LULUCF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -2291,28 +2291,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry"
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010189,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010190,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010192,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010193,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010194,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010195,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010196
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010189,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010190,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010192,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010193,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010194,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010195,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010196
     
     SameAs: 
-        oeo:OEO_00010071,
-        oeo:OEO_00010135
+        OEO_00010071,
+        OEO_00010135
     
     
-Individual: oeo:OEO_00010049
+Individual: OEO_00010049
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2), methane (CH4) and nitrous oxide (N2O) emissions from following categories: Solid waste disposal, Biological treatment of solid waste, 
 Incineration and open burning of waste, Wastewater treatment and discharge.",
@@ -2326,39 +2326,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste"
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010174,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010175,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010176,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010177,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010178
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010174,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010175,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010176,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010177,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010178
     
     
-Individual: oeo:OEO_00010050
+Individual: OEO_00010050
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 6",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 6",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): other"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242
+     OEO_00000504  OEO_00000242
     
     
-Individual: oeo:OEO_00010052
+Individual: OEO_00010052
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.4.a",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.4.a",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'commercial and institutional' is a commercial sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in commercial and institutional buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 1.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2367,18 +2367,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): commercial and institutional"
     
     Types: 
-        oeo:OEO_00000405
+        OEO_00000405
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
     
     
-Individual: oeo:OEO_00010053
+Individual: OEO_00010053
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.4.b",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.4.b",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'residential' is a household sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All emissions from fuel combustion in households.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2387,18 +2387,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): residential"
     
     Types: 
-        oeo:OEO_00000214
+        OEO_00000214
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
     
     
-Individual: oeo:OEO_00010054
+Individual: OEO_00010054
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.4.c",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.4.c",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture, forestry and fishing' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in agriculture, forestry, fishing and fishing industries such as fish farms.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2407,31 +2407,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): agriculture, forestry and fishing"
     
     Types: 
-        oeo:OEO_00000128
+        OEO_00000128
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010043
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
     
     
-Individual: oeo:OEO_00010056
+Individual: OEO_00010056
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector division"
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     
-Individual: oeo:OEO_00010057
+Individual: OEO_00010057
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.B",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.B",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fugitive emissions from fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of solid fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2440,20 +2440,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): fugitive emissions from fuels"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010161,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010162
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010161,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010162
     
     
-Individual: oeo:OEO_00010058
+Individual: OEO_00010058
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.C",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.C",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2462,21 +2462,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): CO2 transport and storage"
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010038
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
     
     DifferentFrom: 
-        oeo:OEO_00010229
+        OEO_00010229
     
     
-Individual: oeo:OEO_00010059
+Individual: OEO_00010059
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.a",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.a",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2485,21 +2485,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic aviation"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
     
     DifferentFrom: 
-        oeo:OEO_00010201
+        OEO_00010201
     
     
-Individual: oeo:OEO_00010060
+Individual: OEO_00010060
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.b",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.b",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'road transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2508,18 +2508,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): road transportation"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
     
     
-Individual: oeo:OEO_00010061
+Individual: OEO_00010061
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.c",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.c",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'railways' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from railway transport for both freight and passenger traffic routes.",
@@ -2528,18 +2528,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): railways"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
     
     
-Individual: oeo:OEO_00010062
+Individual: OEO_00010062
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.d",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.d",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2548,21 +2548,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic navigation"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
     
     DifferentFrom: 
-        oeo:OEO_00010202
+        OEO_00010202
     
     
-Individual: oeo:OEO_00010063
+Individual: OEO_00010063
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.e",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.e",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other transportation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2571,18 +2571,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): other transportation"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010042
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
     
     
-Individual: oeo:OEO_00010064
+Individual: OEO_00010064
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.3.e.i",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.3.e.i",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'pipeline transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2595,17 +2595,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1122",
         rdfs:label "CRF sector (IPCC 2006): pipeline transport"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010063
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010063
     
     
-Individual: oeo:OEO_00010065
+Individual: OEO_00010065
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
@@ -2616,19 +2616,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector energy industry"
     
     Types: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010040,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010057,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010064
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010057,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010064
     
     
-Individual: oeo:OEO_00010066
+Individual: OEO_00010066
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
@@ -2639,19 +2639,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector industry"
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010041,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010058
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010041,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010058
     
     
-Individual: oeo:OEO_00010067
+Individual: OEO_00010067
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)
@@ -2666,19 +2666,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1198",
         rdfs:label "KSG sector buildings"
     
     Types: 
-        oeo:OEO_00010034
+        OEO_00010034
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010044,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010052,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010053
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010044,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010052,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010053
     
     
-Individual: oeo:OEO_00010068
+Individual: OEO_00010068
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
 - CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
@@ -2690,20 +2690,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector transport"
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010059,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010060,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010061,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010062
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010059,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010060,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010061,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010062
     
     
-Individual: oeo:OEO_00010069
+Individual: OEO_00010069
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
@@ -2713,18 +2713,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector agriculture"
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010054
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010054
     
     
-Individual: oeo:OEO_00010070
+Individual: OEO_00010070
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
@@ -2734,18 +2734,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector waste management and other"
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
+     OEO_00000504  OEO_00010056,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
     
     
-Individual: oeo:OEO_00010071
+Individual: OEO_00010071
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
@@ -2754,19 +2754,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector land use, land-use change and forestry"
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010056
+     OEO_00000504  OEO_00010056
     
     SameAs: 
-        oeo:OEO_00010048
+        OEO_00010048
     
     
-Individual: oeo:OEO_00010122
+Individual: OEO_00010122
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The European Union Emissions Trading System (EU ETS) is a policy instrument that implements an emissions trading system covering the European Union, Norway, Iceland and Liechtenstein.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EU ETS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2778,21 +2778,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "European Union Emissions Trading System"@en
     
     Types: 
-        oeo:OEO_00140151,
-        oeo:OEO_00000503 some oeo:OEO_00020064
+        OEO_00140151,
+        OEO_00000503 some OEO_00020064
     
     Facts:  
-     oeo:OEO_00010128  oeo:OEO_00010131,
-     oeo:OEO_00010128  oeo:OEO_00010132,
-     oeo:OEO_00010128  oeo:OEO_00010133,
-     oeo:OEO_00010128  oeo:OEO_00010205,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
+     OEO_00010128  OEO_00010131,
+     OEO_00010128  OEO_00010132,
+     OEO_00010128  OEO_00010133,
+     OEO_00010128  OEO_00010205,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
     
     
-Individual: oeo:OEO_00010124
+Individual: OEO_00010124
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Decision (ESD) is the European effort sharing for the years 2013-2020. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons and sulphur hexafluoride. Emission quantities under the ESD are calculated using global warming potentials from the Fourth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESD",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2800,17 +2800,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Decision"@en
     
     Types: 
-        oeo:OEO_00010123,
-        oeo:OEO_00000503 some oeo:OEO_00010126
+        OEO_00010123,
+        OEO_00000503 some OEO_00010126
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
     
     
-Individual: oeo:OEO_00010125
+Individual: OEO_00010125
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Regulation (ESR) is the European effort sharing for the years 2021-2030. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons, sulphur hexafluoride and nitrogen trifluoride. Emission quantities under the ESR are calculated using global warming potentials from the Fifth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESR",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2818,135 +2818,135 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Regulation"@en
     
     Types: 
-        oeo:OEO_00010123,
-        oeo:OEO_00000503 some oeo:OEO_00010126
+        OEO_00010123,
+        OEO_00000503 some OEO_00010126
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010129
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
     
     
-Individual: oeo:OEO_00010129
+Individual: OEO_00010129
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU climate policy is the policy of the European Union for reducing greenhouse gas emissions. It uses the EU emission sector division.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU climate policy"@en
     
     Types: 
-        oeo:OEO_00140150
+        OEO_00140150
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00010130
+     OEO_00000503  OEO_00010130
     
     
-Individual: oeo:OEO_00010130
+Individual: OEO_00010130
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector division is used in the EU climate policy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector division"@en
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010129
+     OEO_00000504  OEO_00010129
     
     
-Individual: oeo:OEO_00010131
+Individual: OEO_00010131
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS is a sector defined by the EU emission sector division that covers greenhouse gas emissions that are regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010130
+     OEO_00000504  OEO_00010130
     
     
-Individual: oeo:OEO_00010132
+Individual: OEO_00010132
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS stationary"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010130,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010131
+     OEO_00000504  OEO_00010130,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010131
     
     
-Individual: oeo:OEO_00010133
+Individual: OEO_00010133
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS aviation is a transport sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS aviation"@en
     
     Types: 
-        oeo:OEO_00000422
+        OEO_00000422
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010130,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010131
+     OEO_00000504  OEO_00010130,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010131
     
     
-Individual: oeo:OEO_00010134
+Individual: OEO_00010134
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector effort sharing is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the Effort Sharing Decision and the Effort Sharing Regulation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: effort sharing"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010130
+     OEO_00000504  OEO_00010130
     
     
-Individual: oeo:OEO_00010135
+Individual: OEO_00010135
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: LULUCF"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010130
+     OEO_00000504  OEO_00010130
     
     SameAs: 
-        oeo:OEO_00010048
+        OEO_00010048
     
     
-Individual: oeo:OEO_00010158
+Individual: OEO_00010158
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.1.a",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.1.a",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'public electricity and heat production' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Sum of emissions from main activity producers of electricity generation, combined heat and power generation, and heat plants.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2955,18 +2955,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): public electricity and heat production"@en
     
     Types: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
     
     
-Individual: oeo:OEO_00010159
+Individual: OEO_00010159
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.1.b",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.1.b",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'petroleum refining' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion activities supporting the refining of petroleum products including on-site combustion for the generation of electricity and heat for own use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2975,18 +2975,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): petroleum refining"@en
     
     Types: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
     
     
-Individual: oeo:OEO_00010160
+Individual: OEO_00010160
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.A.1.c",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.A.1.c",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacture of solid fuels and other energy industries' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from fuel use during the manufacture of secondary and tertiary products from solid fuels including production of charcoal.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2995,18 +2995,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries"@en
     
     Types: 
-        oeo:OEO_00000158
+        OEO_00000158
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010040
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
     
     
-Individual: oeo:OEO_00010161
+Individual: OEO_00010161
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.B.1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.B.1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3015,18 +3015,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid fuels"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010057
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010057
     
     
-Individual: oeo:OEO_00010162
+Individual: OEO_00010162
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.B.2",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.B.2",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'oil and natural gas' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises fugitive emissions from all oil and natural gas activities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3035,17 +3035,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): oil and natural gas"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010057
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010057
     
     
-Individual: oeo:OEO_00010163
+Individual: OEO_00010163
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GovReg sector division is a sector division defined in Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32020R1208&from=EN#d1e32-98-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3057,17 +3057,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "GovReg sector division"@en
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242
+     OEO_00000503  OEO_00000242
     
     
-Individual: oeo:OEO_00010164
+Individual: OEO_00010164
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.A",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.A",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'mineral industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related carbon dioxide (CO2) emissions resulting from the use of carbonate raw materials in the production and use of a variety of mineral industry products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 2.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3076,18 +3076,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): mineral industry"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010165
+Individual: OEO_00010165
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.A.1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.A.1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related emissions from the production of various types of cement (ISIC: D2694).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3096,18 +3096,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cement production"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010164
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010164
     
     
-Individual: oeo:OEO_00010166
+Individual: OEO_00010166
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.B",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.B",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'chemical industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of various inorganic and organic chemicals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3116,18 +3116,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): chemical industry"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010167
+Individual: OEO_00010167
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.C",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.C",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'metal industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of metals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 4.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3136,18 +3136,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): metal industry"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010168
+Individual: OEO_00010168
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.C.1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.C.1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide is the predominant gas emitted from the production of iron and steel. The sources of the carbon dioxide emissions include that from carbon-containing reducing agents such as coke and pulverized coal, and, from minerals such as limestone and dolomite added.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3156,18 +3156,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): iron and steel production"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010167
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010167
     
     
-Individual: oeo:OEO_00010169
+Individual: OEO_00010169
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.D",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.D",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'non-energy products from fuels and solvent use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 The use of oil products and coal-derived oils primarily intended for purposes other than combustion",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3176,18 +3176,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): non-energy products from fuels and solvent use"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010170
+Individual: OEO_00010170
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.E",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.E",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'electronics industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Several advanced electronics manufacturing processes utilise fluorinated compounds (FCs) for plasma etching intricate patterns, cleaning reactor chambers, and temperature control. The specific electronic industry sectors include semiconductor, thin-film-transistor flat panel display (TFT-FPD), and photovoltaic (PV) manufacturing (collectively termed ‘electronics industry’).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 6.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3196,18 +3196,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): electronics industry"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010171
+Individual: OEO_00010171
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.F",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.F",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'product uses as substitutes for ozone depleting substances' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Hydrofluorocarbons (HFCs) and, to a very limited extent, perfluorocarbons (PFCs), are serving as alternatives to ozone depleting substances (ODS) being phased out under the Montreal Protocol.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 7.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3216,18 +3216,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): product uses as substitutes for ozone depleting substances"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010172
+Individual: OEO_00010172
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.G",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.G",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other product manufacture and use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
 (PFCs) from the manufacture and use of electrical equipment and a number of other products. It also includes emissions of nitrous oxide (N2O) from several products.",
@@ -3235,36 +3235,36 @@ Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
         rdfs:label "CRF sector (IPCC 2006): other product manufacture and use"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010173
+Individual: OEO_00010173
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 2.H",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 2.H",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'industrial processes and product use - other' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use - other"@en
     
     Types: 
-        oeo:OEO_00000227
+        OEO_00000227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010046
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
     
     
-Individual: oeo:OEO_00010174
+Individual: OEO_00010174
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5.A",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5.A",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid waste disposal' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic microbial decomposition of organic matter in solid waste disposal sites.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3273,18 +3273,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid waste disposal"@en
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
     
     
-Individual: oeo:OEO_00010175
+Individual: OEO_00010175
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5.B",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5.B",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'biological treatment of solid waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Solid waste composting and other biological treatment. Emissions from biogas facilities (anaerobic digestion) with energy production are reported in the Energy Sector (1A4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3293,18 +3293,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): biological treatment of solid waste"@en
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
     
     
-Individual: oeo:OEO_00010176
+Individual: OEO_00010176
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5.C",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5.C",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'incineration and open burning of waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Incineration of waste and open burning waste, not including waste-to-energy facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3313,18 +3313,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): incineration and open burning of waste"@en
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
     
     
-Individual: oeo:OEO_00010177
+Individual: OEO_00010177
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5.D",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5.D",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste water treatment and discharge' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic decomposition of organic matter by bacteria in sewage facilities and from food processing and other industrial facilities during wastewater treatment. N2O is also produced by bacteria
 (denitrification and nitrification) in wastewater treatment and discharge.",
@@ -3334,18 +3334,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste water treatment and discharge"@en
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
     
     
-Individual: oeo:OEO_00010178
+Individual: OEO_00010178
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 5.E",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 5.E",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste - other' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3353,18 +3353,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste - other"@en
     
     Types: 
-        oeo:OEO_00010036
+        OEO_00010036
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010049
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
     
     
-Individual: oeo:OEO_00010179
+Individual: OEO_00010179
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.A",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.A",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'enteric fermentation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane emissions from herbivores as a by-product of enteric fermentation (a digestive process by which carbohydrates are broken down by micro-organisms into simple molecules for absorption into the bloodstream). Ruminant animals (e.g., cattle, sheep) are major sources with moderate amounts produced from non-ruminant animals (e.g., pigs, horses).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3373,18 +3373,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): enteric fermentation"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010180
+Individual: OEO_00010180
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.B",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.B",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manure management' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane and nitrous oxide emissions from the decomposition of manure under low oxygen or anaerobic conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3393,18 +3393,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manure management"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010181
+Individual: OEO_00010181
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.C",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.C",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'rice cultivation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane (CH4) emissions from anaerobic decomposition of organic material in flooded rice fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3413,54 +3413,54 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): rice cultivation"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010182
+Individual: OEO_00010182
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.D",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.D",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agricultural soils' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agricultural soils"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010183
+Individual: OEO_00010183
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.E",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.E",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'prescribed burning of savannas' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): prescribed burning of savannas"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010184
+Individual: OEO_00010184
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.F",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.F",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'field burning of agricultural residues' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from urea application",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3469,18 +3469,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): field burning of agricultural residues"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010185
+Individual: OEO_00010185
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.G",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.G",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'liming' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from the use of lime in agricultural soils, managed forest soils or lakes.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3489,72 +3489,72 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): liming"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010186
+Individual: OEO_00010186
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.H",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.H",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'urea application' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): urea application"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010187
+Individual: OEO_00010187
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.I",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.I",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other carbon-containing fertilizers' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other carbon-containing fertilizers"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010188
+Individual: OEO_00010188
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 3.J",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 3.J",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture - other"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010047
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
     
     
-Individual: oeo:OEO_00010189
+Individual: OEO_00010189
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.A",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.A",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'forest land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from lands with woody vegetation consistent with thresholds used to define forest land in the national GHG inventory, sub-divided into managed and unmanaged, and possibly also by climatic region, soil type and vegetation type as appropriate. It also includes systems with vegetation that currently fall below, but are expected to later exceed, the threshold values used by a country to define the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3563,18 +3563,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): forest land"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010190
+Individual: OEO_00010190
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.B",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.B",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cropland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from arable and tillage land, rice fields, and agro-forestry systems where vegetation falls below the thresholds used for the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3583,18 +3583,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cropland"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010191
+Individual: OEO_00010191
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.C",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.C",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'grassland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from rangelands and pasture land that is not considered cropland. It also includes systems with woody vegetation that fall below the threshold values used in the forest land category and are not expected to exceed them, without human intervention. The category also includes all grassland from wild lands to recreational areas as well as agricultural and silvi-pastural systems, subdivided into managed and unmanaged, consistent with national definitions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3603,18 +3603,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): grassland"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010192
+Individual: OEO_00010192
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.D",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.D",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'wetlands' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from land that is covered or saturated by water for all or part of the year (e.g., peatland) and that does not fall into the forest land, cropland, grassland or settlements categories. The category can be subdivided into managed and unmanaged according to national definitions. It includes reservoirs as a managed sub-division and natural rivers and lakes as unmanaged sub-divisions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3623,18 +3623,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): wetlands"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010193
+Individual: OEO_00010193
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.E",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.E",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'settlements' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from all developed land, including transportation infrastructure and human settlements of any size, unless they are already included under other categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3643,18 +3643,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): settlements"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010194
+Individual: OEO_00010194
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.F",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.F",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from bare soil, rock, ice, and all unmanaged land areas that do not fall into any of the other five categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3663,18 +3663,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other land"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010195
+Individual: OEO_00010195
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.G",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.G",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'harvested wood products' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories
 CO2 net emissions or removals resulting from Harvest Wood Products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3683,35 +3683,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): harvested wood products"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010196
+Individual: OEO_00010196
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 4.H",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 4.H",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry - other"@en
     
     Types: 
-        oeo:OEO_00010035
+        OEO_00010035
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010048
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
     
     
-Individual: oeo:OEO_00010197
+Individual: OEO_00010197
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions excluding LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA) https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3721,21 +3721,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions excluding LULUCF"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
     
     
-Individual: oeo:OEO_00010198
+Individual: OEO_00010198
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions including LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; land use, land-use change and forestry; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3745,71 +3745,71 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions including LULUCF"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010048,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010050
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010038,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010048,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
     
     
-Individual: oeo:OEO_00010199
+Individual: OEO_00010199
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.D",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.D",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) international bunkers is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international bunkers and multilateral operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers and multilateral operations"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010203
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010203
     
     
-Individual: oeo:OEO_00010200
+Individual: OEO_00010200
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.D.1",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.D.1",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010202
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010202
     
     
-Individual: oeo:OEO_00010201
+Individual: OEO_00010201
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.D.1.a",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.D.1.a",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3817,26 +3817,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international aviation"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010200
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010200
     
     DifferentFrom: 
-        oeo:OEO_00010059
+        OEO_00010059
     
     
-Individual: oeo:OEO_00010202
+Individual: OEO_00010202
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.D.1.b",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.D.1.b",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3844,26 +3844,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): maritime navigation"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010200
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010200
     
     DifferentFrom: 
-        oeo:OEO_00010062
+        OEO_00010062
     
     
-Individual: oeo:OEO_00010203
+Individual: OEO_00010203
 
     Annotations: 
-        oeo:OEO_00010037 "CRF 1.D.2",
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00010037 "CRF 1.D.2",
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'multilateral operation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used for aviation and waterborne navigation in multilateral operations pursuant to the Charter of the United Nations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3872,22 +3872,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): multilateral operations"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010199
+     OEO_00000504  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010199
     
     
-Individual: oeo:OEO_00010204
+Individual: OEO_00010204
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3895,39 +3895,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector division"@en
     
     Types: 
-        oeo:OEO_00000368
+        OEO_00000368
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242
+     OEO_00000503  OEO_00000242
     
     
-Individual: oeo:OEO_00010205
+Individual: OEO_00010205
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector: M.International aviation in the EU ETS"@en
     
     Types: 
-        oeo:OEO_00000422,
-        oeo:OEO_00010232 some oeo:OEO_00010227,
+        OEO_00000422,
+        OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00010204,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  oeo:OEO_00010133,
-      not  oeo:OEO_00000504  oeo:OEO_00010163
+     OEO_00000504  OEO_00010204,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010133,
+      not  OEO_00000504  OEO_00010163
     
     
-Individual: oeo:OEO_00010206
+Individual: OEO_00010206
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3935,18 +3935,18 @@ Individual: oeo:OEO_00010206
         rdfs:label "total emissions excluding LULUCF and including international bunkers"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010197,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200
+     OEO_00000503  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010197,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200
     
     
-Individual: oeo:OEO_00010207
+Individual: OEO_00010207
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3954,18 +3954,18 @@ Individual: oeo:OEO_00010207
         rdfs:label "total emissions including LULUCF and including international bunkers"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010198,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010200
+     OEO_00000503  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010198,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200
     
     
-Individual: oeo:OEO_00010208
+Individual: OEO_00010208
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2020 emission target of the European Union.",
         
@@ -3976,18 +3976,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions excluding LULUCF and including international aviation"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010197,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201
+     OEO_00000503  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010197,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201
     
     
-Individual: oeo:OEO_00010209
+Individual: OEO_00010209
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2030 emission target as specified in the Nationally Determined Contribution (NDC) of the European Union .",
         
@@ -3998,18 +3998,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions including LULUCF and including international aviation"@en
     
     Types: 
-        oeo:OEO_00000367
+        OEO_00000367
     
     Facts:  
-     oeo:OEO_00000503  oeo:OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010198,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  oeo:OEO_00010201
+     OEO_00000503  OEO_00000242,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010198,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201
     
     
-Individual: oeo:OEO_00010228
+Individual: OEO_00010228
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4017,17 +4017,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 emissions from biomass"@en
     
     Types: 
-        oeo:OEO_00000367,
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00000367,
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242
+     OEO_00000504  OEO_00000242
     
     
-Individual: oeo:OEO_00010229
+Individual: OEO_00010229
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4035,20 +4035,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 captured"@en
     
     Types: 
-        oeo:OEO_00000367,
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00000367,
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242
+     OEO_00000504  OEO_00000242
     
     DifferentFrom: 
-        oeo:OEO_00010058
+        OEO_00010058
     
     
-Individual: oeo:OEO_00010230
+Individual: OEO_00010230
 
     Annotations: 
-        oeo:OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00269001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4056,13 +4056,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): indirect CO2"@en
     
     Types: 
-        oeo:OEO_00000367,
-        oeo:OEO_00010232 some oeo:OEO_00010227
+        OEO_00000367,
+        OEO_00010232 some OEO_00010227
     
     Facts:  
-     oeo:OEO_00000504  oeo:OEO_00000242
+     OEO_00000504  OEO_00000242
     
     
 DisjointClasses: 
-    oeo:OEO_00000145,oeo:OEO_00000213,oeo:OEO_00000422
+    OEO_00000145,OEO_00000213,OEO_00000422
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1,7 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
-Prefix: bfo: <http://purl.obolibrary.org/obo/bfo.owl#>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: obda: <https://w3id.org/obda/vocabulary#>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -19,6 +16,12 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (social module)"
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010037>
+
+    
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00269001>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
 
     
@@ -46,9 +49,6 @@ AnnotationProperty: <http://purl.org/dc/terms/source>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
-AnnotationProperty: OEO_00010037
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -73,6 +73,208 @@ AnnotationProperty: rdfs:seeAlso
 Datatype: rdf:PlainLiteral
 
     
+Datatype: xsd:string
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000503>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000504>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
+
+domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+
+adapt domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "is defined by"
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000505>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000506>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000507>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000508>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000509>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000510>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000522>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010119>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+        rdfs:label "guides"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000056>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010121>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010128>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
+        rdfs:label "governs"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140150> or <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010232>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "has memo item"
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010231>
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020070>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+change range: 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/791
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842
+
+add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "is traded at"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010116> or <http://openenergy-platform.org/ontology/oeo/OEO_00020067> or <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020071>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020071>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+add domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+        rdfs:label "trades"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010116> or <http://openenergy-platform.org/ontology/oeo/OEO_00020067> or <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020070>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00040010>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140008>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140017>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
+        rdfs:label "member of"@en
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140018>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
+        rdfs:label "has member"@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+    
+    Range: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+    
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140164>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     
@@ -94,207 +296,1575 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
-ObjectProperty: OEO_00000503
-
-    
-ObjectProperty: OEO_00000504
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
-
-domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-
-adapt domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "is defined by"
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    
-ObjectProperty: OEO_00000505
-
-    
-ObjectProperty: OEO_00000506
-
-    
-ObjectProperty: OEO_00000507
-
-    
-ObjectProperty: OEO_00000508
-
-    
-ObjectProperty: OEO_00000509
-
-    
-ObjectProperty: OEO_00000510
-
-    
-ObjectProperty: OEO_00000522
-
-    
-ObjectProperty: OEO_00010119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
-        rdfs:label "guides"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000056>
-    
-    Domain: 
-        OEO_00140151
-    
-    Range: 
-        OEO_00140149
-    
-    
-ObjectProperty: OEO_00010121
-
-    
-ObjectProperty: OEO_00010128
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
-        rdfs:label "governs"@en
-    
-    Domain: 
-        OEO_00140150 or OEO_00140151
-    
-    
-ObjectProperty: OEO_00010231
-
-    
-ObjectProperty: OEO_00010232
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a sector and a memo item.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
-        rdfs:label "has memo item"
-    
-    SubPropertyOf: 
-        OEO_00010231
-    
-    Domain: 
-        OEO_00000367
-    
-    Range: 
-        OEO_00010227
-    
-    
-ObjectProperty: OEO_00020056
-
-    
-ObjectProperty: OEO_00020070
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-change range: 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/791
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842
-
-add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "is traded at"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
-        OEO_00010116 or OEO_00020067 or OEO_00140124
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    InverseOf: 
-        OEO_00020071
-    
-    
-ObjectProperty: OEO_00020071
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-add domain and range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "trades"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
-        OEO_00010116 or OEO_00020067 or OEO_00140124
-    
-    InverseOf: 
-        OEO_00020070
-    
-    
-ObjectProperty: OEO_00040010
-
-    
-ObjectProperty: OEO_00140008
-
-    
-ObjectProperty: OEO_00140017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a person and an organisation where the person is a member of the organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
-        rdfs:label "member of"@en
-    
-    Domain: 
-        OEO_00000323
-    
-    Range: 
-        OEO_00030022
-    
-    
-ObjectProperty: OEO_00140018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an organisation and a person where the person is a member of the organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/486
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
-        rdfs:label "has member"@en
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Domain: 
-        OEO_00030022
-    
-    Range: 
-        OEO_00000323
-    
-    
-ObjectProperty: OEO_00140164
-
-    
 ObjectProperty: owl:topObjectProperty
 
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000045>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "producer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000087>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000105>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
+        rdfs:label "consumer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000431>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000107>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1015"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "energy demand sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000145>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "electricity sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "energy transformation sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000213>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "heating and cooling sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000214>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "household sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "industry sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000238>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000264>
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140164> some <http://openenergy-platform.org/ontology/oeo/OEO_00020065>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000315>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000323>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000329>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
+        rdfs:label "political party"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000341>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
+        rdfs:label "prosumer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
+        rdfs:label "sector division"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000379>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
+        rdfs:label "software developer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000405>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "trading, commerce and service sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "commercial sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "transport sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000431>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
+        rdfs:label "user"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010034>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "building sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "agriculture, forestry and land use sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
+        rdfs:label "waste and wastewater sector"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
+        rdfs:label "common reporting format"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010082>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
+        rdfs:label "trade"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010083>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+update definition and improve axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019",
+        rdfs:label "market participant"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00010082>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010115>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "economy"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010116>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010117>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010123>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
+        rdfs:label "effort sharing"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
+        rdfs:label "Annual Emission Allocation"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010136>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
+        rdfs:label "distribution"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010212>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
+        rdfs:label "decarbonisation pathway"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
+        rdfs:label "memo item"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020015>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020060>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel market exchange"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020065>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020071> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00020066>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020064>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+        rdfs:label "EU allowance"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020065>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "energy market exchange"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020066>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020067>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "product"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020070> some <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020068>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020070> some <http://openenergy-platform.org/ontology/oeo/OEO_00020060>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020069>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019"
+        <http://purl.obolibrary.org/obo/RO_0000056> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00010082>
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00010083>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020075>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
+        rdfs:label "emission market exchange"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020069>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020071> some <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020076>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        rdfs:label "markup"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020077>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        rdfs:label "markdown"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020108>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:comment "Feed-in tariffs provide cost-based compensation to renewable energy producers, leading to price certainty and long-term contracts that help finance energy transformation units, e.g. power plants",
+        rdfs:label "feed-in tariff"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020109>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "market premium"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020110>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "levy"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020111>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "capacity premium"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020109>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020112>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
+        rdfs:label "tax"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020110>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020113>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:label "inflation rate"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020114>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:comment "The ratio at which one can exchange one currency for another can differ over time therefore it is necessary to specify a time point when referring to an exchange rate.",
+        rdfs:label "exchange rate"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020115>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
+https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        <http://purl.org/dc/terms/source> "https://www.oecd.org/sdd/prices-ppp/purchasingpowerparities-frequentlyaskedquestionsfaqs.htm#FAQ1",
+        rdfs:label "purchasing power parity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0010006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020116>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:label "system cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020117>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
+        rdfs:comment "has unit some \"currency per energy unit\"",
+        rdfs:label "electricity price"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020124>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "due"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020125>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "remuneration"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020126>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:label "fee"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020127>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+        rdfs:comment "Since over the lifetime of an energy transformation unit different costs exhibit different relevance or vary over time, the LCOE differ over the course of the lifetime.",
+        rdfs:label "levelised cost of electricity"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020128>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add term
+https://github.com/OpenEnergyPlatform/ontology/issues/908
+https://github.com/OpenEnergyPlatform/ontology/pull/929",
+        rdfs:label "market revenue"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020145>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
+        rdfs:label "variable cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020146>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
+        rdfs:label "variable production cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020145>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020156>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
+        rdfs:label "carbon tax"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020112>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "investment",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "FIBO definition of investment relates to property only: https://spec.edmcouncil.org/fibo/ontology?searchBoxQuery=investment, 
+
+Gabler on Investition: langfristige Bindung finanzieller Mittel in materiellen oder in immateriellen Vermögensgegenständen (https://wirtschaftslexikon.gabler.de/definition/investition-39454)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "investment cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020168>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "oemof-Model: https://oemof-solph.readthedocs.io/en/latest/_modules/oemof/solph/options.html?highlight=fix%20costs
+
+Fixe Kosten: Kosten, die von der jeweils betrachteten Einflussgröße bzw. Entscheidung unabhängig sind, d.h. Kosten, die sich nicht mit der jeweils betrachteten Einflussgröße ändern. (https://wirtschaftslexikon.gabler.de/definition/fixe-kosten-33359)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "fixed cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020169>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "equipment cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020170>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "site development cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "installation cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020171>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "grid connection cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020172>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "property cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020173>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "decommissioning cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020167>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020174>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+        rdfs:label "delivery cost"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "organisational energy producer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
+        <http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000045>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:comment "They may be privately or publicly owned.",
+        rdfs:label "energy autoproducer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030018>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
+        rdfs:label "main activity energy producer"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030016>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
+https://github.com/OpenEnergyPlatform/ontology/pull/639
+
+https://github.com/OpenEnergyPlatform/ontology/issues/677
+https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+change label to market exchange role
+https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040004>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/377
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/641
+
+Make trader subclass of market participant:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+https://github.com/OpenEnergyPlatform/ontology/pull/745",
+        rdfs:label "trader"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Trader"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010083>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040006>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "request"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040007>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "price request"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040008>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
+https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        rdfs:label "marginal cost"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040009>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00040011>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090002>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "public funder"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00090003>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+        rdfs:label "private funder"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00090001>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140009>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140013>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
+alternative term:
+https://github.com/OpenEnergyPlatform/ontology/issues/675
+https://github.com/OpenEnergyPlatform/ontology/pull/676",
+        rdfs:label "gross domestic product"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140023>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563
+alternative term:
+https://github.com/OpenEnergyPlatform/ontology/issues/675
+https://github.com/OpenEnergyPlatform/ontology/pull/676",
+        rdfs:label "gross value added"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140109>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
+        rdfs:label "contract"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140117>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "delivery time"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140118>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "delivery time point"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140119>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "sender"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140120>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "receiver"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140121>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "bid"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140122>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "award"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000310>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140123>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:comment "The transfer is typically defined in a contract.",
+        rdfs:label "provider"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140124>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+        rdfs:label "service"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140125>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:comment "This duration is often contractually fixed and regular.",
+        rdfs:label "delivery interval"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140130>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "power plant operator"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000051>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140131>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+        rdfs:label "conventional trader"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140136>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
+        rdfs:label "dispatch assignment"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140137>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
+        rdfs:label "power plant portfolio"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140140>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "demand trader"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140141>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "merit order"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140143>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
+        rdfs:label "direct marketer"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040005>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140146>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
+        rdfs:label "energy demand"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140040>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
+        rdfs:label "transformative measure"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+        rdfs:label "policy"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010121> some <http://openenergy-platform.org/ontology/oeo/OEO_00030022>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
+        rdfs:label "policy instrument"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010119> some <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140171>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
+        rdfs:label "email address"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "population"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230014>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "urban population"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230015>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230015>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
+https://github.com/OpenEnergyPlatform/ontology/issues/479
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "rural population"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230014>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230016>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
+https://github.com/OpenEnergyPlatform/ontology/issues/301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "labour force"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00230017>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
+https://github.com/OpenEnergyPlatform/ontology/issues/479
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
+        rdfs:label "working age population"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00230013>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240003>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240021>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
+        rdfs:label "discount rate"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140012>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040010> some <http://purl.obolibrary.org/obo/UO_0000187>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240036>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
+        rdfs:label "import price"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00240037>
+
+    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
+        rdfs:label "export price"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00040003>
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
@@ -380,1474 +1950,10 @@ Class: <http://purl.obolibrary.org/obo/UO_0000190>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: OEO_00000045
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000160>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "producer"
-    
-    SubClassOf: 
-        OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240003
-    
-    
-Class: OEO_00000051
-
-    
-Class: OEO_00000064
-
-    
-Class: OEO_00000087
-
-    
-Class: OEO_00000105
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
-        rdfs:label "consumer"
-    
-    SubClassOf: 
-        OEO_00000431
-    
-    
-Class: OEO_00000107
-
-    
-Class: OEO_00000128
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1015"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "energy demand sector"
-    
-    SubClassOf: 
-        OEO_00000367
-    
-    
-Class: OEO_00000145
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "electricity sector"
-    
-    SubClassOf: 
-        OEO_00000158
-    
-    
-Class: OEO_00000158
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "energy transformation sector"
-    
-    SubClassOf: 
-        OEO_00000367
-    
-    
-Class: OEO_00000213
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "heating and cooling sector"
-    
-    SubClassOf: 
-        OEO_00000128
-    
-    
-Class: OEO_00000214
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "household sector"
-    
-    SubClassOf: 
-        OEO_00000128
-    
-    
-Class: OEO_00000227
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "industry sector"
-    
-    SubClassOf: 
-        OEO_00000367
-    
-    
-Class: OEO_00000238
-
-    
-Class: OEO_00000264
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00020065
-    
-    
-Class: OEO_00000315
-
-    
-Class: OEO_00000323
-
-    
-Class: OEO_00000329
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is a organisation of a group of people with common views or goals that wants to have influence in politics."@en,
-        rdfs:label "political party"
-    
-    SubClassOf: 
-        OEO_00030022
-    
-    
-Class: OEO_00000341
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
-        rdfs:label "prosumer"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00000350
-
-    
-Class: OEO_00000367
-
-    
-Class: OEO_00000368
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
-    
-Class: OEO_00000379
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
-        rdfs:label "software developer"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00000405
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "trading, commerce and service sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "commercial sector"
-    
-    SubClassOf: 
-        OEO_00000128
-    
-    
-Class: OEO_00000422
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "transport sector"
-    
-    SubClassOf: 
-        OEO_00000128
-    
-    
-Class: OEO_00000431
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
-        rdfs:label "user"
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00010034
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "building sector"
-    
-    SubClassOf: 
-        OEO_00000128
-    
-    
-Class: OEO_00010035
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "agriculture, forestry and land use sector"
-    
-    SubClassOf: 
-        OEO_00000367
-    
-    
-Class: OEO_00010036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
-        rdfs:label "waste and wastewater sector"
-    
-    SubClassOf: 
-        OEO_00000367
-    
-    
-Class: OEO_00010055
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
-        rdfs:label "common reporting format"
-    
-    SubClassOf: 
-        OEO_00000368
-    
-    
-Class: OEO_00010079
-
-    SubClassOf: 
-        OEO_00020056 some OEO_00020063
-    
-    
-Class: OEO_00010082
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
-        rdfs:label "trade"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00040011
-    
-    
-Class: OEO_00010083
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-update definition and improve axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019",
-        rdfs:label "market participant"@en
-    
-    SubClassOf: 
-        OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
-    
-    
-Class: OEO_00010115
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "economy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
-Class: OEO_00010116
-
-    
-Class: OEO_00010117
-
-    
-Class: OEO_00010123
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
-        rdfs:label "effort sharing"@en
-    
-    SubClassOf: 
-        OEO_00140151,
-        OEO_00000503 some OEO_00020063
-    
-    
-Class: OEO_00010126
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
-        rdfs:label "Annual Emission Allocation"@en
-    
-    SubClassOf: 
-        OEO_00020063
-    
-    
-Class: OEO_00010136
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
-        rdfs:label "distribution"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00010212
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
-        rdfs:label "decarbonisation pathway"@en
-    
-    SubClassOf: 
-        OEO_00140150
-    
-    
-Class: OEO_00010227
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
-        rdfs:label "memo item"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
-    
-    
-Class: OEO_00020015
-
-    
-Class: OEO_00020060
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel market exchange"
-    
-    SubClassOf: 
-        OEO_00020065,
-        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
-    
-    
-Class: OEO_00020063
-
-    
-Class: OEO_00020064
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "EU allowance"
-    
-    SubClassOf: 
-        OEO_00020063
-    
-    
-Class: OEO_00020065
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "energy market exchange"
-    
-    SubClassOf: 
-        OEO_00020069
-    
-    
-Class: OEO_00020066
-
-    
-Class: OEO_00020067
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "product"
-    
-    SubClassOf: 
-        OEO_00020070 some OEO_00020069
-    
-    
-Class: OEO_00020068
-
-    SubClassOf: 
-        OEO_00020070 some OEO_00020060
-    
-    
-Class: OEO_00020069
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    SubClassOf: 
-        OEO_00030022,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019"
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (OEO_00010082
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
-    
-    
-Class: OEO_00020075
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
-        rdfs:label "emission market exchange"
-    
-    SubClassOf: 
-        OEO_00020069,
-        OEO_00020071 some OEO_00020063
-    
-    
-Class: OEO_00020076
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
-        rdfs:label "markup"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020077
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
-        rdfs:label "markdown"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020108
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:comment "Feed-in tariffs provide cost-based compensation to renewable energy producers, leading to price certainty and long-term contracts that help finance energy transformation units, e.g. power plants",
-        rdfs:label "feed-in tariff"
-    
-    SubClassOf: 
-        OEO_00140151
-    
-    
-Class: OEO_00020109
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "market premium"
-    
-    SubClassOf: 
-        OEO_00140151
-    
-    
-Class: OEO_00020110
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "levy"
-    
-    SubClassOf: 
-        OEO_00140151
-    
-    
-Class: OEO_00020111
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "capacity premium"
-    
-    SubClassOf: 
-        OEO_00020109
-    
-    
-Class: OEO_00020112
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
-        rdfs:label "tax"
-    
-    SubClassOf: 
-        OEO_00020110
-    
-    
-Class: OEO_00020113
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:label "inflation rate"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00020114
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:comment "The ratio at which one can exchange one currency for another can differ over time therefore it is necessary to specify a time point when referring to an exchange rate.",
-        rdfs:label "exchange rate"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00020115
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value reprensenting the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
-https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        <http://purl.org/dc/terms/source> "https://www.oecd.org/sdd/prices-ppp/purchasingpowerparities-frequentlyaskedquestionsfaqs.htm#FAQ1",
-        rdfs:label "purchasing power parity"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
-    
-Class: OEO_00020116
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:label "system cost"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00020117
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
-        rdfs:comment "has unit some \"currency per energy unit\"",
-        rdfs:label "electricity price"
-    
-    SubClassOf: 
-        OEO_00040003
-    
-    
-Class: OEO_00020124
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "due"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020125
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "remuneration"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020126
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:label "fee"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020127
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
-        rdfs:comment "Since over the lifetime of an energy transformation unit different costs exhibit different relevance or vary over time, the LCOE differ over the course of the lifetime.",
-        rdfs:label "levelised cost of electricity"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00020128
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add term
-https://github.com/OpenEnergyPlatform/ontology/issues/908
-https://github.com/OpenEnergyPlatform/ontology/pull/929",
-        rdfs:label "market revenue"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00020145
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on an amount of goods or services.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
-        rdfs:label "variable cost"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00020146
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are payed by the producer.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
-        rdfs:label "variable production cost"
-    
-    SubClassOf: 
-        OEO_00020145
-    
-    
-Class: OEO_00020156
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "carbon tax"
-    
-    SubClassOf: 
-        OEO_00020112
-    
-    
-Class: OEO_00020167
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "investment",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "FIBO definition of investment relates to property only: https://spec.edmcouncil.org/fibo/ontology?searchBoxQuery=investment, 
-
-Gabler on Investition: langfristige Bindung finanzieller Mittel in materiellen oder in immateriellen Vermögensgegenständen (https://wirtschaftslexikon.gabler.de/definition/investition-39454)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "investment cost"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00020168
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fixed costs are costs for operation and mantainance that do not vary with the amount of goods or services produced.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintanance cost",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "oemof-Model: https://oemof-solph.readthedocs.io/en/latest/_modules/oemof/solph/options.html?highlight=fix%20costs
-
-Fixe Kosten: Kosten, die von der jeweils betrachteten Einflussgröße bzw. Entscheidung unabhängig sind, d.h. Kosten, die sich nicht mit der jeweils betrachteten Einflussgröße ändern. (https://wirtschaftslexikon.gabler.de/definition/fixe-kosten-33359)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "fixed cost"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00020169
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment costs are investment costs for acquisition of the components and machinery including environmental facilities.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "equipment cost"
-    
-    SubClassOf: 
-        OEO_00020167
-    
-    
-Class: OEO_00020170
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "site development cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "installation cost"
-    
-    SubClassOf: 
-        OEO_00020167
-    
-    
-Class: OEO_00020171
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "grid connection cost"
-    
-    SubClassOf: 
-        OEO_00020167
-    
-    
-Class: OEO_00020172
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Property costs are investment costs arising from the acquisition of a property.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "property cost"
-    
-    SubClassOf: 
-        OEO_00020167
-    
-    
-Class: OEO_00020173
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "decommissioning cost"
-    
-    SubClassOf: 
-        OEO_00020167
-    
-    
-Class: OEO_00020174
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery costs are costs for a product or service that refer to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
-        rdfs:label "delivery cost"
-    
-    SubClassOf: 
-        OEO_00040009
-    
-    
-Class: OEO_00030016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisational energy producer"
-    
-    SubClassOf: 
-        OEO_00030022,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000045
-    
-    
-Class: OEO_00030017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:comment "They may be privately or publicly owned.",
-        rdfs:label "energy autoproducer"
-    
-    SubClassOf: 
-        OEO_00030016
-    
-    
-Class: OEO_00030018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:comment "They may be privately or publicly owned. Note that the sale need not take place through the public grid.",
-        rdfs:label "main activity energy producer"
-    
-    SubClassOf: 
-        OEO_00030016
-    
-    
-Class: OEO_00030022
-
-    
-Class: OEO_00030035
-
-    
-Class: OEO_00040002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639
-
-https://github.com/OpenEnergyPlatform/ontology/issues/677
-https://github.com/OpenEnergyPlatform/ontology/pull/740
-
-change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00040003
-
-    
-Class: OEO_00040004
-
-    
-Class: OEO_00040005
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/377
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/641
-
-Make trader subclass of market participant:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-https://github.com/OpenEnergyPlatform/ontology/pull/745",
-        rdfs:label "trader"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/Trader"
-    
-    SubClassOf: 
-        OEO_00010083
-    
-    
-Class: OEO_00040006
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "request"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00040007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "price request"@en
-    
-    SubClassOf: 
-        OEO_00040006
-    
-    
-Class: OEO_00040008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
-        rdfs:label "marginal cost"@en
-    
-    SubClassOf: 
-        OEO_00140012
-    
-    
-Class: OEO_00040009
-
-    
-Class: OEO_00040011
-
-    
-Class: OEO_00090001
-
-    
-Class: OEO_00090002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "public funder"@en
-    
-    SubClassOf: 
-        OEO_00090001
-    
-    
-Class: OEO_00090003
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "private funder"@en
-    
-    SubClassOf: 
-        OEO_00090001
-    
-    
-Class: OEO_00140009
-
-    
-Class: OEO_00140012
-
-    
-Class: OEO_00140013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
-alternative term:
-https://github.com/OpenEnergyPlatform/ontology/issues/675
-https://github.com/OpenEnergyPlatform/ontology/pull/676",
-        rdfs:label "gross domestic product"@en
-    
-    SubClassOf: 
-        OEO_00140012
-    
-    
-Class: OEO_00140023
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563
-alternative term:
-https://github.com/OpenEnergyPlatform/ontology/issues/675
-https://github.com/OpenEnergyPlatform/ontology/pull/676",
-        rdfs:label "gross value added"@en
-    
-    SubClassOf: 
-        OEO_00140012
-    
-    
-Class: OEO_00140040
-
-    
-Class: OEO_00140109
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
-        rdfs:label "contract"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: OEO_00140117
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "delivery time"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>
-    
-    
-Class: OEO_00140118
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "delivery time point"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
-    
-Class: OEO_00140119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "sender"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00140120
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "receiver"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00140121
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "bid"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: OEO_00140122
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "award"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
-    
-    
-Class: OEO_00140123
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:comment "The transfer is typically defined in a contract.",
-        rdfs:label "provider"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00140124
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
-        rdfs:label "service"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140125
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:comment "This duration is often contractually fixed and regular.",
-        rdfs:label "delivery interval"@en
-    
-    SubClassOf: 
-        OEO_00030035
-    
-    
-Class: OEO_00140130
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "power plant operator"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
-    
-Class: OEO_00140131
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
-        rdfs:label "conventional trader"@en
-    
-    SubClassOf: 
-        OEO_00040005
-    
-    
-Class: OEO_00140136
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
-        rdfs:label "dispatch assignment"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>
-    
-    
-Class: OEO_00140137
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
-        rdfs:label "power plant portfolio"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00140140
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "demand trader"@en
-    
-    SubClassOf: 
-        OEO_00040005
-    
-    
-Class: OEO_00140141
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "merit order"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>
-    
-    
-Class: OEO_00140143
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
-        rdfs:label "direct marketer"@en
-    
-    SubClassOf: 
-        OEO_00040005
-    
-    
-Class: OEO_00140146
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
-        rdfs:label "energy demand"@en
-    
-    SubClassOf: 
-        OEO_00140040
-    
-    
-Class: OEO_00140149
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
-        rdfs:label "transformative measure"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140150
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
-        rdfs:label "policy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
-        OEO_00010121 some OEO_00030022,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140151
-    
-    
-Class: OEO_00140151
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
-        rdfs:label "policy instrument"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149
-    
-    
-Class: OEO_00140171
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
-        rdfs:label "email address"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    
-Class: OEO_00230013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "population"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
-    
-Class: OEO_00230014
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "urban population"@en
-    
-    SubClassOf: 
-        OEO_00230013
-    
-    DisjointWith: 
-        OEO_00230015
-    
-    
-Class: OEO_00230015
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
-https://github.com/OpenEnergyPlatform/ontology/issues/479
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "rural population"@en
-    
-    SubClassOf: 
-        OEO_00230013
-    
-    DisjointWith: 
-        OEO_00230014
-    
-    
-Class: OEO_00230016
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
-https://github.com/OpenEnergyPlatform/ontology/issues/301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "labour force"@en
-    
-    SubClassOf: 
-        OEO_00230013
-    
-    
-Class: OEO_00230017
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
-https://github.com/OpenEnergyPlatform/ontology/issues/479
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
-        rdfs:label "working age population"@en
-    
-    SubClassOf: 
-        OEO_00230013
-    
-    
-Class: OEO_00240003
-
-    
-Class: OEO_00240021
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
-        rdfs:label "discount rate"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
-    
-    
-Class: OEO_00240036
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
-        rdfs:label "import price"
-    
-    SubClassOf: 
-        OEO_00040003
-    
-    
-Class: OEO_00240037
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
-        rdfs:label "export price"
-    
-    SubClassOf: 
-        OEO_00040003
-    
-    
-Individual: OEO_00000160
-
-    Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
@@ -1856,12 +1962,13 @@ The energy balance expresses all forms of energy in a common accounting unit. Th
         rdfs:label "eurostat energy balances"
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     
-Individual: OEO_00000193
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000193>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
@@ -1893,39 +2000,42 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
         rdfs:label "german energy balances"
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     
-Individual: OEO_00000242
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 2006) is a version of the common reporting format that was used for national greenhouse gas inventories since the year 2015. It implements the 2006 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 2006)"
     
     Types: 
-        OEO_00010055
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
     
     Facts:  
-     OEO_00000504  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
-Individual: OEO_00000243
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000243>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 1996) is a version of the common reporting format that was used for national greenhouse gas inventories until the year 2014. It implements the Revised 1996 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sectors (IPCC 1996)"
     
     Types: 
-        OEO_00010055
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010055>
     
     
-Individual: OEO_00000291
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000291>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
@@ -1933,24 +2043,26 @@ NACE is a four-digit classification providing the framework for collecting and p
         rdfs:label "nace_ sectors"
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     
-Individual: OEO_00000355
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00000355>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
         rdfs:label "renewable_ energy_ directive_ sectors"
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     
-Individual: OEO_00010038
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
 
     Annotations: 
-        OEO_00010037 "CRF 1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) energy is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All GHG emissions arising from combustion and fugitive releases of fuels. Emissions from the non-energy uses of fuels are generally not included here, but reported under Industrial Processes and Product Use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1959,21 +2071,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): energy"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010041,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010042,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010043,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010044
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010041>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010044>
     
     
-Individual: OEO_00010039
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the intentional oxidation of materials within an apparatus that is designed to raise heat and provide it either as heat or as mechanical work to a process or for use away from the apparatus.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1982,17 +2095,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
     
     
-Individual: OEO_00010040
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industry' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises emissions from fuels combusted by the fuel extraction or energy-producing industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2005,20 +2119,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): energy industry"
     
     Types: 
-        OEO_00000158
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010158,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010159,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010160
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010158>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010159>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010160>
     
     
-Individual: OEO_00010041
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010041>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacturing industries and construction' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion of fuels in industry. Also includes combustion for the generation of electricity and heat for own use in these industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2027,17 +2142,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): manufacturing industries and construction"
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
     
     
-Individual: OEO_00010042
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the combustion and evaporation of fuel for all transport activity (excluding military transport), regardless of the sector, specifiedby sub-categories below. Emissions from fuel sold to any air or marine vessel engaged in international transport (1 A 3 a i and 1 A 3 d i) should as far as possible be excluded from the totals and subtotals in this category and should be reported separately.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2046,17 +2162,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): transport"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
     
     
-Individual: OEO_00010043
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.4",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion - other sectors' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion activities as described below, including combustion for the generation of electricity and heat for own use in these sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2065,19 +2182,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other sectors"
     
     Types: 
-        OEO_00000128
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010052,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010053
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010052>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
     
     
-Individual: OEO_00010044
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010044>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.5",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.5",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All remaining emissions from fuel combustion that are not specified elsewhere. Include emissions from fuel delivered to the military in the country and delivered to the military of other countries that are not engaged in multilateral operations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2086,17 +2204,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         rdfs:label "CRF sector (IPCC 2006): fuel combustion - other"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010039>
     
     
-Individual: OEO_00010046
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
 
     Annotations: 
-        OEO_00010037 "CRF 2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industrial processes and product use' (IPPU) is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 It covers greenhouse gas emissions occurring from industrial processes, from the use of greenhouse gases in products, and from non-energy uses of fossil fuel carbon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "IPPU",
@@ -2110,24 +2229,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use"
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010164,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010166,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010167,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010169,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010170,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010171,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010172,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010173
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010164>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010166>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010167>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010169>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010170>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010171>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010172>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010173>
     
     
-Individual: OEO_00010047
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
 
     Annotations: 
-        OEO_00010037 "CRF 3",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -2138,26 +2258,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture"
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010179,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010180,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010181,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010182,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010183,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010184,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010185,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010186,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010187,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010188
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010179>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010180>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010181>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010182>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010183>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010184>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010185>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010186>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010187>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010188>
     
     
-Individual: OEO_00010048
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
 
     Annotations: 
-        OEO_00010037 "CRF 4",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry' (LULUCF) is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LULUCF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -2169,27 +2290,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry"
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010189,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010190,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010192,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010193,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010194,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010195,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010196
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010189>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010190>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010192>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010193>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010194>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010195>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010196>
     
     SameAs: 
-        OEO_00010071,
-        OEO_00010135
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010071>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010135>
     
     
-Individual: OEO_00010049
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
 
     Annotations: 
-        OEO_00010037 "CRF 5",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2), methane (CH4) and nitrous oxide (N2O) emissions from following categories: Solid waste disposal, Biological treatment of solid waste, 
 Incineration and open burning of waste, Wastewater treatment and discharge.",
@@ -2203,37 +2325,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste"
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010174,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010175,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010176,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010177,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010178
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010174>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010175>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010176>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010177>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010178>
     
     
-Individual: OEO_00010050
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
 
     Annotations: 
-        OEO_00010037 "CRF 6",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 6",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): other"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
-Individual: OEO_00010052
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010052>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.4.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'commercial and institutional' is a commercial sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in commercial and institutional buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 1.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2242,17 +2366,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): commercial and institutional"
     
     Types: 
-        OEO_00000405
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000405>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
     
     
-Individual: OEO_00010053
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.4.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'residential' is a household sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All emissions from fuel combustion in households.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2261,17 +2386,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): residential"
     
     Types: 
-        OEO_00000214
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000214>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
     
     
-Individual: OEO_00010054
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010054>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.4.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.4.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture, forestry and fishing' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in agriculture, forestry, fishing and fishing industries such as fish farms.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2280,29 +2406,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "CRF sector (IPCC 2006): agriculture, forestry and fishing"
     
     Types: 
-        OEO_00000128
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000128>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010043
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010043>
     
     
-Individual: OEO_00010056
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010056>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector division"
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     
-Individual: OEO_00010057
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
 
     Annotations: 
-        OEO_00010037 "CRF 1.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fugitive emissions from fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of solid fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2311,19 +2439,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): fugitive emissions from fuels"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010161,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010162
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010161>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010162>
     
     
-Individual: OEO_00010058
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
 
     Annotations: 
-        OEO_00010037 "CRF 1.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2332,20 +2461,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): CO2 transport and storage"
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010038
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>
     
     DifferentFrom: 
-        OEO_00010229
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010229>
     
     
-Individual: OEO_00010059
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010059>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2354,20 +2484,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic aviation"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
     
     DifferentFrom: 
-        OEO_00010201
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
     
     
-Individual: OEO_00010060
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010060>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'road transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2376,17 +2507,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): road transportation"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
     
     
-Individual: OEO_00010061
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010061>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'railways' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from railway transport for both freight and passenger traffic routes.",
@@ -2395,17 +2527,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): railways"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
     
     
-Individual: OEO_00010062
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.d",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.d",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2414,20 +2547,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): domestic navigation"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
     
     DifferentFrom: 
-        OEO_00010202
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
     
     
-Individual: OEO_00010063
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010063>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.e",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.e",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other transportation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2436,17 +2570,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "CRF sector (IPCC 2006): other transportation"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010042
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010042>
     
     
-Individual: OEO_00010064
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010064>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.3.e.i",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.3.e.i",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'pipeline transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2459,16 +2594,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1122",
         rdfs:label "CRF sector (IPCC 2006): pipeline transport"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010063
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010063>
     
     
-Individual: OEO_00010065
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010065>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
@@ -2479,18 +2615,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector energy industry"
     
     Types: 
-        OEO_00000158
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010057,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010064
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010064>
     
     
-Individual: OEO_00010066
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010066>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
@@ -2501,18 +2638,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector industry"
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010041,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010058
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010041>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
     
     
-Individual: OEO_00010067
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010067>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)
@@ -2527,18 +2665,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1198",
         rdfs:label "KSG sector buildings"
     
     Types: 
-        OEO_00010034
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010034>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010044,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010052,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010053
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010044>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010052>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010053>
     
     
-Individual: OEO_00010068
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010068>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
 - CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
@@ -2550,19 +2689,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector transport"
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010059,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010060,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010061,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010062
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010059>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010060>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010061>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
     
     
-Individual: OEO_00010069
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010069>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
@@ -2572,17 +2712,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector agriculture"
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010054
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010054>
     
     
-Individual: OEO_00010070
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010070>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
@@ -2592,17 +2733,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector waste management and other"
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00010056,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
     
     
-Individual: OEO_00010071
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010071>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
@@ -2611,18 +2753,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595",
         rdfs:label "KSG sector land use, land-use change and forestry"
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00010056
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010056>
     
     SameAs: 
-        OEO_00010048
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010122
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010122>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The European Union Emissions Trading System (EU ETS) is a policy instrument that implements an emissions trading system covering the European Union, Norway, Iceland and Liechtenstein.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EU ETS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2634,20 +2777,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "European Union Emissions Trading System"@en
     
     Types: 
-        OEO_00140151,
-        OEO_00000503 some OEO_00020064
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140151>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00020064>
     
     Facts:  
-     OEO_00010128  OEO_00010131,
-     OEO_00010128  OEO_00010132,
-     OEO_00010128  OEO_00010133,
-     OEO_00010128  OEO_00010205,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
+     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>,
+     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010132>,
+     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010133>,
+     <http://openenergy-platform.org/ontology/oeo/OEO_00010128>  <http://openenergy-platform.org/ontology/oeo/OEO_00010205>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
     
     
-Individual: OEO_00010124
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010124>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Decision (ESD) is the European effort sharing for the years 2013-2020. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons and sulphur hexafluoride. Emission quantities under the ESD are calculated using global warming potentials from the Fourth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESD",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2655,16 +2799,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Decision"@en
     
     Types: 
-        OEO_00010123,
-        OEO_00000503 some OEO_00010126
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010123>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
     
     
-Individual: OEO_00010125
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010125>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Regulation (ESR) is the European effort sharing for the years 2021-2030. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons, sulphur hexafluoride and nitrogen trifluoride. Emission quantities under the ESR are calculated using global warming potentials from the Fifth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESR",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2672,127 +2817,135 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "Effort Sharing Regulation"@en
     
     Types: 
-        OEO_00010123,
-        OEO_00000503 some OEO_00010126
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010123>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000503> some <http://openenergy-platform.org/ontology/oeo/OEO_00010126>
     
     Facts:  
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010129
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
     
     
-Individual: OEO_00010129
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU climate policy is the policy of the European Union for reducing greenhouse gas emissions. It uses the EU emission sector division.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU climate policy"@en
     
     Types: 
-        OEO_00140150
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140150>
     
     Facts:  
-     OEO_00000503  OEO_00010130
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
     
     
-Individual: OEO_00010130
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector division is used in the EU climate policy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector division"@en
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     Facts:  
-     OEO_00000504  OEO_00010129
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010129>
     
     
-Individual: OEO_00010131
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS is a sector defined by the EU emission sector division that covers greenhouse gas emissions that are regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00010130
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
     
     
-Individual: OEO_00010132
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010132>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS stationary"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00010130,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010131
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
     
     
-Individual: OEO_00010133
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010133>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS aviation is a transport sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: ETS aviation"@en
     
     Types: 
-        OEO_00000422
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>
     
     Facts:  
-     OEO_00000504  OEO_00010130,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010131
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010131>
     
     
-Individual: OEO_00010134
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010134>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector effort sharing is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the Effort Sharing Decision and the Effort Sharing Regulation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: effort sharing"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00010130
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
     
     
-Individual: OEO_00010135
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010135>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
         rdfs:label "EU emission sector: LULUCF"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00010130
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010130>
     
     SameAs: 
-        OEO_00010048
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010158
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010158>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.1.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'public electricity and heat production' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Sum of emissions from main activity producers of electricity generation, combined heat and power generation, and heat plants.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2801,17 +2954,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): public electricity and heat production"@en
     
     Types: 
-        OEO_00000158
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
     
     
-Individual: OEO_00010159
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010159>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.1.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'petroleum refining' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion activities supporting the refining of petroleum products including on-site combustion for the generation of electricity and heat for own use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2820,17 +2974,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): petroleum refining"@en
     
     Types: 
-        OEO_00000158
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
     
     
-Individual: OEO_00010160
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010160>
 
     Annotations: 
-        OEO_00010037 "CRF 1.A.1.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.A.1.c",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacture of solid fuels and other energy industries' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from fuel use during the manufacture of secondary and tertiary products from solid fuels including production of charcoal.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2839,17 +2994,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries"@en
     
     Types: 
-        OEO_00000158
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000158>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010040
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010040>
     
     
-Individual: OEO_00010161
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010161>
 
     Annotations: 
-        OEO_00010037 "CRF 1.B.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2858,17 +3014,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid fuels"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010057
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
     
     
-Individual: OEO_00010162
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010162>
 
     Annotations: 
-        OEO_00010037 "CRF 1.B.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.B.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'oil and natural gas' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises fugitive emissions from all oil and natural gas activities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2877,16 +3034,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): oil and natural gas"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010057
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010057>
     
     
-Individual: OEO_00010163
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010163>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GovReg sector division is a sector division defined in Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32020R1208&from=EN#d1e32-98-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -2898,16 +3056,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "GovReg sector division"@en
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     Facts:  
-     OEO_00000503  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
-Individual: OEO_00010164
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010164>
 
     Annotations: 
-        OEO_00010037 "CRF 2.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'mineral industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related carbon dioxide (CO2) emissions resulting from the use of carbonate raw materials in the production and use of a variety of mineral industry products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 2.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2916,17 +3075,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): mineral industry"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010165
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010165>
 
     Annotations: 
-        OEO_00010037 "CRF 2.A.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.A.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related emissions from the production of various types of cement (ISIC: D2694).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2935,17 +3095,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cement production"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010164
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010164>
     
     
-Individual: OEO_00010166
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010166>
 
     Annotations: 
-        OEO_00010037 "CRF 2.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'chemical industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of various inorganic and organic chemicals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2954,17 +3115,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): chemical industry"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010167
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010167>
 
     Annotations: 
-        OEO_00010037 "CRF 2.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'metal industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of metals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 4.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2973,17 +3135,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): metal industry"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010168
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010168>
 
     Annotations: 
-        OEO_00010037 "CRF 2.C.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.C.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide is the predominant gas emitted from the production of iron and steel. The sources of the carbon dioxide emissions include that from carbon-containing reducing agents such as coke and pulverized coal, and, from minerals such as limestone and dolomite added.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2992,17 +3155,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): iron and steel production"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010167
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010167>
     
     
-Individual: OEO_00010169
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010169>
 
     Annotations: 
-        OEO_00010037 "CRF 2.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'non-energy products from fuels and solvent use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 The use of oil products and coal-derived oils primarily intended for purposes other than combustion",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3011,17 +3175,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): non-energy products from fuels and solvent use"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010170
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010170>
 
     Annotations: 
-        OEO_00010037 "CRF 2.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'electronics industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Several advanced electronics manufacturing processes utilise fluorinated compounds (FCs) for plasma etching intricate patterns, cleaning reactor chambers, and temperature control. The specific electronic industry sectors include semiconductor, thin-film-transistor flat panel display (TFT-FPD), and photovoltaic (PV) manufacturing (collectively termed ‘electronics industry’).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 6.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3030,17 +3195,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): electronics industry"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010171
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010171>
 
     Annotations: 
-        OEO_00010037 "CRF 2.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'product uses as substitutes for ozone depleting substances' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Hydrofluorocarbons (HFCs) and, to a very limited extent, perfluorocarbons (PFCs), are serving as alternatives to ozone depleting substances (ODS) being phased out under the Montreal Protocol.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 7.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3049,17 +3215,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): product uses as substitutes for ozone depleting substances"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010172
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010172>
 
     Annotations: 
-        OEO_00010037 "CRF 2.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other product manufacture and use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
 (PFCs) from the manufacture and use of electrical equipment and a number of other products. It also includes emissions of nitrous oxide (N2O) from several products.",
@@ -3067,34 +3234,36 @@ Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
         rdfs:label "CRF sector (IPCC 2006): other product manufacture and use"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010173
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010173>
 
     Annotations: 
-        OEO_00010037 "CRF 2.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 2.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'industrial processes and product use - other' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): industrial processes and product use - other"@en
     
     Types: 
-        OEO_00000227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010046
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>
     
     
-Individual: OEO_00010174
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010174>
 
     Annotations: 
-        OEO_00010037 "CRF 5.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid waste disposal' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic microbial decomposition of organic matter in solid waste disposal sites.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3103,17 +3272,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): solid waste disposal"@en
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
     
     
-Individual: OEO_00010175
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010175>
 
     Annotations: 
-        OEO_00010037 "CRF 5.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'biological treatment of solid waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Solid waste composting and other biological treatment. Emissions from biogas facilities (anaerobic digestion) with energy production are reported in the Energy Sector (1A4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3122,17 +3292,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): biological treatment of solid waste"@en
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
     
     
-Individual: OEO_00010176
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010176>
 
     Annotations: 
-        OEO_00010037 "CRF 5.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'incineration and open burning of waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Incineration of waste and open burning waste, not including waste-to-energy facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3141,17 +3312,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): incineration and open burning of waste"@en
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
     
     
-Individual: OEO_00010177
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010177>
 
     Annotations: 
-        OEO_00010037 "CRF 5.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste water treatment and discharge' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic decomposition of organic matter by bacteria in sewage facilities and from food processing and other industrial facilities during wastewater treatment. N2O is also produced by bacteria
 (denitrification and nitrification) in wastewater treatment and discharge.",
@@ -3161,17 +3333,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste water treatment and discharge"@en
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
     
     
-Individual: OEO_00010178
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010178>
 
     Annotations: 
-        OEO_00010037 "CRF 5.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 5.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste - other' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3179,17 +3352,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): waste - other"@en
     
     Types: 
-        OEO_00010036
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010036>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010049
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>
     
     
-Individual: OEO_00010179
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010179>
 
     Annotations: 
-        OEO_00010037 "CRF 3.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'enteric fermentation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane emissions from herbivores as a by-product of enteric fermentation (a digestive process by which carbohydrates are broken down by micro-organisms into simple molecules for absorption into the bloodstream). Ruminant animals (e.g., cattle, sheep) are major sources with moderate amounts produced from non-ruminant animals (e.g., pigs, horses).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3198,17 +3372,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): enteric fermentation"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010180
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010180>
 
     Annotations: 
-        OEO_00010037 "CRF 3.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manure management' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane and nitrous oxide emissions from the decomposition of manure under low oxygen or anaerobic conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3217,17 +3392,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): manure management"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010181
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010181>
 
     Annotations: 
-        OEO_00010037 "CRF 3.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'rice cultivation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane (CH4) emissions from anaerobic decomposition of organic material in flooded rice fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3236,51 +3412,54 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): rice cultivation"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010182
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010182>
 
     Annotations: 
-        OEO_00010037 "CRF 3.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agricultural soils' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agricultural soils"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010183
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010183>
 
     Annotations: 
-        OEO_00010037 "CRF 3.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'prescribed burning of savannas' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): prescribed burning of savannas"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010184
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010184>
 
     Annotations: 
-        OEO_00010037 "CRF 3.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'field burning of agricultural residues' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from urea application",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3289,17 +3468,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): field burning of agricultural residues"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010185
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010185>
 
     Annotations: 
-        OEO_00010037 "CRF 3.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'liming' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from the use of lime in agricultural soils, managed forest soils or lakes.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3308,68 +3488,72 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): liming"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010186
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010186>
 
     Annotations: 
-        OEO_00010037 "CRF 3.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'urea application' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): urea application"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010187
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010187>
 
     Annotations: 
-        OEO_00010037 "CRF 3.I",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.I",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other carbon-containing fertilizers' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other carbon-containing fertilizers"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010188
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010188>
 
     Annotations: 
-        OEO_00010037 "CRF 3.J",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 3.J",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): agriculture - other"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010047
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>
     
     
-Individual: OEO_00010189
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010189>
 
     Annotations: 
-        OEO_00010037 "CRF 4.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.A",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'forest land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from lands with woody vegetation consistent with thresholds used to define forest land in the national GHG inventory, sub-divided into managed and unmanaged, and possibly also by climatic region, soil type and vegetation type as appropriate. It also includes systems with vegetation that currently fall below, but are expected to later exceed, the threshold values used by a country to define the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3378,17 +3562,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): forest land"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010190
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010190>
 
     Annotations: 
-        OEO_00010037 "CRF 4.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.B",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cropland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from arable and tillage land, rice fields, and agro-forestry systems where vegetation falls below the thresholds used for the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3397,17 +3582,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): cropland"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010191
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010191>
 
     Annotations: 
-        OEO_00010037 "CRF 4.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.C",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'grassland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from rangelands and pasture land that is not considered cropland. It also includes systems with woody vegetation that fall below the threshold values used in the forest land category and are not expected to exceed them, without human intervention. The category also includes all grassland from wild lands to recreational areas as well as agricultural and silvi-pastural systems, subdivided into managed and unmanaged, consistent with national definitions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3416,17 +3602,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): grassland"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010192
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010192>
 
     Annotations: 
-        OEO_00010037 "CRF 4.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'wetlands' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from land that is covered or saturated by water for all or part of the year (e.g., peatland) and that does not fall into the forest land, cropland, grassland or settlements categories. The category can be subdivided into managed and unmanaged according to national definitions. It includes reservoirs as a managed sub-division and natural rivers and lakes as unmanaged sub-divisions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3435,17 +3622,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): wetlands"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010193
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010193>
 
     Annotations: 
-        OEO_00010037 "CRF 4.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.E",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'settlements' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from all developed land, including transportation infrastructure and human settlements of any size, unless they are already included under other categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3454,17 +3642,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): settlements"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010194
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010194>
 
     Annotations: 
-        OEO_00010037 "CRF 4.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.F",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from bare soil, rock, ice, and all unmanaged land areas that do not fall into any of the other five categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3473,17 +3662,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): other land"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010195
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010195>
 
     Annotations: 
-        OEO_00010037 "CRF 4.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.G",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'harvested wood products' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories
 CO2 net emissions or removals resulting from Harvest Wood Products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3492,33 +3682,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): harvested wood products"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010196
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010196>
 
     Annotations: 
-        OEO_00010037 "CRF 4.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 4.H",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
         rdfs:label "CRF sector (IPCC 2006): land use, land-use change and forestry - other"@en
     
     Types: 
-        OEO_00010035
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010035>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010048
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>
     
     
-Individual: OEO_00010197
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010197>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions excluding LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA) https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3528,20 +3720,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions excluding LULUCF"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
     
     
-Individual: OEO_00010198
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010198>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions including LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; land use, land-use change and forestry; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3551,66 +3744,71 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): total emissions including LULUCF"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010038,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010047,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010048,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010049,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010050
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010038>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010046>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010047>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010048>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010049>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010050>
     
     
-Individual: OEO_00010199
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010199>
 
     Annotations: 
-        OEO_00010037 "CRF 1.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) international bunkers is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international bunkers and multilateral operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers and multilateral operations"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010203
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010203>
     
     
-Individual: OEO_00010200
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
 
     Annotations: 
-        OEO_00010037 "CRF 1.D.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international bunkers"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010202
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
     
     
-Individual: OEO_00010201
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
 
     Annotations: 
-        OEO_00010037 "CRF 1.D.1.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1.a",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3618,24 +3816,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): international aviation"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010200
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
     
     DifferentFrom: 
-        OEO_00010059
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010059>
     
     
-Individual: OEO_00010202
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010202>
 
     Annotations: 
-        OEO_00010037 "CRF 1.D.1.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.1.b",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3643,24 +3843,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): maritime navigation"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010200
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
     
     DifferentFrom: 
-        OEO_00010062
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010062>
     
     
-Individual: OEO_00010203
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010203>
 
     Annotations: 
-        OEO_00010037 "CRF 1.D.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010037> "CRF 1.D.2",
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'multilateral operation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used for aviation and waterborne navigation in multilateral operations pursuant to the Charter of the United Nations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3669,20 +3871,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "CRF sector (IPCC 2006): multilateral operations"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010199
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010199>
     
     
-Individual: OEO_00010204
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010204>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3690,36 +3894,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector division"@en
     
     Types: 
-        OEO_00000368
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000368>
     
     Facts:  
-     OEO_00000503  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
-Individual: OEO_00010205
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010205>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "MMR sector: M.International aviation in the EU ETS"@en
     
     Types: 
-        OEO_00000422,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000422>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00010204,
-     <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010133,
-      not  OEO_00000504  OEO_00010163
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010204>,
+     <http://purl.obolibrary.org/obo/BFO_0000050>  <http://openenergy-platform.org/ontology/oeo/OEO_00010133>,
+      not  <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00010163>
     
     
-Individual: OEO_00010206
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010206>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3727,17 +3934,18 @@ Individual: OEO_00010206
         rdfs:label "total emissions excluding LULUCF and including international bunkers"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000503  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010197,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010197>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
     
     
-Individual: OEO_00010207
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010207>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3745,17 +3953,18 @@ Individual: OEO_00010207
         rdfs:label "total emissions including LULUCF and including international bunkers"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000503  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010198,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010200
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010198>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010200>
     
     
-Individual: OEO_00010208
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010208>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2020 emission target of the European Union.",
         
@@ -3766,17 +3975,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions excluding LULUCF and including international aviation"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000503  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010197,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010197>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
     
     
-Individual: OEO_00010209
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010209>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2030 emission target as specified in the Nationally Determined Contribution (NDC) of the European Union .",
         
@@ -3787,17 +3997,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
         rdfs:label "total emissions including LULUCF and including international aviation"@en
     
     Types: 
-        OEO_00000367
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
     
     Facts:  
-     OEO_00000503  OEO_00000242,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010198,
-     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010201
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000503>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010198>,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  <http://openenergy-platform.org/ontology/oeo/OEO_00010201>
     
     
-Individual: OEO_00010228
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010228>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3805,16 +4016,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 emissions from biomass"@en
     
     Types: 
-        OEO_00000367,
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
-Individual: OEO_00010229
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010229>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3822,19 +4034,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): CO2 captured"@en
     
     Types: 
-        OEO_00000367,
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     DifferentFrom: 
-        OEO_00010058
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010058>
     
     
-Individual: OEO_00010230
+Individual: <http://openenergy-platform.org/ontology/oeo/OEO_00010230>
 
     Annotations: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00269001> "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3842,13 +4055,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
         rdfs:label "CRF sector (IPCC 2006): indirect CO2"@en
     
     Types: 
-        OEO_00000367,
-        OEO_00010232 some OEO_00010227
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010232> some <http://openenergy-platform.org/ontology/oeo/OEO_00010227>
     
     Facts:  
-     OEO_00000504  OEO_00000242
+     <http://openenergy-platform.org/ontology/oeo/OEO_00000504>  <http://openenergy-platform.org/ontology/oeo/OEO_00000242>
     
     
 DisjointClasses: 
-    OEO_00000145,OEO_00000213,OEO_00000422
+    <http://openenergy-platform.org/ontology/oeo/OEO_00000145>,<http://openenergy-platform.org/ontology/oeo/OEO_00000213>,<http://openenergy-platform.org/ontology/oeo/OEO_00000422>
 

--- a/src/scripts/btma/annotator.py
+++ b/src/scripts/btma/annotator.py
@@ -8,138 +8,268 @@ to which module this class belongs
 @author: alexander stage    
 """
 
-# Imports
-
+#* Imports
+import io
 import pathlib as path
 import csv
 import subprocess as sp
 import os
 import shutil as sh
+import sys, time, threading
 
-# Load 'static' values
+#* Define used methods
 
-ontology_iri = 'http://openenergy-platform.org/ontology/oeo/OEO'
+def find_root_dir(dirname : str) -> path.Path:
+    """
+    Finds the parent directory named `dirname` of the current directory.
 
-modules = ['oeo-shared',
-           'oeo-physical',
-           'oeo-social',
-           'oeo-model']
+    Args:
+        `dirname (str)`: name of the current file directory
+
+    Returns:
+        `path.Path`: parent path of the directory with the name `dirname` in this project
+    """
+    return __find_root_dir(path.Path('.').absolute(), dirname)
+
+def __find_root_dir(cur_path : path.Path, dirname : str) -> path.Path:
+    if cur_path.name == dirname:
+        return cur_path
+    else:
+        return __find_root_dir(cur_path.parent, dirname)
+
+#* Create overview about IRIs and there belonging
+
+def extract_belongings(ids : set, ids_per_module) -> list:
+    """
+    Extracts the belonging of each ID
+
+    Args:
+        `ids (set)`: set of IDs
+        `ids_per_module (_type_)`: partition of `ids` in modules
+
+    Returns:
+        `list`: list of IDs per modules
+    """
+    belongings : list = []
+
+    for (i,id) in enumerate(ids):
+        belongings.append([])
+        for (j,module_ids) in enumerate(ids_per_module):
+            if id in module_ids:
+                belongings[i].append(modules[j])
+                
+    return belongings
+
+def extract_types(ids) -> list:
+    """
+    Assigns each ID to its type.
+
+    Args:
+        `ids`: list of IDs
+
+    Returns:
+        `list`: list of the types of each ID
+    """
+    types = []
+    for i, elem in enumerate(ids):
+            types.append(elem[1])
+            ids[i] = elem[0]
+    return types
 
 
-src_path = path.Path(__file__).parent.parent.parent.absolute()
-script_path = path.Path(__file__).parent.parent.absolute()
+def extract_IDs_Types(path : path.Path) -> list:
+    """
+    Extract ID and Type of each entity.
 
-omn_path = src_path / 'ontology' / 'edits'              
-csv_path = src_path / 'ontology' / 'exports'          
-owl_path = src_path / 'ontology' / 'imports'
-robot_path = script_path / 'btma' / 'robot.jar'
+    Args:
+        `path (path.Path)`: The path of a CSV-file with IDs and Types in the first and second column
 
-def extract_IDs(module : list) -> list:
-    file = open(csv_path / (module + '.csv'))
-    CSVreader = csv.reader(file)
+    Returns:
+        `list`: List of Tuples e.g. [(<ID_1>,<Type_1>),...,(<ID_N>,<Type_N>)]
+    """
     ids = []
-    for row in CSVreader:
-        t = row[0].split('_')
-        if t[0] == ontology_iri: 
-            ids.append(t[1])
+    with open(path) as file:
+        CSVreader = csv.reader(file)
+        for row in CSVreader:
+            if row[0].startswith('OEO'):
+                id = row[0]
+                typ = row[1]
+                if typ == 'Class':
+                    typ = typ.lower()
+                ids.append((id, typ))
     return ids
 
+
+def reset_btma():
+    """
+    Reset the project at the end of the script.
+    """
+    os.remove(script_path / 'btma' / "template.csv")
+    try:
+        sh.rmtree(db_path)
+    except:
+        pass
+    os.rename(csv_path, db_path)
+    sh.rmtree(exp_path)
+
+
+def __loadingAnimation(process):
+    while running:
+        chars = '/—\|' 
+        for char in chars:
+            sys.stdout.write('\r'+'Running annotator... '+char)
+            time.sleep(.1)
+            sys.stdout.flush()
+    if not changed:
+        sys.stdout.write('\r'+'Annotations are already up to date.\n')
+    sys.stdout.write('\r'+'Finished!                    ')
+
+
 def main():
+    global running
+    global changed
+    
     try:
         os.mkdir(csv_path)
     except:
         pass
 
-    col = 'ID'                           
+    col = 'ID|Type'                           
     _ = None
     ids_per_module = [_,_,_,_]
 
-    # Load necessary IRIs of the different ontology-modules
+    #* Load necessary IRIs of the different ontology-modules
 
-    print('Loading ontologies...')
     ids : set = set([])
     for (i,module) in enumerate(modules):
-        mod = ""
         mod = omn_path / "{m}.omn".format(m=module)
         exp = csv_path / "{m}.csv".format(m=module)
+        
         sp.call('java -jar {jar} export --input {m} \
-                                    --header "{c}" \
-                                    --export {e}'.format(jar=robot_path,
-                                                           m=mod, 
-                                                           c=col, 
-                                                           e=exp))
-        tmp = extract_IDs(module)
+                                        --prefix "OEO: {iri}" \
+                                        --header "{c}" \
+                                        --export {e}'.format(jar=robot_path,
+                                                             m=mod, 
+                                                             iri=ontology_iri + '/OEO_', 
+                                                             c=col, 
+                                                             e=exp), shell=True)
+        
+        tmp = extract_IDs_Types(csv_path / (module + '.csv'))
         ids = ids.union(set(tmp))
         ids_per_module[i] = tmp
 
     ids = list(ids)
 
-    # Create overview about IRIs and there belonging
+    #* Compare new data with database
 
-    print('Finding belongings...')
-
-    belonging = ids.copy()
-
-    for (i,id) in enumerate(ids):
-        for (j,module_ids) in enumerate(ids_per_module):
-            if id in module_ids:
-                belonging[i] = modules[j]
-                break
-
-    # Create the CSV template with the help of the overview
-
-    print('Creating template...')
+#    old_ids_per_module = [_,_,_,_]
+#    try:
+#        for i, module in enumerate(modules):
+#            old_ids_per_module[i] = extract_IDs_Types(db_path / (module + '.csv'))
+#    except:
+#        pass
+#
+#    changed = old_ids_per_module != ids_per_module
+    #* edit omn if and only if omn was changed
+    if changed:
+        #* Create the CSV template with the help of an 'overview'
         
-    belongs_to_module = list(zip(ids, belonging))
-
-    csv_table = [["ID","belongs to module"],
-                 ["ID","AI OEO:belongs_to_module"]]
-
-    csv_table_per_module = (csv_table, csv_table, csv_table, csv_table)
-
-    for (ids, belonging) in belongs_to_module:
-        if belonging == module[0]:
-            csv_table_per_module[0].append(['OEO:' + ids, ontology_iri + '/' + belonging])
-        elif belonging == module[1]:
-            csv_table_per_module[1].append(['OEO:' + ids, ontology_iri + '/' + belonging])
-        elif belonging == module[2]:
-            csv_table_per_module[2].append(['OEO:' + ids, ontology_iri + '/' + belonging])
-        else:
-            csv_table_per_module[3].append(['OEO:' + ids, ontology_iri + '/' + belonging])
+        belongings : list[list] = extract_belongings(ids, ids_per_module)
         
-    print('Creating ontologies...')
+        types = extract_types(ids)
+        
+        belongs_to_module = list(zip(ids, types, belongings))
+        
+        csv_table = [["ID", "Entity Type", "OEO:00269001"],
+                     ["ID", "TYPE SPLIT=|", "A OEO:00269001"]]
+        
+        csv_table_per_module = {'oeo-shared' : csv_table,
+                                'oeo-physical' : [a for a in csv_table], 
+                                'oeo-social' : [a for a in csv_table], 
+                                'oeo-model' : [a for a in csv_table]}
 
-    for (i, csv_table) in enumerate(csv_table_per_module):
-        f = open(script_path / 'btma' / "template.csv", 'w', newline='')
+        #* Adds only one belonging to an entity
+        #* regarding to following rule:
+        #* First: Shared; Second: Physical; Third: Model; Fourth: Social
+        #* Using Dictionaries instead of lists <dict>[<string>] instead of <list>[<int>] for better maintenance 
+        for ids, type_, belonging in belongs_to_module:
+            #print(ids,type_,belonging)
+            if 'oeo-shared' in belonging:
+                csv_table_per_module['oeo-shared'].append([ids, type_, ontology_iri + '/oeo-shared'])
+            elif 'oeo-physical' in belonging:
+                csv_table_per_module['oeo-physical'].append([ids, type_, ontology_iri + '/oeo-physical'])
+            elif 'oeo-model' in belonging:
+                csv_table_per_module['oeo-model'].append([ids, type_, ontology_iri + '/oeo-model'])
+            elif 'oeo-social' in belonging:
+                csv_table_per_module['oeo-social'].append([ids, type_, ontology_iri + '/oeo-social'])
 
-        writer = csv.writer(f)
+        for module in csv_table_per_module:
+            
+            with open(script_path / 'btma' / 'template.csv', 'w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerows(csv_table_per_module[module])
 
-        writer.writerows(csv_table)
+            #* Create OMN with help of the CSV template
+            callstring = 'java -jar {jar} template --template {template} \
+                                              --prefix \"OEO: {iri}\" \
+                                              --input {inp} \
+                                              --force true --errors "errors.csv" \
+                                              --output {out}'.format(jar=robot_path,
+                                                                     template=script_path / 'btma' / 'template.csv',
+                                                                     iri=ontology_iri + '/OEO_',
+                                                                     inp=omn_path / (module + '.omn'),
+                                                                     out=exp_path / 'belongs-to-{m}-annotation.omn'.format(m=module))
+            sp.call(callstring, shell=True)
+        
+        #* MERGE OMN files with the oeo modules
+        
+        for module in csv_table_per_module:
 
-        f.close()
+            sp.call('java -jar {jar} merge --input {out} \
+                                           --input {inp} \
+                                           --output {out} \
+                                           --collapse-import-closure false \
+                                           --include-annotations true'.format(jar=robot_path,
+                                                                              out=omn_path / (module + '.omn'),
+                                                                              inp=exp_path / 'belongs-to-{m}-annotation.omn'.format(m=module)),
+                    shell=True)
+            sp.call(callstring, shell=True)
+                
+        reset_btma()
+        
+#    else:
+#        sh.rmtree(csv_path)
+        
+    running = False    
 
-        # Create OWL/XML with help of the CSV template
-    
-        sp.call('java -jar {jar} template --template {template} \
-                                          --prefix "OEO: {iri}_" \
-                                          --output {out}'.format(jar=robot_path,
-                                                                 template=script_path / 'btma' / 'template.csv',
-                                                                 iri=ontology_iri,
-                                                                 out=csv_path / 'belongs-to-{m}-annotation.omn'.format(m=modules[i])))
-    
-        os.remove(script_path / 'btma' / "template.csv")
+#* Script start here
+#* Load 'static' values
 
-        sp.call('java -jar {jar} merge --input {out} \
-                                       --input {inp} \
-                                       --output {out}'.format(jar=robot_path,
-                                                              out=omn_path / (modules[i] + '.omn'),
-                                                              inp=csv_path / 'belongs-to-{m}-annotation.omn'.format(m=modules[i])))
-    
-    # MERGE .OMN with oeo-modules
+ontology_iri = 'http://openenergy-platform.org/ontology/oeo'
 
-    sh.rmtree(csv_path)
+changed = True
+running = True
+modules = ['oeo-shared',
+           'oeo-physical',
+           'oeo-social',
+           'oeo-model']
 
-    print('Finished!')
-    
+src_path = path.Path('/Users/hastingj/Work/Onto/open-energy-ontology/src').absolute()            #<- For development use this in your IDE instead of 'find_root_dir'
+#src_path = find_root_dir('src')
+script_path = src_path / 'scripts'
+omn_path = src_path / 'ontology' / 'edits'
+btma_path = script_path / 'btma'
+csv_path = btma_path / 'data'
+db_path = btma_path / 'database'
+exp_path = btma_path / 'exports'
+onto_path = src_path / 'ontology'
+owl_path = onto_path / 'imports'
+robot_path = btma_path / 'robot.jar'
+pre_path = btma_path / 'prefixes'
+            
 if __name__ == '__main__':
-    main()
+    loading_process = threading.Thread(target=main)
+    loading_process.start()
+
+    __loadingAnimation(loading_process)
+    loading_process.join()


### PR DESCRIPTION
This PR adds annotations to classes and individuals about which module they belong to. 

These annotations will need to be manually updated if the content is moved between modules.  Regular updates cannot be automated. 

In partial fulfillment of #870 