### PR TITLE
Add energy input axiom to internal combustion engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - heat exchanger (#1263)
 - program parameter (#1274)
 - electrical heat pump (#1282)
+- internal combustion engine (#1285)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4642,7 +4642,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
 add energy input axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1280
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1284",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1285",
         rdfs:label "internal combustion engine"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4638,12 +4638,17 @@ Class: OEO_00010029
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
+
+add energy input axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1280
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1284",
         rdfs:label "internal combustion engine"@en
     
     SubClassOf: 
         OEO_00010032,
         OEO_00000503 some OEO_00000099,
+        OEO_00010234 some OEO_00000007,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -466,7 +466,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 ObjectProperty: OEO_00020184
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an ouput of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an output of the artificial object or process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
         rdfs:label "is energy output of"


### PR DESCRIPTION
## Summary of the discussion

Describe energy input relation.

## Type of change (CHANGELOG.md)

### Added
- Add axiom `'internal combustion engine' 'has energy input' some 'chemical energy'`

### Changes
- Fix typo in `is energy output of`
(This is such a minor change that neither a separate issue or pull request is needed.)

## Workflow checklist

### Automation
Closes #1280

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
