### PR TITLE
Add `OEP user`, `qualitist`, `quantitist`, `apinist` #1339

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - tank, fuel tank, volume (#1356)
+- OEP user, qualitist, quantitist, apinist (#1383)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -849,7 +849,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
 Class: OEO_00010328
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An OEP user is a user that interacts with the Open Energy Platform.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An OEP user is a user who interacts with the Open Energy Platform.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "OEP user"@en
@@ -861,7 +861,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
 Class: OEO_00010329
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with qualitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user who mainly interacts with qualitive information.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "qualitist"@en
@@ -873,7 +873,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
 Class: OEO_00010330
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with quantitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user who mainly interacts with quantitive information.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "quantitist"@en
@@ -885,7 +885,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
 Class: OEO_00010331
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An apinist is an OEP user that mainly interacts via an API.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An apinist is an OEP user who mainly interacts via an API.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "apinist"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -852,7 +852,7 @@ Class: OEO_00010328
         <http://purl.obolibrary.org/obo/IAO_0000115> "An OEP user is a user who interacts with the Open Energy Platform.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
-        rdfs:label "OEP user"@en
+        rdfs:label "OEP user"
     
     SubClassOf: 
         OEO_00000431
@@ -861,10 +861,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
 Class: OEO_00010329
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user who mainly interacts with qualitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user who mainly interacts with qualitative information.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
-        rdfs:label "qualitist"@en
+        rdfs:label "qualitist"
     
     SubClassOf: 
         OEO_00010328
@@ -873,10 +873,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
 Class: OEO_00010330
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user who mainly interacts with quantitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantitist is an OEP user who mainly interacts with quantitative information.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
-        rdfs:label "quantitist"@en
+        rdfs:label "quantitist"
     
     SubClassOf: 
         OEO_00010328
@@ -888,7 +888,7 @@ Class: OEO_00010331
         <http://purl.obolibrary.org/obo/IAO_0000115> "An apinist is an OEP user who mainly interacts via an API.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
-        rdfs:label "apinist"@en
+        rdfs:label "apinist"
     
     SubClassOf: 
         OEO_00010328

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -850,6 +850,8 @@ Class: OEO_00010328
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An OEP user is a user that interacts with the Open Energy Platform.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "OEP user"@en
     
     SubClassOf: 
@@ -860,6 +862,8 @@ Class: OEO_00010329
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with qualitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "qualitist"@en
     
     SubClassOf: 
@@ -870,6 +874,8 @@ Class: OEO_00010330
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with quantitive information.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "quantitist"@en
     
     SubClassOf: 
@@ -880,6 +886,8 @@ Class: OEO_00010331
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An apinist is an OEP user that mainly interacts via an API.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1339
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         rdfs:label "apinist"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -846,6 +846,46 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1334",
         OEO_00010312 some OEO_00140004
     
     
+Class: OEO_00010328
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An OEP user is a user that interacts with the Open Energy Platform.",
+        rdfs:label "OEP user"@en
+    
+    SubClassOf: 
+        OEO_00000431
+    
+    
+Class: OEO_00010329
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with qualitive information.",
+        rdfs:label "qualitist"@en
+    
+    SubClassOf: 
+        OEO_00010328
+    
+    
+Class: OEO_00010330
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A qualitist is an OEP user that mainly interacts with quantitive information.",
+        rdfs:label "quantitist"@en
+    
+    SubClassOf: 
+        OEO_00010328
+    
+    
+Class: OEO_00010331
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An apinist is an OEP user that mainly interacts via an API.",
+        rdfs:label "apinist"@en
+    
+    SubClassOf: 
+        OEO_00010328
+    
+    
 Class: OEO_00020015
 
     


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Added
* `OEP user`: _An OEP user is a user that interacts with the Open Energy Platform._
* `qualitist`: _A qualitist is an OEP user that mainly interacts with qualitive information._
* `quantitist`: _A qualitist is an OEP user that mainly interacts with quantitive information._
* `apinist`: _An apinist is an OEP user that mainly interacts via an API._

### Updated

### Removed

## Workflow checklist

### Automation
Closes #1339

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
