### PR TITLE
Restructure energy storage (function)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
 - equivalence subclasses for car and truck (#1345)
+- chemical/electrical/kinetic/potential energy storage function
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -57,7 +58,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
-- energy storage -> energy storage function
+- energy storage -> energy storage function; thermal energy storage function
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
-- energy storage -> energy storage function; thermal energy storage function; methanation gas storage -> power-to-methane system (#1348)
+- energy storage -> energy storage function; thermal energy storage function; methanation gas storage -> power-to-methane system; power-to-liquid system (#1348)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - methanation gas storage -> power-to-methane system; power-to-liquid system (#1348)
 
 ### Removed
+- battery storage (#1348)
 
 ## [1.11.0] - 2022-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
 - equivalence subclasses for car and truck (#1345)
-- chemical/electrical/kinetic/potential energy storage function
+- chemical/electrical/kinetic/potential energy storage function (#1348)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -58,7 +58,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
-- energy storage -> energy storage function; thermal energy storage function
+- energy storage -> energy storage function; thermal energy storage function; methanation gas storage -> power-to-methane system (#1348)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
+- energy storage -> energy storage function
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
 - equivalence subclasses for car and truck (#1345)
-- chemical/electrical/kinetic/potential energy storage function (#1348)
+- chemical/electrical/kinetic/potential energy storage function; underground fuel storage object (#1348)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - final energy consumption (#1340)
 - fuel cell (#1341)
 - energy storage -> energy storage function; thermal energy storage function; energy storage object; storage unit (#1348)
-- methanation gas storage -> power-to-methane system; power-to-liquid system (#1348)
+- methanation gas storage -> power-to-methane system; power-to-liquid system; pumped water, pumped hydro storage power plant (#1348)
 
 ### Removed
 - battery storage (#1348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
-- energy storage -> energy storage function; thermal energy storage function; methanation gas storage -> power-to-methane system; power-to-liquid system (#1348)
+- energy storage -> energy storage function; thermal energy storage function; energy storage object; storage unit (#1348)
+- methanation gas storage -> power-to-methane system; power-to-liquid system (#1348)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6861,7 +6861,7 @@ Class: OEO_00010325
         <http://purl.obolibrary.org/obo/IAO_0000115> "An underground fuel storage object is an energy storage object that stores chemical energy in form of fuels underground.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "underground fuel storage object"@en
+        rdfs:label "underground fuel storage object"
     
     SubClassOf: 
         OEO_00000159,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6825,7 +6825,7 @@ Class: OEO_00010322
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage function is an energy storage function with electrical energy as input and output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "electrical energy storage function"@en
+        rdfs:label "electrical energy storage function"
     
     SubClassOf: 
         OEO_00000012

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3178,7 +3178,7 @@ Class: OEO_00000269
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to methane process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1170
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "power-to-methane system"
     
@@ -4618,7 +4618,7 @@ Class: OEO_00010020
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid (often abbreviated P2L or PtL) system is an energy storage object that converts electrical power to a liquid fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is an energy transformation unit that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
@@ -4626,7 +4626,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         rdfs:label "power-to-liquid system"
     
     SubClassOf: 
-        OEO_00000159
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021
     
     
 Class: OEO_00010021

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2350,7 +2350,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 
 Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "energy storage object"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1121,10 +1121,10 @@ Class: OEO_00000012
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage is a function of an artificial object that has been engineered to contain energy for conversion as usable energy later.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is a function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
-        rdfs:label "energy storage"
+        rdfs:label "energy storage function"
     
     SubClassOf: 
         OEO_00000151,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6813,7 +6813,7 @@ Class: OEO_00010321
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical energy storage function is an energy storage function with chemical energy as input and output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "chemical energy storage function"@en
+        rdfs:label "chemical energy storage function"
     
     SubClassOf: 
         OEO_00000012

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3172,7 +3172,7 @@ Class: OEO_00000269
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2353,8 +2353,16 @@ Class: OEO_00000159
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+
+Make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "energy storage object"
+    
+    EquivalentTo: 
+        OEO_00000061
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
     
     SubClassOf: 
         OEO_00000061
@@ -3968,6 +3976,10 @@ Class: OEO_00000399
         <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
         rdfs:label "storage unit"
     
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
+    
     SubClassOf: 
         OEO_00020006,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
@@ -4622,7 +4634,11 @@ Class: OEO_00010020
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+Align with 'power-to-gas system':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "power-to-liquid system"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4056,7 +4056,7 @@ Class: OEO_00000429
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
 Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4056,14 +4056,18 @@ Class: OEO_00000429
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an energy storage object that stores hydrogen underground. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462",
-        rdfs:label "underground hydrogen storage"
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462
+
+Improve definition and classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
+        rdfs:label "underground hydrogen storage object"
     
     SubClassOf: 
-        OEO_00000159,
+        OEO_00010325,
         OEO_00000503 some OEO_00000220
     
     
@@ -6849,6 +6853,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
     
     SubClassOf: 
         OEO_00000012
+    
+    
+Class: OEO_00010325
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground fuel storage object? is an energy storage object that stores chemical energy in form of fuels underground.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
+        rdfs:label "underground fuel storage object"@en
+    
+    SubClassOf: 
+        OEO_00000159,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010321
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6849,7 +6849,7 @@ Class: OEO_00010324
         <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage function is an energy storage function with potential energy as input and output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "potential energy storage function"@en
+        rdfs:label "potential energy storage function"
     
     SubClassOf: 
         OEO_00000012

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6837,7 +6837,7 @@ Class: OEO_00010323
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kinetic energy storage function is an energy storage function with kinetic energy as input and output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "kinetic energy storage function"@en
+        rdfs:label "kinetic energy storage function"
     
     SubClassOf: 
         OEO_00000012

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3172,7 +3172,7 @@ Class: OEO_00000269
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to methane process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
@@ -6858,7 +6858,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010325
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground fuel storage object? is an energy storage object that stores chemical energy in form of fuels underground.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground fuel storage object is an energy storage object that stores chemical energy in form of fuels underground.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "underground fuel storage object"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3974,6 +3974,9 @@ Class: OEO_00000399
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1338
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "storage unit"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1567,7 +1567,7 @@ Class: OEO_00000039
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
-        rdfs:label "thermal energy storage"
+        rdfs:label "thermal energy storage function"
     
     SubClassOf: 
         OEO_00000012

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1128,7 +1128,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
     
     SubClassOf: 
         OEO_00000151,
-        <http://purl.obolibrary.org/obo/BFO_0000034>
+        OEO_00010121 some OEO_00000061
     
     
 Class: OEO_00000013
@@ -1566,7 +1566,7 @@ Class: OEO_00000039
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage is an energy storage that stores thermal energy for later use.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
         rdfs:label "thermal energy storage"
     
     SubClassOf: 
@@ -6784,6 +6784,46 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         OEO_00020102,
         OEO_00000503 some OEO_00000115,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010315
+    
+    
+Class: OEO_00010321
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical energy storage function is an energy storage function with chemical energy as input and output.",
+        rdfs:label "chemical energy storage function"@en
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00010322
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage function is an energy storage function with electrical energy as input and output.",
+        rdfs:label "electrical energy storage function"@en
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00010323
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A kinetic energy storage function is an energy storage function with kinetic energy as input and output.",
+        rdfs:label "kinetic energy storage function"@en
+    
+    SubClassOf: 
+        OEO_00000012
+    
+    
+Class: OEO_00010324
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage function is an energy storage function with potential energy as input and output.",
+        rdfs:label "potential energy storage function"@en
+    
+    SubClassOf: 
+        OEO_00000012
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1121,7 +1121,7 @@ Class: OEO_00000012
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is a function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is the function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1123,7 +1123,11 @@ Class: OEO_00000012
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is a function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+
+Improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1170
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "energy storage function"
     
     SubClassOf: 
@@ -1567,6 +1571,9 @@ Class: OEO_00000039
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "thermal energy storage function"
     
     SubClassOf: 
@@ -3168,11 +3175,16 @@ Class: OEO_00000269
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation gas storage is a energy storage that uses carbon dioxide and hydrogen from electrolysis to produce methan and store this. The methan can then be used to produce electricity or heat in a gas generator."@en,
-        rdfs:label "methanation gas storage"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to methane process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1170
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
+        rdfs:label "power-to-methane system"
     
     SubClassOf: 
-        OEO_00000012
+        OEO_00000335,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010217
     
     DisjointWith: 
         OEO_00000070
@@ -6790,6 +6802,8 @@ Class: OEO_00010321
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical energy storage function is an energy storage function with chemical energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "chemical energy storage function"@en
     
     SubClassOf: 
@@ -6800,6 +6814,8 @@ Class: OEO_00010322
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage function is an energy storage function with electrical energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "electrical energy storage function"@en
     
     SubClassOf: 
@@ -6810,6 +6826,8 @@ Class: OEO_00010323
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kinetic energy storage function is an energy storage function with kinetic energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "kinetic energy storage function"@en
     
     SubClassOf: 
@@ -6820,6 +6838,8 @@ Class: OEO_00010324
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage function is an energy storage function with potential energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "potential energy storage function"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1829,21 +1829,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
     
     SubClassOf: 
         OEO_00000159,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000070
-    
-    
-Class: OEO_00000070
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery storage is a energy storage that uses batteries to store energy."@en,
-        rdfs:label "battery storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    DisjointWith: 
-        OEO_00000269
+        OEO_00010234 some OEO_00000139,
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140037,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010322
     
     
 Class: OEO_00000071
@@ -3194,9 +3183,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         OEO_00000335,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010217
     
-    DisjointWith: 
-        OEO_00000070
-    
     
 Class: OEO_00000282
 
@@ -3655,17 +3641,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
     
     
-Class: OEO_00000343
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped storage (pumped-storage hdyroelectricity) is an energy storage that uses water from a higher reservoir to generate energy."@en,
-        rdfs:label "pumped storage"
-    
-    SubClassOf: 
-        OEO_00000012
-    
-    
 Class: OEO_00000345
 
     Annotations: 
@@ -3676,12 +3651,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
 
 add secondary energy carrier disposition
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243
+
+add potential energy axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "pumped water"
     
     SubClassOf: 
         OEO_00110000,
         OEO_00000501 some OEO_00000399,
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020045,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
     
     
@@ -5163,12 +5143,17 @@ Class: OEO_00010089
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
+
+Add energy storage function axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "pumped hydro storage power plant"@en
     
     SubClassOf: 
         OEO_00010088,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010090,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010322
     
     
 Class: OEO_00010090


### PR DESCRIPTION
## Summary of the discussion

This PR solves large parts of the confusion and inconsistencies of energy storage as function and energy storage as object which was discussed in various issues (#1170, #1174, #1261, #1262 and #1338). This topic was discussed on OEO dev meeting 46. Some parts of this topic are not solved by this PR, but it covers at least the most important part. For the parts that are remaining, we use either existing issues or create new issues.

This is how the `energy storage function` classes will look like:
![grafik](https://user-images.githubusercontent.com/36884905/197202691-473bcd9a-5581-4e5b-ad26-d977095d72b8.png)

And this is how the `energy storage object` classes will look like:
![grafik](https://user-images.githubusercontent.com/36884905/197204908-13b77a0a-d404-48a4-8bfb-382240cd88bb.png)

## Type of change (CHANGELOG.md)

### Added
- `chemical energy storage function`
- `electrical energy storage function`
- `kinetic energy storage function `
- `potential energy storage function `
- `underground fuel storage object`

### Updated
- `energy storage` ➡️ `energy storage function`
- `thermal energy storage` ➡️  `thermal energy storage function`
- `energy storage object`
- `storage unit`
- `methanation gas storage` ➡️  `power-to-methane system`
- `power-to-liquid system`
- `battery`
- `pumped water`
- `pumped hydro storage power plant`
- `underground hydrogen storage object` ➡️  `underground hydrogen storage object`

### Removed
- `battery storage`
- `pumped storage`

## Workflow checklist

### Automation
* Closes #1170
* Closes #1174
* Closes #1262
* Closes #1338

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
