### PR TITLE
Add transport participant axiom #1271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - scenario (#1296)
 - heat transfer (#1299)
 - bottom up, hybrid, top down (#1302)
+- transport (#1309)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2395,7 +2395,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
 add performance axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289",
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1271
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309",
         rdfs:label "transport"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2404,7 +2404,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140002 some OEO_00320000
+        OEO_00140002 some OEO_00320000,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000323 or OEO_00010116)
     
     
 Class: OEO_00140004


### PR DESCRIPTION
## Summary of the discussion

This is only a partial solution of issue #1271. It adds one axiom already agreed on; further axioms are needed but need some time.

## Type of change (CHANGELOG.md)

### Added
- Axiom: `transport 'has participant some (person or good)`

## Workflow checklist

### Automation
No automation, as this PR is only a partial solution of issue #1271.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
