### PR TITLE
Add waste heat sources #1265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil, mineral oil product, mineral oil refinery, mineral oil refining, mineral oil refining sector (#1331)
 - international transport sector (#1334)
 - equivalence subclasses for car and truck (#1345)
+- data center, sewage plant, industrial waste thermal energy, recovered heat, aerothermal energy (#1265)
 
 ### Changed
 - github: update the description of the readme file (#1292)
@@ -57,6 +58,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - CRF sector (IPCC 2006): international bunkers / international aviation / maritime bunkers; MMR sector: M.International aviation in the EU ETS (#1334)
 - final energy consumption (#1340)
 - fuel cell (#1341)
+- energy converting component, energy storage object, hardware, solar receiving object, vehicle, waste thermal energy (#1265)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1113,6 +1113,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
     
     SubClassOf: 
         OEO_00000061,
+        OEO_00010235 some OEO_00010114,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
     
@@ -2350,7 +2351,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
         rdfs:label "energy storage object"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00000165
@@ -5565,11 +5567,11 @@ Class: OEO_00010114
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
-        rdfs:label "waste thermal energy"@en
+        rdfs:label "waste thermal energy"
     
     SubClassOf: 
         OEO_00000207
@@ -7328,6 +7330,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
     
     SubClassOf: 
         OEO_00000061,
+        OEO_00010235 some OEO_00010114,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
@@ -7619,7 +7622,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199)
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00020201
@@ -9752,11 +9756,67 @@ Class: OEO_00310000
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A datacenter is an artificial object that houses computer systems and associated components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request:",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "data center"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114
+    
+    
+Class: OEO_00310001
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sewage plant is an artificial object that removes contaminants from wastewater to produce an effluent that is suitable for discharge to the surrounding environment or an intended reuse application."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
+        rdfs:label "sewage plant"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00000503 some OEO_00000441,
+        OEO_00010235 some OEO_00010114
+    
+    
+Class: OEO_00310004
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste thermal energy is waste thermal energy that is energy output of some industrial process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
+        rdfs:label "industrial waste thermal energy"
+    
+    SubClassOf: 
+        OEO_00010114,
+        OEO_00020184 some OEO_00050000
+    
+    
+Class: OEO_00310005
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Recovered heat is a thermal energy that is physical output of an energy transformation process and that is recovered and would otherwise be emitted in the environment as waste thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
+        rdfs:label "recovered heat"
+    
+    SubClassOf: 
+        OEO_00000207
+    
+    
+Class: OEO_00310006
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Aerothermal energy is a natural ambient thermal energy that is stored in the air of a natural environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
+        rdfs:label "aerothermal energy"
+    
+    SubClassOf: 
+        OEO_00140104
     
     
 Class: OEO_00320004

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1107,7 +1107,10 @@ renaming to component
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
 redefine
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:comment "formerly called energy transformer and formerly called energy converting device",
         rdfs:label "energy converting component"
     
@@ -2347,7 +2350,10 @@ Class: OEO_00000159
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "energy storage object"
     
     SubClassOf: 
@@ -5570,7 +5576,10 @@ Class: OEO_00010114
         <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813
+
+change label and definition language
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "waste thermal energy"
     
     SubClassOf: 
@@ -7614,7 +7623,10 @@ Class: OEO_00020200
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "solar receiving object"
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9746,6 +9746,19 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000122>
     
     
+Class: OEO_00310000
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A datacenter is an artificial object that houses computer systems and associated components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request:",
+        rdfs:label "data center"
+    
+    SubClassOf: 
+        OEO_00000061
+    
+    
 Class: OEO_00320004
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1184,7 +1184,10 @@ Class: OEO_00000206
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "hardware"
     
     SubClassOf: 
@@ -1454,7 +1457,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 
 Add vehicle operational mode axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         rdfs:label "vehicle",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -647,7 +647,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
     InverseOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>
     
-    
+
 ObjectProperty: OEO_00010312
 
     Annotations: 
@@ -1185,7 +1185,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350",
         rdfs:label "hardware"
     
     SubClassOf: 
-        OEO_00000061
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00000238
@@ -1459,6 +1460,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000061,
+        OEO_00010235 some OEO_00010114,
         <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
     
     
@@ -1475,7 +1477,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
         OEO_00000350,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
     
-    
+
 Class: OEO_00010116
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -647,7 +647,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
     InverseOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>
     
+    
+ObjectProperty: OEO_00010235
 
+    
 ObjectProperty: OEO_00010312
 
     Annotations: 
@@ -1477,7 +1480,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
         OEO_00000350,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
     
+    
+Class: OEO_00010114
 
+    
 Class: OEO_00010116
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

This PR closes [Issue 1265](https://github.com/OpenEnergyPlatform/ontology/issues/1265).

### Added
- `data center`
- `sewage plant`
- `industrial waste thermal energy`
- `recovered heat` 
- `aerothermal energy`


### Updated
- `energy converting component`
- `energy storage object` 
- `hardware` 
- `solar receiving object` 
- `vehicle` 
- `waste thermal energy` -> changed label and definition according to other definitions (language en at definitions not labels)


### Removed


## Workflow checklist

### Automation
* Closes #1265 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
