### PR TITLE
Add sector activity related concepts

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6600,6 +6600,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
         OEO_00000503 some OEO_00000245
     
     
+Class: OEO_00010313
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral energy consumption is the energy use of a sector.",
+        rdfs:label "sectoral energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00010210,
+        OEO_00140002 some OEO_00140081
+    
+    
+Class: OEO_00010314
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral energy consumption is the energy use of a sector.",
+        rdfs:label "sectoral emission"@en
+    
+    SubClassOf: 
+        OEO_00000147,
+        OEO_00140002 some OEO_00050019
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6614,7 +6614,7 @@ Class: OEO_00010313
 Class: OEO_00010314
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral energy consumption is the energy use of a sector.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral emission is the emission of a sector.",
         rdfs:label "sectoral emission"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -648,6 +648,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
         <http://purl.obolibrary.org/obo/IAO_0000136>
     
     
+ObjectProperty: OEO_00010312
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a sector and the processes or material entities it covers.",
+        rdfs:label "is sector of"@en
+    
+    Domain: 
+        OEO_00000367
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
 ObjectProperty: OEO_00020056
 
     Annotations: 
@@ -949,6 +962,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912"
     SubClassOf: 
         OEO_00000514 some OEO_00020121
     
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000104>
+
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 


### PR DESCRIPTION
## Summary of the discussion

This PR implements what has already been agreed on in issue #864

## Type of change (CHANGELOG.md)

### Added
- object property `is sector of`: _A relation that holds between a sector and the processes or material entities it covers._
- class `sectoral energy consumption`: _A sectoral energy consumption is the energy use of a sector._
- class `sectoral emission`: _A sectoral emission is the emission of a sector._

## Workflow checklist

### Automation
No automation, as this PR does not fully solve issue #864.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
