### PR TITLE
Feature 1298 equivalence subclasses for vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - data file format, and subclasses (#1326)
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
+- equivalence subclasses for car and truck (#1345)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10315,6 +10315,8 @@ Class: OEO_00320043
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel car is a car that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "diesel car"@en
     
     EquivalentTo: 
@@ -10331,6 +10333,8 @@ Class: OEO_00320044
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel truck is a truck that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "diesel truck"@en
     
     EquivalentTo: 
@@ -10347,6 +10351,8 @@ Class: OEO_00320045
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline car is a car that has only a gasoline engine as motor for propulsion and thus is also a gasoline vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "gasoline car"@en
     
     EquivalentTo: 
@@ -10363,6 +10369,8 @@ Class: OEO_00320046
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric car is a car that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "battery electric car"@en
     
     EquivalentTo: 
@@ -10378,6 +10386,8 @@ Class: OEO_00320047
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric car is a car that has an eletric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "fuel cell electric car"@en
     
     EquivalentTo: 
@@ -10393,6 +10403,8 @@ Class: OEO_00320048
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas car is a car that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "compressed gas car"@en
     
     EquivalentTo: 
@@ -10410,6 +10422,8 @@ Class: OEO_00320049
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied petroleum gas car is a car that uses liquefied petroleum gas in a gas engine for propulsion and thus is also a liquefied petroleum gas vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "liquefied petroleum gas car"@en
     
     EquivalentTo: 
@@ -10427,6 +10441,8 @@ Class: OEO_00320050
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric car is a car that can switch between an electric traction motor and an internal combustion engine for propulsion and thus is also a plug-in hybrid electric vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "plug-in hybrid electric car"@en
     
     EquivalentTo: 
@@ -10444,6 +10460,8 @@ Class: OEO_00320051
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric truck is a truck that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "battery electric truck"@en
     
     EquivalentTo: 
@@ -10459,6 +10477,8 @@ Class: OEO_00320052
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric truck is a truck that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "fuel cell electric truck"@en
     
     EquivalentTo: 
@@ -10474,6 +10494,8 @@ Class: OEO_00320053
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas truck is a truck that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "compressed gas truck"@en
     
     EquivalentTo: 
@@ -10491,6 +10513,8 @@ Class: OEO_00320054
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied natural gas truck is a truck that uses liquefied natural gas in a gas engine for propulsion and thus is also a liquefied natural gas vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         rdfs:label "liquefied natural gas truck"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4813,7 +4813,7 @@ Class: OEO_00010030
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both a traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both an electric traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10311,6 +10311,199 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1316",
         OEO_00030024
     
     
+Class: OEO_00320043
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel car is a car that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
+        rdfs:label "diesel car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320044
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel truck is a truck that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
+        rdfs:label "diesel truck"@en
+    
+    EquivalentTo: 
+        OEO_00010278
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010244> or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010278
+    
+    
+Class: OEO_00320045
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline car is a car that has only a gasoline engine as motor for propulsion and thus is also a gasoline vehicle.",
+        rdfs:label "gasoline car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (<http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010243> or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320046
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric car is a car that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
+        rdfs:label "battery electric car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028)
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320047
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric car is a car that has an eletric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
+        rdfs:label "fuel cell electric car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000016)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028)
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320048
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas car is a car that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
+        rdfs:label "compressed gas car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (OEO_00000503 some OEO_00320015)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (OEO_00320008 or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320049
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied petroleum gas car is a car that uses liquefied petroleum gas in a gas engine for propulsion and thus is also a liquefied petroleum gas vehicle.",
+        rdfs:label "liquefied petroleum gas car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (OEO_00000503 some OEO_00320011)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (OEO_00320008 or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320050
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric car is a car that can switch between an electric traction motor and an internal combustion engine for propulsion and thus is also a plug-in hybrid electric vehicle.",
+        rdfs:label "plug-in hybrid electric car"@en
+    
+    EquivalentTo: 
+        OEO_00010276
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00010029
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010253>)))
+    
+    SubClassOf: 
+        OEO_00010276
+    
+    
+Class: OEO_00320051
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric truck is a truck that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
+        rdfs:label "battery electric truck"@en
+    
+    EquivalentTo: 
+        OEO_00010278
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028)
+    
+    SubClassOf: 
+        OEO_00010278
+    
+    
+Class: OEO_00320052
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric truck is a truck that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
+        rdfs:label "fuel cell electric truck"@en
+    
+    EquivalentTo: 
+        OEO_00010278
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000016)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010028)
+    
+    SubClassOf: 
+        OEO_00010278
+    
+    
+Class: OEO_00320053
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas truck is a truck that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
+        rdfs:label "compressed gas truck"@en
+    
+    EquivalentTo: 
+        OEO_00010278
+         and (OEO_00000503 some OEO_00320015)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (OEO_00320008 or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010278
+    
+    
+Class: OEO_00320054
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied natural gas truck is a truck that uses liquefied natural gas in a gas engine for propulsion and thus is also a liquefied natural gas vehicle.",
+        rdfs:label "liquefied natural gas truck"@en
+    
+    EquivalentTo: 
+        OEO_00010278
+         and (OEO_00000503 some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010237>)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
+            (OEO_00320008 or (not (OEO_00010032))))
+    
+    SubClassOf: 
+        OEO_00010278
+    
+    
 Individual: OEO_00000182
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Add equivalence subclasses for vehicles to create concepts that combine propulsion and vehicle type. It has been decided to limit such equivalence subclasses to `car` and `truck` where they are most useful.

## Type of change (CHANGELOG.md)

### Added
* `diesel truck`: _A diesel truck is a truck that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle._
* `diesel car`: _A diesel car is a car that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle._
* `gasoline car`: _A gasoline car is a car that has only a gasoline engine as motor for propulsion and thus is also a gasoline vehicle._
* `battery electric car`: _A battery electric car is a car that as an electric traction motor and a traction buttery and thus is also a battery electric vehicle._
- `fuel cell electric car`: _A fuel cell electric car is a car that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle._
- `compressed gas car`: _A compressed gas car is a car that uses compressed gas in a gas engine and thus is also a compressed gas vehicle._
- `liquefied petroleum gas car`: _A liquefied petroleum gas car is a car that uses liquefied petroleum gas in a gas engine and thus is also a liquefied petroleum gas vehicle._
- `plug-in hybrid electric car`: _A plug-in hybrid electric car is a car that can switch between an electric traction motor and an internal combustion engine for propulsion and thus is also a plug-in hybrid electric vehicle._
- `battery electric truck`: _A battery electric truck is a truck that has an electric traction motor and a traction battery and thus is also a battery electric vehicle._
- `fuel cell electric truck`: _A fuel cell electric truck is a truck that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle._
- `compressed gas truck`: _A compressed gas truck is a truck that uses compressed gas in a gas engine and thus is also a compressed gas vehicle._
- `liquefied natural gas truck`: _A liquefied natural gas truck is a truck that uses liquefied natural gas in a gas engine and thus is also a liquefied natural gas vehicle._

### Other
Fixed a typo in `plug-in hybrid electric vehicle`. It should be _**electric** traction motor_ not just _traction motor_.


## Workflow checklist

### Automation
Closes #1298

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
