### PR TITLE
Use general diesel fuel and add disjoint axiom #1286

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - program parameter (#1274)
 - electrical heat pump (#1282)
 - internal combustion engine (#1285)
+- diesel fuel, diesel fuel role, diesel engine, diesel vehicle (#1288)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -597,6 +597,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     SubClassOf: 
         OEO_00000001
     
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
 
@@ -608,6 +611,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     
     SubClassOf: 
         OEO_00000001
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010239>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
@@ -629,6 +635,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     SubClassOf: 
         OEO_00000099
     
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
+    
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
 
@@ -644,6 +653,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     
     SubClassOf: 
         OEO_00000099
+    
+    DisjointWith: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010241>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>
@@ -675,7 +687,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     
     SubClassOf: 
         OEO_00010029,
-        OEO_00000503 some OEO_00000131
+        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
     
     
 Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010245>
@@ -708,7 +720,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
     
     SubClassOf: 
         OEO_00000240,
-        OEO_00000503 some OEO_00000131,
+        OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>,
         <http://purl.obolibrary.org/obo/BFO_0000051> only 
             (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032)))

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -606,7 +606,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010240>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel role is a fuel role that expresses that a portion of matter can be used in a diesel engine.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+add disjoint axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
         rdfs:label "diesel fuel role"@en
     
     SubClassOf: 
@@ -644,7 +648,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010242>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel is a combustion fuel that has a diesel fuel role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+add disjoint axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
         rdfs:label "diesel fuel"@en
     
     EquivalentTo: 
@@ -682,7 +690,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel engine is an internal combustion engine that uses a diesel fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "diesel motor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+update axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
         rdfs:label "diesel engine"@en
     
     SubClassOf: 
@@ -715,7 +727,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010246>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel vehicle is an internal combustion vehicle that has only a diesel engine as motor for propulsion.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+update axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
         rdfs:label "diesel vehicle"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Update diesel related axioms

## Type of change (CHANGELOG.md)

### Added
* `'diesel fuel role' DisjointWith: 'gasoline fuel role'`
* `'diesel fuel' DisjointWith: 'gasoline fule'`

### Updated
* `'diesel engine' uses some 'fossil diesel fuel'` to `'diesel engine' uses some 'diesel fuel'`
* `'diesel vehicle' uses some 'fossil diesel fuel'` to `'diesel vehicle' uses some 'diesel fuel'`


## Workflow checklist

### Automation
Closes #1286

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
