### PR TITLE
Add `refinery gas` and `petroleum coke` #1332

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
 - equivalence subclasses for car and truck (#1345)
+- refinery gas, petroleum coke (#1351)
 
 ### Changed
 - github: update the description of the readme file (#1292)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6814,7 +6814,7 @@ Class: OEO_00010327
         <http://purl.obolibrary.org/obo/IAO_0000118> "pet coke",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
-        rdfs:label "petroleum coke"@en
+        rdfs:label "petroleum coke"
     
     SubClassOf: 
         OEO_00000331,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6790,6 +6790,8 @@ Class: OEO_00010326
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Refinery gas is a gas mixture that is produced as a by product of a mineral oil refining process. It mainly consists of hydrogen, methane, ethane and olefins and can be used as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
         rdfs:label "refinery gas"@en
     
     SubClassOf: 
@@ -6810,6 +6812,8 @@ Class: OEO_00010327
         <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum coke is a portion of matter with a solid state of matter that is produced in a mineral oil refining process. It consists mainly of carbon and can be uses as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "coke",
         <http://purl.obolibrary.org/obo/IAO_0000118> "pet coke",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
         rdfs:label "petroleum coke"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6786,6 +6786,41 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010315
     
     
+Class: OEO_00010326
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Refinery gas is a gas mixture that is produced as a by product of a mineral oil refining process. It mainly consists of hydrogen, methane, ethane and olefins and can be used as a fuel.",
+        rdfs:label "refinery gas"@en
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00000025
+             and OEO_00000220),
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000182
+    
+    
+Class: OEO_00010327
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum coke is a portion of matter with a solid state of matter that is produced in a mineral oil refining process. It consists mainly of carbon and can be uses as a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "coke",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "pet coke",
+        rdfs:label "petroleum coke"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000390
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6792,7 +6792,7 @@ Class: OEO_00010326
         <http://purl.obolibrary.org/obo/IAO_0000115> "Refinery gas is a gas mixture that is produced as a by product of a mineral oil refining process. It mainly consists of hydrogen, methane, ethane and olefins and can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
-        rdfs:label "refinery gas"@en
+        rdfs:label "refinery gas"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,


### PR DESCRIPTION
## Summary of the discussion

Add `refinery gas` and `petroleum coke`

## Type of change (CHANGELOG.md)

### Added
- `refinery gas`: _Refinery gas is a gas mixture that is produced as a by product of a mineral oil refining process. It mainly consists of hydrogen, methane, ethane and olefins and can be used as a fuel._
- `petroleum coke`: _Petroleum coke is a portion of matter with a solid state of matter that is produced in a mineral oil refining process. It consists mainly of carbon and can be uses as a fuel._

## Workflow checklist

### Automation
Closes #1332

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
