### PR TITLE
add subrelations of is about for bundle dev #1335

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - data file format, and subclasses (#1326)
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
+- has study region, has study subregio, has considered region, has interacting region, has scenario year (#1347)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -262,7 +262,7 @@ ObjectProperty: OEO_00020224
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a scenario year to indicated the scenario year of a scenario.",
-        rdfs:label "has scenario year"@de
+        rdfs:label "has scenario year"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -214,7 +214,7 @@ ObjectProperty: OEO_00020221
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a considered region to indicated a considered region of a scenario.",
-        rdfs:label "has considered region"@de
+        rdfs:label "has considered region"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -198,7 +198,7 @@ ObjectProperty: OEO_00020220
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study region to indicated the study region of a scenario.",
-        rdfs:label "has study region"@de
+        rdfs:label "has study region"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -194,6 +194,86 @@ ObjectProperty: OEO_00000522
 ObjectProperty: OEO_00020056
 
     
+ObjectProperty: OEO_00020220
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study region to indicated the study region of a scenario.",
+        rdfs:label "has study region"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00000364
+    
+    Range: 
+        OEO_00020032
+    
+    
+ObjectProperty: OEO_00020221
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a considered region to indicated a considered region of a scenario.",
+        rdfs:label "has considered region"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00000364
+    
+    Range: 
+        OEO_00020035
+    
+    
+ObjectProperty: OEO_00020222
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and an interacting region to indicated an interacting region of a scenario.",
+        rdfs:label "has interacting region"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00000364
+    
+    Range: 
+        OEO_00020036
+    
+    
+ObjectProperty: OEO_00020223
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study subregion to indicated a study subregion of a scenario.",
+        rdfs:label "has study subregion"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00000364
+    
+    Range: 
+        OEO_00020034
+    
+    
+ObjectProperty: OEO_00020224
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a scenario year to indicated the scenario year of a scenario.",
+        rdfs:label "has scenario year"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00000364
+    
+    Range: 
+        OEO_00020097
+    
+    
 ObjectProperty: OEO_00040010
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -230,7 +230,7 @@ ObjectProperty: OEO_00020222
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and an interacting region to indicated an interacting region of a scenario.",
-        rdfs:label "has interacting region"@de
+        rdfs:label "has interacting region"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -246,7 +246,7 @@ ObjectProperty: OEO_00020223
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study subregion to indicated a study subregion of a scenario.",
-        rdfs:label "has study subregion"@de
+        rdfs:label "has study subregion"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -198,6 +198,8 @@ ObjectProperty: OEO_00020220
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study region to indicated the study region of a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         rdfs:label "has study region"
     
     SubPropertyOf: 
@@ -214,6 +216,8 @@ ObjectProperty: OEO_00020221
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a considered region to indicated a considered region of a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         rdfs:label "has considered region"
     
     SubPropertyOf: 
@@ -230,6 +234,8 @@ ObjectProperty: OEO_00020222
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and an interacting region to indicated an interacting region of a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         rdfs:label "has interacting region"
     
     SubPropertyOf: 
@@ -246,6 +252,8 @@ ObjectProperty: OEO_00020223
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a study subregion to indicated a study subregion of a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         rdfs:label "has study subregion"
     
     SubPropertyOf: 
@@ -262,6 +270,8 @@ ObjectProperty: OEO_00020224
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a scenario year to indicated the scenario year of a scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         rdfs:label "has scenario year"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-model.properties
+++ b/src/ontology/edits/oeo-model.properties
@@ -1,0 +1,5 @@
+#Fri Oct 21 09:55:57 CEST 2022
+jdbc.url=
+jdbc.driver=
+jdbc.user=
+jdbc.password=

--- a/src/ontology/edits/oeo-model.properties
+++ b/src/ontology/edits/oeo-model.properties
@@ -1,5 +1,0 @@
-#Fri Oct 21 13:13:26 CEST 2022
-jdbc.url=
-jdbc.driver=
-jdbc.user=
-jdbc.password=

--- a/src/ontology/edits/oeo-model.properties
+++ b/src/ontology/edits/oeo-model.properties
@@ -1,4 +1,4 @@
-#Fri Oct 21 09:55:57 CEST 2022
+#Fri Oct 21 13:13:26 CEST 2022
 jdbc.url=
 jdbc.driver=
 jdbc.user=


### PR DESCRIPTION
## Summary of the discussion

New subrelations of `is about` are introduced to indicate regional and temporal aspects of scenarios, see #1335 .

## Type of change (CHANGELOG.md)

### Added
- `has study region`
- `has study subregion`
- `has considered region`
- `has interacting region`
- `has scenario year`


## Workflow checklist

### Automation
closes #1335

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
