### PR TITLE
Make `final energy consumption` an `energy consumption value` #1322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - energy use (#1321)
 - data format (#1326)
 - crude oil; gas diesel oil, gasoline, kerosene, and subclasses; CRF sector (IPCC 2006): petroleum refining (#1331)
+- final energy consumption (#1340)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2410,13 +2410,17 @@ Class: OEO_00050016
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is the consumption of energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is an energy consumption value accounting for the energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+Make 'energy consumption value'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1322
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340",
         rdfs:label "final energy consumption"@en
     
     SubClassOf: 
-        OEO_00140039
+        OEO_00240019
     
     
 Class: OEO_00050019
@@ -2640,6 +2644,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00240019
+
+    
 Class: OEO_00240022
 
     Annotations: 
@@ -2800,21 +2807,3 @@ Individual: OEO_00020165
         OEO_00020122
     
     
-Class: OEO_00020166
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
-        rdfs:label "methodology"
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
-
-


### PR DESCRIPTION
## Summary of the discussion

Align `final energy consumption` with `primary energy consumption` and `gross inland energy value`.

## Type of change (CHANGELOG.md)

### Updated
- Make `final energy consumption` a subclass of `energy consumption value`:  _Final energy consumption is **an energy consumption value accounting for** the ~consumption of~ energy delivered to and consumed by end users._

## Workflow checklist

### Automation
Closes #1322

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
