### PR TITLE
Fix `electrical heat pump axiom` #1281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - equipment cost, variable cost, property cost, delivery cost, fixed cost (#1260)
 - heat exchanger (#1263)
 - program parameter (#1274)
+- electrical heat pump (#1282)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1011,6 +1011,9 @@ Class: OEO_00000009
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "fix energy axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1281
+pull: https://github.com/OpenEnergyPlatform/ontology/pulls/1282",
         rdfs:label "electric heat pump"
     
     SubClassOf: 
@@ -1022,7 +1025,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
 change uses energy axiom to 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        OEO_00010235 some OEO_00000139
+        OEO_00010234 some OEO_00000139
     
     
 Class: OEO_00000010


### PR DESCRIPTION
## Summary of the discussion

No discussion, but an obvious error

## Type of change (CHANGELOG.md)

### Updated

Replace axiom:`'electric heat pump' 'has energy output' some 'electrical energy'`
with axiom: `'electric heat pump' 'has energy input' some 'electrical energy'`

This satisfies the definition: _An electric heat pump is a heat pump that uses **electrical energy as drive energy**._

## Workflow checklist

### Automation
Closes #1281

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
