### PR TITLE
Add passenger-kilometre and ton-kilometre #1272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - steam reforming process (#1251)
 - emission price, CO2 price, CO2 emission, CO2 emission value, carbon tax value (#1253)
 - fuel cost (#1260)
-- transport performance value, transport performance unit, passenger-kilometre, ton-kilometre (#1272)
+- transport performance value, transport performance unit, passenger-kilometre, ton-kilometre (#1289)
 
 ### Changed
 - energy transformation (#1251)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - steam reforming process (#1251)
 - emission price, CO2 price, CO2 emission, CO2 emission value, carbon tax value (#1253)
 - fuel cost (#1260)
+- transport performance value, transport performance unit, passenger-kilometre, ton-kilometre (#1272)
 
 ### Changed
 - energy transformation (#1251)

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2399,7 +2399,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00140002 some OEO_00320000
     
     
 Class: OEO_00140004
@@ -2592,6 +2593,47 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
     
     SubClassOf: 
         OEO_00020136
+    
+    
+Class: OEO_00320000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
+        rdfs:label "transport performance value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00320001
+    
+    
+Class: OEO_00320001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods."@en,
+        rdfs:label "transport performance unit"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00320002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person."@en,
+        rdfs:label "passenger-kilometre"@en
+    
+    SubClassOf: 
+        OEO_00320001
+    
+    
+Class: OEO_00320003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods."@en,
+        rdfs:label "ton-kilometre"@en
+    
+    SubClassOf: 
+        OEO_00320001
     
     
 Individual: OEO_00020161

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2391,7 +2391,11 @@ Class: OEO_00140003
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+add performance axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289",
         rdfs:label "transport"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -2599,6 +2603,8 @@ Class: OEO_00320000
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
         rdfs:label "transport performance value"@en
     
     SubClassOf: 
@@ -2610,6 +2616,8 @@ Class: OEO_00320001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
         rdfs:label "transport performance unit"@en
     
     SubClassOf: 
@@ -2620,6 +2628,8 @@ Class: OEO_00320002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
         rdfs:label "passenger-kilometre"@en
     
     SubClassOf: 
@@ -2630,6 +2640,8 @@ Class: OEO_00320003
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
         rdfs:label "ton-kilometre"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion
Add new classes:

`transport performance value`: A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods.
Axiom: `'has unit' some 'transport performance unit'`

`transport performance unit`: A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.

`passenger-kilometre`: Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.

`ton-kilometre`: Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.

Add new axiom:
`'transport' 'has quantity value' some 'transport performance value'`

## Workflow checklist

### Automation
Closes #1272

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
