### PR TITLE
Features 1266 1267 1278 add transport networks and components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - gas vehicles, gas engines, more gas fuels, compressed gas fuel role (#1290)
 - motorised vehicle, aircraft and subclasses, land vehicle and subclasses, watercraft and subclasses (#1293)
 - conventional energy (#1295)
+- transport network, transport network component, transport hubs, and subclasses (#1297)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9524,6 +9524,8 @@ Class: OEO_00320016
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is an object aggregate of transport network components that enables the transport of people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "transport network"@en
     
     SubClassOf: 
@@ -9537,6 +9539,8 @@ Class: OEO_00320017
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road network is a transport network that enables transport on roads."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "road network"@en
     
     SubClassOf: 
@@ -9549,6 +9553,8 @@ Class: OEO_00320018
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rail network is a transport network that enables transport on rails."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "rail network"@en
     
     SubClassOf: 
@@ -9562,6 +9568,8 @@ Class: OEO_00320019
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waterway network is a transport network that enables transport on water."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "waterway network"@en
     
     SubClassOf: 
@@ -9574,6 +9582,8 @@ Class: OEO_00320020
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aviation network is a transport network that enables air transport."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "aviation network"@en
     
     SubClassOf: 
@@ -9586,6 +9596,8 @@ Class: OEO_00320021
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "transport network component"@en
     
     EquivalentTo: 
@@ -9602,6 +9614,8 @@ Class: OEO_00320022
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road is a transport network component with an artificial surface that allows transport for road vehicles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "road"@en
     
     SubClassOf: 
@@ -9613,6 +9627,8 @@ Class: OEO_00320023
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bridge is a transport network component that spans a physical obstacle without blocking the way underneath."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:comment "It can hold other transport network components such as rails and roads."@en,
         rdfs:label "bridge"@en
     
@@ -9625,6 +9641,8 @@ Class: OEO_00320024
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tunnel is a transport network component that is built through a certain environment (e.g. a mountain or water) and allows to pass through that environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:comment "It can contain other transport network components such as rails and roads."@en,
         rdfs:label "tunnel"@en
     
@@ -9637,6 +9655,8 @@ Class: OEO_00320025
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by rail vehicles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "railway"@en
     
     SubClassOf: 
@@ -9648,6 +9668,8 @@ Class: OEO_00320026
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A canal is a transport network component that is an artificially created waterway."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "canal"@en
     
     SubClassOf: 
@@ -9659,6 +9681,8 @@ Class: OEO_00320027
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport hub is a transport network component that allows the exchange of people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "transport hub"@en
     
     SubClassOf: 
@@ -9670,6 +9694,8 @@ Class: OEO_00320028
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A train station is a transport hub for trains."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "train station"@en
     
     SubClassOf: 
@@ -9681,6 +9707,8 @@ Class: OEO_00320029
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight train station is a train station for the exchange of goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "freight train station"@en
     
     SubClassOf: 
@@ -9692,6 +9720,8 @@ Class: OEO_00320030
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger train station is a train station for the exchange of passengers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "passenger train station"@en
     
     SubClassOf: 
@@ -9703,6 +9733,8 @@ Class: OEO_00320031
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bus station is a transport hub for busses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "bus station"@en
     
     SubClassOf: 
@@ -9714,6 +9746,8 @@ Class: OEO_00320032
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A port is a transport hub for ships."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "port"@en
     
     SubClassOf: 
@@ -9725,6 +9759,8 @@ Class: OEO_00320033
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight port is a port for the exchange of goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "freight port"@en
     
     SubClassOf: 
@@ -9736,6 +9772,8 @@ Class: OEO_00320034
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger port is a port for the exchange of passengers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "passenger port"@en
     
     SubClassOf: 
@@ -9747,6 +9785,8 @@ Class: OEO_00320035
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An airport is a transport hub for airplanes."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "airport"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9513,6 +9513,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         OEO_00000099
     
     
+Class: OEO_00320016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is an object aggregate of transport network components that enables the transport of people and/or goods."@en,
+        rdfs:label "transport network"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
+    
+Class: OEO_00320017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A road network is a transport network that enables transport on roads."@en,
+        rdfs:label "road network"@en
+    
+    SubClassOf: 
+        OEO_00320016
+    
+    
+Class: OEO_00320018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rail network is a transport network that enables transport on rails."@en,
+        rdfs:label "rail network"@en
+    
+    SubClassOf: 
+        OEO_00320016
+    
+    
+Class: OEO_00320019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waterway network is a transport network that enables transport on water."@en,
+        rdfs:label "waterway network"@en
+    
+    SubClassOf: 
+        OEO_00320016
+    
+    
+Class: OEO_00320020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An aviation network is a transport network that enables air transport."@en,
+        rdfs:label "aviation network"@en
+    
+    SubClassOf: 
+        OEO_00320016
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9647,6 +9647,94 @@ Class: OEO_00320027
         OEO_00320021
     
     
+Class: OEO_00320028
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A train station is a transport hub for trains."@en,
+        rdfs:label "train station"@en
+    
+    SubClassOf: 
+        OEO_00320027
+    
+    
+Class: OEO_00320029
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A freight train station is a train station for the exchange of goods."@en,
+        rdfs:label "freight train station"@en
+    
+    SubClassOf: 
+        OEO_00320028
+    
+    
+Class: OEO_00320030
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger train station is a train station for the exchange of passengers."@en,
+        rdfs:label "passenger train station"@en
+    
+    SubClassOf: 
+        OEO_00320028
+    
+    
+Class: OEO_00320031
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bus station is a transport hub for busses."@en,
+        rdfs:label "bus station"@en
+    
+    SubClassOf: 
+        OEO_00320027
+    
+    
+Class: OEO_00320032
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A port is a transport hub for ships."@en,
+        rdfs:label "port"@en
+    
+    SubClassOf: 
+        OEO_00320027
+    
+    
+Class: OEO_00320033
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A freight port is a port for the exchange of goods."@en,
+        rdfs:label "freight port"@en
+    
+    SubClassOf: 
+        OEO_00320032
+    
+    
+Class: OEO_00320034
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger port is a port for the exchange of passengers."@en,
+        rdfs:label "passenger port"@en
+    
+    SubClassOf: 
+        OEO_00320032
+    
+    
+Class: OEO_00320035
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An airport is a transport hub for airplanes."@en,
+        rdfs:label "airport"@en
+    
+    SubClassOf: 
+        OEO_00320027
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9516,6 +9516,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320016
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is an object aggregate of transport network components that enables the transport of people and/or goods."@en,
         rdfs:label "transport network"@en
     
@@ -9526,6 +9527,7 @@ Class: OEO_00320016
 Class: OEO_00320017
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road network is a transport network that enables transport on roads."@en,
         rdfs:label "road network"@en
     
@@ -9536,6 +9538,7 @@ Class: OEO_00320017
 Class: OEO_00320018
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rail network is a transport network that enables transport on rails."@en,
         rdfs:label "rail network"@en
     
@@ -9546,6 +9549,7 @@ Class: OEO_00320018
 Class: OEO_00320019
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waterway network is a transport network that enables transport on water."@en,
         rdfs:label "waterway network"@en
     
@@ -9556,6 +9560,7 @@ Class: OEO_00320019
 Class: OEO_00320020
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aviation network is a transport network that enables air transport."@en,
         rdfs:label "aviation network"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9563,6 +9563,85 @@ Class: OEO_00320020
         OEO_00320016
     
     
+Class: OEO_00320021
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
+        rdfs:label "transport network component"@en
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
+Class: OEO_00320022
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A road is a transport network component with an artificial surface that allows transport for road vehicles."@en,
+        rdfs:label "road"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
+Class: OEO_00320023
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bridge is a transport network component that spans a physical obstacle without blocking the way underneath."@en,
+        rdfs:comment "It can hold other transport network components such as rails and roads."@en,
+        rdfs:label "bridge"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
+Class: OEO_00320024
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tunnel is a transport network component that is built through a certain environment (e.g. a mountain or water) and allows to pass through that environment."@en,
+        rdfs:comment "It can contain other transport network components such as rails and roads."@en,
+        rdfs:label "tunnel"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
+Class: OEO_00320025
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by rail vehicles."@en,
+        rdfs:label "railway"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
+Class: OEO_00320026
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A canal is a transport network component that is an artificially created waterway."@en,
+        rdfs:label "canal"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
+Class: OEO_00320027
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport hub is a transport network component that allows the exchange of people and/or goods."@en,
+        rdfs:label "transport hub"@en
+    
+    SubClassOf: 
+        OEO_00320021
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -433,6 +433,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 ObjectProperty: OEO_00020056
 
     
+ObjectProperty: OEO_00020180
+
+    
 ObjectProperty: OEO_00020182
 
     Annotations: 
@@ -7548,6 +7551,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030035
 
     
+Class: OEO_00040009
+
+    
 Class: OEO_00040011
 
     
@@ -9521,7 +9527,9 @@ Class: OEO_00320016
         rdfs:label "transport network"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
+        <http://purl.obolibrary.org/obo/BFO_0000027>,
+        OEO_00140002 some OEO_00140001,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320021
     
     
 Class: OEO_00320017
@@ -9532,7 +9540,8 @@ Class: OEO_00320017
         rdfs:label "road network"@en
     
     SubClassOf: 
-        OEO_00320016
+        OEO_00320016,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320022
     
     
 Class: OEO_00320018
@@ -9543,7 +9552,9 @@ Class: OEO_00320018
         rdfs:label "rail network"@en
     
     SubClassOf: 
-        OEO_00320016
+        OEO_00320016,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320025,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320028
     
     
 Class: OEO_00320019
@@ -9554,7 +9565,8 @@ Class: OEO_00320019
         rdfs:label "waterway network"@en
     
     SubClassOf: 
-        OEO_00320016
+        OEO_00320016,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320032
     
     
 Class: OEO_00320020
@@ -9565,7 +9577,8 @@ Class: OEO_00320020
         rdfs:label "aviation network"@en
     
     SubClassOf: 
-        OEO_00320016
+        OEO_00320016,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320035
     
     
 Class: OEO_00320021
@@ -9575,8 +9588,13 @@ Class: OEO_00320021
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
         rdfs:label "transport network component"@en
     
-    SubClassOf: 
+    EquivalentTo: 
         OEO_00000061
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016)
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00020180 some OEO_00040009
     
     
 Class: OEO_00320022

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9619,7 +9619,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "road"@en
     
     SubClassOf: 
-        OEO_00320021
+        OEO_00320021,
+        OEO_00000501 some OEO_00010274
     
     
 Class: OEO_00320023
@@ -9654,13 +9655,14 @@ Class: OEO_00320025
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by rail vehicles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by trains."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "railway"@en
     
     SubClassOf: 
-        OEO_00320021
+        OEO_00320021,
+        OEO_00000501 some OEO_00010280
     
     
 Class: OEO_00320026
@@ -9699,7 +9701,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "train station"@en
     
     SubClassOf: 
-        OEO_00320027
+        OEO_00320027,
+        OEO_00000501 some OEO_00010280
     
     
 Class: OEO_00320029
@@ -9712,7 +9715,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "freight train station"@en
     
     SubClassOf: 
-        OEO_00320028
+        OEO_00320028,
+        OEO_00000501 some OEO_00010281
     
     
 Class: OEO_00320030
@@ -9725,7 +9729,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "passenger train station"@en
     
     SubClassOf: 
-        OEO_00320028
+        OEO_00320028,
+        OEO_00000501 some OEO_00010282
     
     
 Class: OEO_00320031
@@ -9738,7 +9743,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "bus station"@en
     
     SubClassOf: 
-        OEO_00320027
+        OEO_00320027,
+        OEO_00000501 some OEO_00010277
     
     
 Class: OEO_00320032
@@ -9751,7 +9757,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "port"@en
     
     SubClassOf: 
-        OEO_00320027
+        OEO_00320027,
+        OEO_00000501 some OEO_00010286
     
     
 Class: OEO_00320033
@@ -9764,7 +9771,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "freight port"@en
     
     SubClassOf: 
-        OEO_00320032
+        OEO_00320032,
+        OEO_00000501 some OEO_00010288
     
     
 Class: OEO_00320034
@@ -9777,7 +9785,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "passenger port"@en
     
     SubClassOf: 
-        OEO_00320032
+        OEO_00320032,
+        OEO_00000501 some OEO_00010287
     
     
 Class: OEO_00320035
@@ -9790,7 +9799,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         rdfs:label "airport"@en
     
     SubClassOf: 
-        OEO_00320027
+        OEO_00320027,
+        OEO_00000501 some OEO_00010292
     
     
 Individual: OEO_00000182


### PR DESCRIPTION
## Summary of the discussion

This PR implements the concepts from issues 1266, 1267, and 1278 together, because they are closely related.

## Type of change (CHANGELOG.md)

### Added
Added new classes with axioms:

- `transport network`: _A transport network is an object aggregate of transport network components that enables the transport of people and/or goods._
  Axioms: `'has part' some 'transport network component'`
  `'has quantity value' some 'length value'`
  - `road network`: _A road network is a transport network that enables transport on roads._
    Axiom: `'has part' some 'road'`
  - `rail network`: _A rail network is a transport network that enables transport on rails._
    Axioms: `'has part' some 'railway'`
    `'has part' some 'train station'`
  - `waterway network`: _A waterway network is a transport network that enables transport on water._
    Axiom: `'has part' some 'port'`
  - `aviation network`: _An aviation network is a transport network that enables air transport._
    Axiom: `'has part' some 'airport'`

- `transport network component`: _A transport network component is an artificial object that is part of a transport network._
  Axioms: `equivalentTo 'artificial object' and ('part of' some 'transport network')`
  `'has economic value' some 'cost'`
  - `road`: _A road is a transport network component with an artificial surface that allows transport for road vehicles._
    Axiom: `'is used by' some 'road vehicle'`
  - `bridge`: _A bridge is a transport network component that spans a physical obstacle without blocking the way underneath._
    As comment: It can hold other transport network components such as rails and roads.
  - `tunnel`: _A tunnel is a transport network component that is built through a certain environment (e.g. a mountain or water) and allows to pass through that environment._
    As comment: It can contain other transport network components such as rails and roads.
  - `railway`: _A railway is a transport network component that can only be used by trains._
    Axiom: `'is used by' some train`
  - `canal`: _A canal is a transport network component that is an artificially created waterway._
  - `transport hub`: _A transport hub is a transport network component that allows the exchange of people and/or goods._
    - `train station`: _A train station is a transport hub for trains._
      Axiom: `'is used by' some train`
   - `freight train station`: _A freight train station is a train station for the exchange of goods._
     Axiom: `'is used by' some 'freight train'`
   - `passenger train station`: _A passenger train station is a train station for the exchange of passengers._
     Axiom: `'is used by' some 'passenger train'`
    - `bus station`: _A bus station is a transport hub for busses._
      Axiom: `'is used by' some bus`
    - `port`: _A port is a transport hub for ships._
      Axiom: `'is used by' some ship`
   - `freight port`: _A freight port is a port for the exchange of goods._
     Axiom: `'is used by' some 'cargo ship'`
   - `passenger port`: _A passenger port is a port for the exchange of passengers._
     Axiom: `'is used by' some 'passenger ship'`
    - `airport`: _An airport is a transport hub for airplanes._
      Axiom: `'is used by' some aircraft`

Edit: added changes from below

## Workflow checklist

### Automation
Closes #1266 
Closes #1267 
Closes #1278 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
