### PR TITLE
Fix definition of `heat exchanger` #1263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - steam reforming process (#1251)
 - emission certificate price (#1253)
+- heat exchanger (#1263)
 
 ### Changed
 - energy transformation (#1251)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,15 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.X.X] - 20XX-XX-XX
 
 ### Added
-- emission price, CO2 price, CO2 emission, CO2 emission value, carbon tax value (#1253)
-
-### Changed
 - steam reforming process (#1251)
-- emission certificate price (#1253)
-- heat exchanger (#1263)
+- emission price, CO2 price, CO2 emission, CO2 emission value, carbon tax value (#1253)
 
 ### Changed
 - energy transformation (#1251)
 - added annotations for which modules classes and individuals belong to (#1252)
+- emission certificate price (#1253)
 - power generating unit (#1259)
+- heat exchanger (#1263)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8127,7 +8127,7 @@ Class: OEO_00140102
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an component converting device that is used for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an energy converting component that is used for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
 
@@ -8136,7 +8136,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+fix definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1264",
         rdfs:label "heat exchanger"@en
     
     SubClassOf: 


### PR DESCRIPTION
Fix definition of `heat exchanger` to match subclass of relation:
_A heat exchanger is an ~component converting device~ **energy converting component** that is used for a heat transfer process._

This PR also fixes the duplicated "changed" section in CHANGELOG.md and puts the entries in the appropriate sections.

Closes #1263