### PR TITLE
Add `narrative` and `storyline` as alternative label for `scenario` #1232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - internal combustion engine (#1285)
 - diesel fuel, diesel fuel role, diesel engine, diesel vehicle (#1288)
 - internal combustion vehicle (#1293)
+- scenario (#1296)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -878,7 +878,11 @@ Class: OEO_00000364
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
 add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'narrative' and 'storyline' as alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
         rdfs:label "scenario"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -873,6 +873,8 @@ Class: OEO_00000364
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
 add is about-relation


### PR DESCRIPTION
## Summary of the discussion

Narrative and storyline are like scenario.

## Type of change (CHANGELOG.md)

### Added
- Add `narrative` and `storyline` as alternative label to `scenario`

## Workflow checklist

### Automation
Closes #1232 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
