### PR TITLE
Add SubclassOf axiom to `model descriptor` #1386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)
+- model descriptor (#1387)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1292,12 +1292,19 @@ Class: OEO_00020016
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+
+Add SubclassOf axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
         rdfs:label "model descriptor"@en
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020017


### PR DESCRIPTION
## Summary of the discussion

The class `model descriptor` lacks a SubclassOf axiom and therefore is not displayed properly in the OEO-viewer.

## Type of change (CHANGELOG.md)

Add axiom: `'model descriptor' SubclassOf: 'information content entity'`

## Workflow checklist

### Automation
Closes #1386

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
