### PR TITLE
Add `NC/BR sector division` and `NC/BR sector: X` individuals #1273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - primary energy consumption calculation method and subclasses (#1306)
 - vehicle operational mode (#1314)
 - gas turbine vehicle, jet fuel vehicle, jet fuel gas turbine (#1315)
+- NC/BR sector division; NC/BR sector individuals (#1317)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2249,6 +2249,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
      OEO_00000504  OEO_00000242,
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
     
+    SameAs: 
+        OEO_00010306,
+        OEO_00010311
+    
     
 Individual: OEO_00010043
 
@@ -2354,6 +2358,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010187,
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010188
     
+    SameAs: 
+        OEO_00010307,
+        OEO_00010308
+    
     
 Individual: OEO_00010048
 
@@ -2385,7 +2393,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
     
     SameAs: 
         OEO_00010071,
-        OEO_00010135
+        OEO_00010135,
+        OEO_00010308,
+        OEO_00010309
     
     
 Individual: OEO_00010049
@@ -2416,6 +2426,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010177,
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010178
     
+    SameAs: 
+        OEO_00010309,
+        OEO_00010310
+    
     
 Individual: OEO_00010050
 
@@ -2432,6 +2446,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
     
     Facts:  
      OEO_00000504  OEO_00000242
+    
+    SameAs: 
+        OEO_00010310,
+        OEO_00010311
     
     
 Individual: OEO_00010052
@@ -4143,6 +4161,142 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
      OEO_00000504  OEO_00000242
     
     
+Individual: OEO_00010304
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector division is a sector division defined by the UNFCCC reporting guidelines on national communications for Parties included in Annex I to the Convention.
+(https://unfccc.int/sites/default/files/resource/cp2019_13a01_adv.pdf, 6/CP.25, VI, Table 2)",
+        rdfs:label "NC/BR sector division"@en
+    
+    Types: 
+        OEO_00000368
+    
+    
+Individual: OEO_00010305
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"energy\" is a sector defined by the NC/BR sector division that includes all energy use that is not related to transport or industry. The sector includes:
+- CRF sector (IPCC 2006): energy industry
+- CRF sector (IPCC 2006): fuel combustion - other sectors
+- CRF sector (IPCC 2006): fuel combustion - other
+- CRF sector (IPCC 2006): fugitive emissions from fuels
+- CRF sector (IPCC 2006): CO2 transport and storage",
+        rdfs:label "NC/BR sector: energy"@en
+    
+    Types: 
+        OEO_00000367
+    
+    Facts:  
+     OEO_00000504  OEO_00010304,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010040,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010043,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010044,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010057,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010058
+    
+    
+Individual: OEO_00010306
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"transport\" is a transport sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): transport.",
+        rdfs:label "NC/BR sector: transport"@en
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00010304
+    
+    SameAs: 
+        OEO_00010042
+    
+    
+Individual: OEO_00010307
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"industry/industrial processes and product use\" is an industry sector defined by the NC/BR sector division. The sector includes:
+- CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries
+- CRF sector (IPCC 2006): industrial processes and product use",
+        rdfs:label "NC/BR sector: industry/industrial processes and product use"@en
+    
+    Types: 
+        OEO_00000227
+    
+    Facts:  
+     OEO_00000504  OEO_00010304
+    
+    SameAs: 
+        OEO_00010047
+    
+    
+Individual: OEO_00010308
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"agriculture\" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): agriculture.",
+        rdfs:label "NC/BR sector: agriculture"@en
+    
+    Types: 
+        OEO_00010035
+    
+    SameAs: 
+        OEO_00010047,
+        OEO_00010048
+    
+    
+Individual: OEO_00010309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"forestry/LULUCF\" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): land use, land-use change and forestry.",
+        rdfs:label "NC/BR sector: forestry/LULUCF"@en
+    
+    Types: 
+        OEO_00010035
+    
+    Facts:  
+     OEO_00000504  OEO_00010304
+    
+    SameAs: 
+        OEO_00010048,
+        OEO_00010049
+    
+    
+Individual: OEO_00010310
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"waste management/waste\" is a waste and wastewater sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): waste.",
+        rdfs:label "NC/BR sector: waste management/waste"@en
+    
+    Types: 
+        OEO_00010036
+    
+    Facts:  
+     OEO_00000504  OEO_00010304
+    
+    SameAs: 
+        OEO_00010049,
+        OEO_00010050
+    
+    
+Individual: OEO_00010311
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"other\" is a sector defined by the NC/BR sector division that includes everything that is not included in the other NC/BR sectors. It aligns to the CRF sector (IPCC 2006): other.",
+        rdfs:label "NC/BR sector: other"@en
+    
+    Types: 
+        OEO_00000367
+    
+    Facts:  
+     OEO_00000504  OEO_00010304
+    
+    SameAs: 
+        OEO_00010042,
+        OEO_00010050
+    
+    
 DisjointClasses: 
     OEO_00000145,OEO_00000213,OEO_00000422
+
+DifferentIndividuals: 
+    OEO_00010305,OEO_00010306,OEO_00010307,OEO_00010308,OEO_00010309,OEO_00010310,OEO_00010311
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2250,8 +2250,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010039
     
     SameAs: 
-        OEO_00010306,
-        OEO_00010311
+        OEO_00010306
     
     
 Individual: OEO_00010043
@@ -2359,7 +2358,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010188
     
     SameAs: 
-        OEO_00010307,
         OEO_00010308
     
     
@@ -2394,7 +2392,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
     SameAs: 
         OEO_00010071,
         OEO_00010135,
-        OEO_00010308,
         OEO_00010309
     
     
@@ -2427,7 +2424,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941",
      <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010178
     
     SameAs: 
-        OEO_00010309,
         OEO_00010310
     
     
@@ -2448,7 +2444,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
      OEO_00000504  OEO_00000242
     
     SameAs: 
-        OEO_00010310,
         OEO_00010311
     
     
@@ -4166,6 +4161,8 @@ Individual: OEO_00010304
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector division is a sector division defined by the UNFCCC reporting guidelines on national communications for Parties included in Annex I to the Convention.
 (https://unfccc.int/sites/default/files/resource/cp2019_13a01_adv.pdf, 6/CP.25, VI, Table 2)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector division"@en
     
     Types: 
@@ -4181,6 +4178,8 @@ Individual: OEO_00010305
 - CRF sector (IPCC 2006): fuel combustion - other
 - CRF sector (IPCC 2006): fugitive emissions from fuels
 - CRF sector (IPCC 2006): CO2 transport and storage",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: energy"@en
     
     Types: 
@@ -4199,6 +4198,8 @@ Individual: OEO_00010306
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"transport\" is a transport sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): transport.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: transport"@en
     
     Types: 
@@ -4217,36 +4218,40 @@ Individual: OEO_00010307
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"industry/industrial processes and product use\" is an industry sector defined by the NC/BR sector division. The sector includes:
 - CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries
 - CRF sector (IPCC 2006): industrial processes and product use",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: industry/industrial processes and product use"@en
     
     Types: 
         OEO_00000227
     
     Facts:  
-     OEO_00000504  OEO_00010304
-    
-    SameAs: 
-        OEO_00010047
+     OEO_00000504  OEO_00010304,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010046,
+     <http://purl.obolibrary.org/obo/BFO_0000051>  OEO_00010160
     
     
 Individual: OEO_00010308
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"agriculture\" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): agriculture.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: agriculture"@en
     
     Types: 
         OEO_00010035
     
     SameAs: 
-        OEO_00010047,
-        OEO_00010048
+        OEO_00010047
     
     
 Individual: OEO_00010309
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"forestry/LULUCF\" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): land use, land-use change and forestry.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: forestry/LULUCF"@en
     
     Types: 
@@ -4256,14 +4261,15 @@ Individual: OEO_00010309
      OEO_00000504  OEO_00010304
     
     SameAs: 
-        OEO_00010048,
-        OEO_00010049
+        OEO_00010048
     
     
 Individual: OEO_00010310
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"waste management/waste\" is a waste and wastewater sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): waste.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: waste management/waste"@en
     
     Types: 
@@ -4273,14 +4279,15 @@ Individual: OEO_00010310
      OEO_00000504  OEO_00010304
     
     SameAs: 
-        OEO_00010049,
-        OEO_00010050
+        OEO_00010049
     
     
 Individual: OEO_00010311
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The NC/BR sector \"other\" is a sector defined by the NC/BR sector division that includes everything that is not included in the other NC/BR sectors. It aligns to the CRF sector (IPCC 2006): other.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1273
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
         rdfs:label "NC/BR sector: other"@en
     
     Types: 
@@ -4290,7 +4297,6 @@ Individual: OEO_00010311
      OEO_00000504  OEO_00010304
     
     SameAs: 
-        OEO_00010042,
         OEO_00010050
     
     


### PR DESCRIPTION
## Summary of the discussion

Add the sector concept (sector division) used in National Communications (NC) and Biennial Reports (BR).

## Type of change (CHANGELOG.md)

### Added
* `NC/BR sector division`: _The NC/BR sector division is a sector division defined by the UNFCCC reporting guidelines on national communications for Parties included in Annex I to the Convention. (https://unfccc.int/sites/default/files/resource/cp2019_13a01_adv.pdf, 6/CP.25, VI, Table 2)_
* `NC/BR sector: energy`: _The NC/BR sector "energy" is a sector defined by the NC/BR sector division that includes all energy use that is not related to transport or industry. It encompasses: CRF sector (IPCC 2006): energy industry; CRF sector (IPCC 2006): fuel combustion - other sectors; CRF sector (IPCC 2006): fuel combustion - other; CRF sector (IPCC 2006): fugitive emissions from fuels; CRF sector (IPCC 2006): CO2 transport and storage._
* `NC/BR sector: transport`: _The NC/BR sector "transport" is a transport sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): transport._
* `NC/BR sector: industry/industrial processes and product use`: _The NC/BR sector "industry/industrial processes and product use" is an industry sector defined by the NC/BR sector division. The sector includes: CRF sector (IPCC 2006): manufacture of solid fuels and other energy industries; CRF sector (IPCC 2006): industrial processes and product use"
* `NC/BR sector: agriculture`: _The NC/BR sector "agriculture" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): agriculture._
* `NC/BR sector: forestry/LULUCF`: _The NC/BR sector "forestry/LULUCF" is an agriculture, forestry and land use sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): land use, land-use change and forestry._
* `NC/BR sector: waste management/waste`: _The NC/BR sector "waste management/waste" is a waste and wastewater sector defined by the NC/BR sector division. It aligns to the CRF sector (IPCC 2006): waste._
* `NC/BR sector: other` _The NC/BR sector "other" is a sector defined by the NC/BR sector division that includes everything that is not included in the other NC/BR sectors. It aligns to the CRF sector (IPCC 2006): other._
* `DifferentIndividuals` axiom for all these new NC/BR sectors.

### Changed
`SameAs` axioms are added by Protégé automatically on both sides of the relation. Therefore the following existing individuals were also changed:
* `CRF sector (IPCC 2006): transport`
* `CRF sector (IPCC 2006): agriculture`
* `CRF sector (IPCC 2006): land use, land-use change and forestry`
* `CRF sector (IPCC 2006): other`

As these changes were automatically and to not really change the individuals themselves, I do not think it is necessary to add term trackers for that or mention this in the CHANGELOG.md.

## Workflow checklist

### Automation
Closes #1273

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
