### PR TITLE
Add `conventional energy` #1270

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - transport performance value, transport performance unit, passenger-kilometre, ton-kilometre (#1289)
 - gas vehicles, gas engines, more gas fuels, compressed gas fuel role (#1290)
 - motorised vehicle, aircraft and subclasses, land vehicle and subclasses, watercraft and subclasses (#1293)
+- conventional energy (#1295)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6418,6 +6418,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         OEO_00010292
     
     
+Class: OEO_00010295
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy is an energy that has a conventional origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1270
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
+        rdfs:label "conventional energy"@en
+    
+    EquivalentTo: 
+        OEO_00000150
+         and (OEO_00000530 some OEO_00020147)
+    
+    SubClassOf: 
+        OEO_00000150
+    
+    DisjointWith: 
+        OEO_00020085
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -6901,6 +6920,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
     
     SubClassOf: 
         OEO_00000150
+    
+    DisjointWith: 
+        OEO_00010295
     
     
 Class: OEO_00020086


### PR DESCRIPTION
## Summary of the discussion

Add `conventional energy` in parallel to `renewable energy`.

## Type of change (CHANGELOG.md)

### Added
Class `conventional energy`: _A conventional energy is an energy that has a conventional origin._

Axioms:
* `Equivalent To: energy and ('has origin' some conventional)`
* `Disjoint With: 'renewable energy'`

## Workflow checklist

### Automation
Closes #1270

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
