### PR TITLE
Feature 1129 primary energy consumption accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - conventional energy (#1295)
 - transport network, transport network component, transport hubs, and subclasses (#1297)
 - subclasses for energy transfer, fuel transport and subclass, axiom for fuel, axiom for freight transport (#1299)
+- primary energy consumption calculation method and subclasses (#1306)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -33,6 +34,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - internal combustion vehicle (#1293)
 - scenario (#1296)
 - heat transfer (#1299)
+- primary energy consumption, gross inland energy consumption (#1306)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1521,20 +1521,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
     
     
-Class: OEO_00020166
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
-    
-    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7800,7 +7800,7 @@ Class: OEO_00050018
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
@@ -7813,13 +7813,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
         rdfs:label "primary energy consumption"@en
     
     SubClassOf: 
-        OEO_00140039,
+        OEO_00240019,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
         (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210),
-        OEO_00140002 some OEO_00050019
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
     
     
 Class: OEO_00050019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6448,6 +6448,47 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
         OEO_00020085
     
     
+Class: OEO_00010296
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
+        rdfs:label "primary energy consumption calculation method"@en
+    
+    SubClassOf: 
+        OEO_00020166,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
+    
+    
+Class: OEO_00010297
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier.",
+        rdfs:label "substitution method"@en
+    
+    SubClassOf: 
+        OEO_00010296
+    
+    
+Class: OEO_00010298
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses.",
+        rdfs:label "direct equivalent method"@en
+    
+    SubClassOf: 
+        OEO_00010296
+    
+    
+Class: OEO_00010299
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is method to calculate primary energy consumption that quantifies and renewable and nuclear energies by attributing an efficiency value each.",
+        rdfs:label "physical methdod"@en
+    
+    SubClassOf: 
+        OEO_00010296
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -7192,6 +7233,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
     SubClassOf: 
         OEO_00000007
     
+    
+Class: OEO_00020166
+
     
 Class: OEO_00020196
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7762,7 +7762,7 @@ Class: OEO_00050017
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value measuring the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
 Gross inland energy consumption covers:

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6488,7 +6488,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
 Class: OEO_00010299
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is method to calculate primary energy consumption that quantifies and renewable and nuclear energies by attributing an efficiency value each.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is a method to calculate primary energy consumption that quantifies renewable and nuclear energies by attributing an efficiency value each.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
         rdfs:label "physical method"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6452,6 +6452,8 @@ Class: OEO_00010296
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
         rdfs:label "primary energy consumption calculation method"@en
     
     SubClassOf: 
@@ -6463,6 +6465,8 @@ Class: OEO_00010297
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
         rdfs:label "substitution method"@en
     
     SubClassOf: 
@@ -6473,6 +6477,8 @@ Class: OEO_00010298
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
         rdfs:label "direct equivalent method"@en
     
     SubClassOf: 
@@ -6483,7 +6489,9 @@ Class: OEO_00010299
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is method to calculate primary energy consumption that quantifies and renewable and nuclear energies by attributing an efficiency value each.",
-        rdfs:label "physical methdod"@en
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+        rdfs:label "physical method"@en
     
     SubClassOf: 
         OEO_00010296
@@ -7828,7 +7836,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+improve definition: issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "gross inland energy consumption"@en
     
     SubClassOf: 
@@ -7853,7 +7864,11 @@ https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Prim
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+make energy consumption value:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "primary energy consumption"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1916,10 +1916,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020166
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "methodology"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1908,6 +1908,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
     
     
+Class: OEO_00020166
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
+        rdfs:label "methodology"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
+    
+    
 Class: OEO_00020175
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Add primary energy consumption calculation methods and align definitions of primary energy and gross inland consumption.

## Type of change (CHANGELOG.md)

### Added
- `primary energy consumption method`: _A primary energy consumption calculation method is a methodology to calculate primary energy consumption._
- `substitution method`: _A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier._
- `direct equivalent method`: _A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses._
- `physical method`: _A physical method is method to calculate primary energy consumption that quantifies and renewable and nuclear energies by attributing an efficiency value each._

### Updated
- Make `primary energy consumption` an `energy consumption value`: _Gross inland energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)._
- Improve definition of `gross inland energy consumption`: _Gross inland energy consumption is an energy consumption value ~measuring~ **accounting for** the total consumption of energy in a spatial region (e.g. a country)._
- Move `methodology` from oeo-model to oeo-shared. Else, the subclasses of methodology cannot be added to oeo-physical.

## Workflow checklist

### Automation
Closes #1129

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
