### PR TITLE
Add `international transport sector` #969

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is sector of, sectoral energy consumption, sectoral emission (#1321)
 - data file format, and subclasses (#1326)
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
+- international transport sector (#1334)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -52,6 +53,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - energy use (#1321)
 - data format (#1326)
 - crude oil; gas diesel oil, gasoline, kerosene, and subclasses; CRF sector (IPCC 2006): petroleum refining (#1331)
+- CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -837,6 +837,8 @@ Class: OEO_00010320
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An international transport sector is a transport sector of international transport processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/969
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         rdfs:label "international transport sector"@en
     
     SubClassOf: 
@@ -3918,11 +3920,15 @@ Individual: OEO_00010200
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
+
+Make instance of 'international transport sector':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/969
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         rdfs:label "CRF sector (IPCC 2006): international bunkers"@en
     
     Types: 
-        OEO_00000422,
+        OEO_00010320,
         OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3943,11 +3949,15 @@ Individual: OEO_00010201
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
+
+Make instance of 'international transport sector':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/969
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         rdfs:label "CRF sector (IPCC 2006): international aviation"@en
     
     Types: 
-        OEO_00000422,
+        OEO_00010320,
         OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3970,11 +3980,15 @@ Individual: OEO_00010202
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
+
+Make instance of 'international transport sector':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/969
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         rdfs:label "CRF sector (IPCC 2006): maritime navigation"@en
     
     Types: 
-        OEO_00000422,
+        OEO_00010320,
         OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -4037,11 +4051,15 @@ Individual: OEO_00010205
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
+
+Make instance of 'international transport sector':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/969
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         rdfs:label "MMR sector: M.International aviation in the EU ETS"@en
     
     Types: 
-        OEO_00000422,
+        OEO_00010320,
         OEO_00010232 some OEO_00010227,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -833,6 +833,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         OEO_00010312 some OEO_00010315
     
     
+Class: OEO_00010320
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An international transport sector is a transport sector of international transport processes.",
+        rdfs:label "international transport sector"@en
+    
+    SubClassOf: 
+        OEO_00000422,
+        OEO_00010312 some OEO_00140004
+    
+    
 Class: OEO_00020015
 
     
@@ -1537,6 +1548,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
     SubClassOf: 
         OEO_00090001
     
+    
+Class: OEO_00140004
+
     
 Class: OEO_00140009
 


### PR DESCRIPTION
## Summary of the discussion

Introduce a sector for international transport.

## Type of change (CHANGELOG.md)

### Added
- `international transport sector`: _An international transport sector is a transport sector of international transport processes._

### Updated
Make existing individuals instances of this new class:
* `CRF sector (IPCC 2006): international bunkers`
* `CRF sector (IPCC 2006): international aviation`
* `CRF sector (IPCC 2006): maritime navigation`
* `MMR sector: M.International aviation in the EU ETS`

Opposing to [this comment](https://github.com/OpenEnergyPlatform/ontology/issues/969#issuecomment-1268595033), I did not make `CRF sector (IPCC 2006): international bunkers and multilateral operations` and instance of this class, as this includes more than international transport and thus just being a `transport sector` is better.

## Workflow checklist

### Automation
Closes #969

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
