### PR TITLE
Add `has bearer` axioms to subclasses of `realizable entity` #1305

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - scenario (#1296)
 - heat transfer (#1299)
 - bottom up, hybrid, top down (#1302)
+- has bearer axioms to OEO-defined realizable entities 
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3823,7 +3823,11 @@ Class: OEO_00000395
         <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "state of matter"
     
     SubClassOf: 
@@ -4370,7 +4374,11 @@ Class: OEO_00010011
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "volatility"@en
     
     SubClassOf: 
@@ -7131,7 +7139,11 @@ Class: OEO_00020144
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "rotor diameter"
     
     SubClassOf: 
@@ -7981,7 +7993,11 @@ Class: OEO_00140000
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "hub height"@en
     
     SubClassOf: 
@@ -8611,7 +8627,11 @@ Class: OEO_00140126
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "planned availability"@en
     
     SubClassOf: 
@@ -8654,7 +8674,11 @@ Class: OEO_00140129
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availabilty is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "unplanned availability"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1609,7 +1609,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
 Class: OEO_00000043
@@ -2609,7 +2610,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some 
+            (OEO_00000331
+             and (OEO_00000531 value OEO_00000182))
     
     
 Class: OEO_00000199
@@ -3823,7 +3827,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39",
         rdfs:label "state of matter"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some OEO_00000331
     
     
 Class: OEO_00000396
@@ -4369,7 +4374,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "volatility"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some OEO_00000331
     
     
 Class: OEO_00010012
@@ -7130,6 +7136,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some 
+            (OEO_00000044 or OEO_00000448),
         OEO_00140002 some OEO_00140001
     
     
@@ -7978,6 +7986,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some OEO_00000044,
         OEO_00140002 some OEO_00140001
     
     
@@ -8607,6 +8616,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some OEO_00000031,
         OEO_00140002 some OEO_00140127
     
     
@@ -8649,6 +8659,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some OEO_00000031,
         OEO_00140002 some OEO_00140127
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1601,7 +1601,11 @@ Class: OEO_00000042
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of an object aggregate that has been discarded after primary use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "waste role",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -2602,7 +2606,11 @@ Class: OEO_00000198
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "greenhouse effect disposition",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1004,7 +1004,11 @@ Class: OEO_00000051
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "agent"
     
     SubClassOf: 
@@ -1483,7 +1487,11 @@ add relation to monetary price
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
 
 update definition:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "good role"@en
     
     SubClassOf: 
@@ -1770,7 +1778,11 @@ Class: OEO_00020121
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "resolution"
     
     SubClassOf: 
@@ -1786,7 +1798,11 @@ Class: OEO_00020122
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
 add individuals
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "temporal resolution"
     
     SubClassOf: 
@@ -2527,7 +2543,11 @@ Class: OEO_00140040
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         rdfs:label "demand"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1008,7 +1008,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210",
         rdfs:label "agent"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some 
+            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000061
@@ -1486,6 +1488,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000002>,
         OEO_00020180 some OEO_00040003
     
     
@@ -1771,7 +1774,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
         rdfs:label "resolution"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 Class: OEO_00020122
@@ -1786,7 +1790,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972",
         rdfs:label "temporal resolution"
     
     SubClassOf: 
-        OEO_00020121
+        OEO_00020121,
+        OEO_00010121 some OEO_00030034
     
     DisjointWith: 
         OEO_00020123
@@ -2242,6 +2247,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
         <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
+Class: OEO_00030034
+
+    
 Class: OEO_00030035
 
     Annotations: 
@@ -2523,7 +2531,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
         rdfs:label "demand"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000017>
+        <http://purl.obolibrary.org/obo/BFO_0000017>,
+        OEO_00010121 some 
+            (OEO_00000323 or OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
     
     
 Class: OEO_00140081


### PR DESCRIPTION
## Summary of the discussion

Implement the axioms that are already solved in the table of issue #1305.

## Type of change (CHANGELOG.md)

### Added axioms
* `'hub height' 'has bearer' some 'wind energy converting unit'`
* `'rotor diameter' 'has bearer' some ('wind energy converting unit' or 'wind rotor')`
* `'planned availability' 'has bearer' some 'power plant'`
* `'unplanned availability' 'has bearer' some 'power plant'`
* `resolution 'has bearer some 'data set'`
* `'temporal resolution' 'has bearer' some 'time series'`
* `demand 'has bearer' some (person or organisation or object)`
* `'state of matter' 'has bearer' some 'portion of matter'`
* `'greenhouse effect disposition' 'has bearer' some ('portion of matter' and ('has state of matter' value gaseous))`
* `volatility 'has bearer' some 'portion of matter'`
* `agent 'has bearer' some 'person or organisation'`
* `'good role' 'has bearer' some continuant'`
* `'waste role' 'has bearer' some 'object aggregate'`

## Workflow checklist

### Automation
No automation, as issue #1305 is only partly solved by this PR.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
