### PR TITLE
Feature 1269 energy transfer and fuel transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - motorised vehicle, aircraft and subclasses, land vehicle and subclasses, watercraft and subclasses (#1293)
 - conventional energy (#1295)
 - transport network, transport network component, transport hubs, and subclasses (#1297)
+- subclasses for energy transfer, fuel transport and subclass, axiom for fuel, axiom for freight transport (#1299)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -31,6 +32,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - diesel fuel, diesel fuel role, diesel engine, diesel vehicle (#1288)
 - internal combustion vehicle (#1293)
 - scenario (#1296)
+- heat transfer (#1299)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2359,7 +2359,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
          and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
     
     SubClassOf: 
-        OEO_00000331
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117
     
     
 Class: OEO_00000174
@@ -5445,6 +5446,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
         OEO_00000207
     
     
+Class: OEO_00010117
+
+    
 Class: OEO_00010127
 
     Annotations: 
@@ -7987,9 +7991,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
     
-Class: OEO_00140003
-
-    
 Class: OEO_00140005
 
     
@@ -9813,7 +9814,9 @@ Class: OEO_00320036
         rdfs:label "electrical energy transfer"@en
     
     SubClassOf: 
-        OEO_00020103
+        OEO_00020103,
+        OEO_00010234 some OEO_00000139,
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00320037
@@ -9823,17 +9826,20 @@ Class: OEO_00320037
         rdfs:label "chemical energy transfer"@en
     
     SubClassOf: 
-        OEO_00020103
+        OEO_00020103,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000007
     
     
 Class: OEO_00320038
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the transport of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the freight transport of fuels."@en,
         rdfs:label "fuel transport"@en
     
     SubClassOf: 
-        OEO_00140003
+        OEO_00140005,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000173
     
     
 Class: OEO_00320039
@@ -9843,7 +9849,10 @@ Class: OEO_00320039
         rdfs:label "combustion fuel transport"@en
     
     SubClassOf: 
-        OEO_00320038
+        OEO_00320038,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000007,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000099
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8465,7 +8465,7 @@ Class: OEO_00140101
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer with thermal energy as the only input and thermal energy as the only output.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer of thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7987,6 +7987,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
     
+Class: OEO_00140003
+
+    
 Class: OEO_00140005
 
     
@@ -9821,6 +9824,26 @@ Class: OEO_00320037
     
     SubClassOf: 
         OEO_00020103
+    
+    
+Class: OEO_00320038
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the transport of fuels."@en,
+        rdfs:label "fuel transport"@en
+    
+    SubClassOf: 
+        OEO_00140003
+    
+    
+Class: OEO_00320039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport for combustion fuels."@en,
+        rdfs:label "combustion fuel transport"@en
+    
+    SubClassOf: 
+        OEO_00320038
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2351,7 +2351,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 shorten definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187
+
+Add good role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "fuel"
     
     EquivalentTo: 
@@ -8475,7 +8479,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Shorten definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "heat transfer"@en
     
     SubClassOf: 
@@ -9812,6 +9820,8 @@ Class: OEO_00320036
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "electrical energy transfer"@en
     
     SubClassOf: 
@@ -9825,6 +9835,8 @@ Class: OEO_00320037
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "chemical energy transfer"@en
     
     SubClassOf: 
@@ -9838,6 +9850,8 @@ Class: OEO_00320038
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the freight transport of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "fuel transport"@en
     
     SubClassOf: 
@@ -9850,6 +9864,8 @@ Class: OEO_00320039
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport for combustion fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "combustion fuel transport"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9810,6 +9810,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320036
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
         rdfs:label "electrical energy transfer"@en
     
@@ -9822,6 +9823,7 @@ Class: OEO_00320036
 Class: OEO_00320037
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
         rdfs:label "chemical energy transfer"@en
     
@@ -9834,6 +9836,7 @@ Class: OEO_00320037
 Class: OEO_00320038
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the freight transport of fuels."@en,
         rdfs:label "fuel transport"@en
     
@@ -9845,6 +9848,7 @@ Class: OEO_00320038
 Class: OEO_00320039
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport for combustion fuels."@en,
         rdfs:label "combustion fuel transport"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9863,7 +9863,7 @@ Class: OEO_00320039
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport for combustion fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport of combustion fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "combustion fuel transport"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9803,6 +9803,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         OEO_00000501 some OEO_00010292
     
     
+Class: OEO_00320036
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
+        rdfs:label "electrical energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00020103
+    
+    
+Class: OEO_00320037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
+        rdfs:label "chemical energy transfer"@en
+    
+    SubClassOf: 
+        OEO_00020103
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2426,7 +2426,11 @@ Class: OEO_00140005
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Add axiom for goods as participant:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "freight transport"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2430,7 +2430,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
         rdfs:label "freight transport"@en
     
     SubClassOf: 
-        OEO_00140003
+        OEO_00140003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
     
     
 Class: OEO_00140006


### PR DESCRIPTION

## Summary of the discussion

New subclasses for electrical and chemical energy transfer
New classes for (combustion) fuel transfer
Fuel gets good role
Freight transport gets axiomatised
Definition of heat transfer is updated

## Type of change (CHANGELOG.md)

### Added
New classes:
`electrical energy transfer`: Electrical energy transfer is an energy transfer of electrical energy.
`chemical energy transfer`: Chemical energy transfer is an energy transfer of chemical energy.
`fuel transport`: Fuel transport is the freight transport of fuels.
`combustion fuel transport`: Combustion fuel transport is the fuel transport for combustion fuels.

New axioms:
`'electrical energy transfer' 'has energy input' some 'electrical energy'`
`'electrical energy transfer' 'has energy output' some 'electrical energy'`

`'chemical energy transfer' 'has energy input' some 'chemical energy'`
`'chemical energy transfer' 'has energy output' some 'chemical energy'`

`'fuel transport' 'has participant' some fuel`

`'combustion fuel transport' 'has participant' some 'combustion fuel'`
`'combustion fuel transport' 'has energy input' some 'chemical energy'`
`'combustion fuel transport' 'has energy output' some 'chemical energy'`

`'fuel' 'has role' some 'good role'`

`'freight transport' 'has participant' some good`

### Updated
- Updated definition of `heat transfer`: Heat transfer is an energy transfer ~~with~~ **of** thermal energy ~~as the only input and and thermal energy as the only output~~.


## Workflow checklist

### Automation
Closes #1269

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
