### PR TITLE
delete individuals csv and txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Removed
 - battery storage (#1348)
+- csv and txt (#1371)
 
 ## [1.11.0] - 2022-07-04
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1988,16 +1988,6 @@ Individual: OEO_00000114
         OEO_00000392
     
     
-Individual: OEO_00000116
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        rdfs:label "csv"
-    
-    Types: 
-        OEO_00000120
-    
-    
 Individual: OEO_00000121
 
     Annotations: 
@@ -2226,16 +2216,6 @@ Individual: OEO_00000424
     
     Types: 
         OEO_00000078
-    
-    
-Individual: OEO_00000426
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        rdfs:label "txt"
-    
-    Types: 
-        OEO_00000120
     
     
 Individual: OEO_00000450


### PR DESCRIPTION
The individuals csv and txt were replaced by classes OEO:00280003 and OEO:00280001. Hence, the individuals should be deleted.
See issue #1145 

## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Removed
- Removed individuals csv OEO:00000116 and txt OEO:00000426

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
