### PR TITLE
Add vehicle operational mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - conventional energy (#1295)
 - transport network, transport network component, transport hubs, and subclasses (#1297)
 - subclasses for energy transfer, fuel transport and subclass, axiom for fuel, axiom for freight transport (#1299)
+- vehicle operational mode (#1314)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -35,6 +36,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - heat transfer (#1299)
 - bottom up, hybrid, top down (#1302)
 - transport (#1309)
+- vehicle (#1314)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2675,7 +2675,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
         rdfs:label "vehicle operational mode"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        OEO_00010121 some OEO_00010023
     
     
 Individual: OEO_00020161

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1422,7 +1422,11 @@ Class: OEO_00010023
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+Add vehicle operational mode axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
         rdfs:label "vehicle",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -2665,6 +2669,8 @@ Class: OEO_00320041
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
         rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
         rdfs:label "vehicle operational mode"@en
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1430,7 +1430,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00000061,
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
     
     
 Class: OEO_00010079
@@ -2657,6 +2658,18 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
     
     SubClassOf: 
         OEO_00320001
+    
+    
+Class: OEO_00320041
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
+        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
+        rdfs:label "vehicle operational mode"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
     
     
 Individual: OEO_00020161


### PR DESCRIPTION
## Summary of the discussion

Operational mode is added, but only for vehicles, because machine is tricky to define.

## Type of change (CHANGELOG.md)

### Added
`vehicle operational mode`: A vehicle operational mode is a realizable entity that determines how a vehicle is operating.

### Updated
`vehicle`: `vehicle 'bearer of' some 'operational mode'`


## Workflow checklist

### Automation
Closes #1304 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
