### PR TITLE
Add electricity and fuel demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - tank, fuel tank, volume (#1356)
 - sustainability criterion, material sustainability, process sustainability, process sustainability, sustainable process (#1385)
+- electricity demand, fuel demand (#1389)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2070,6 +2070,8 @@ Class: OEO_00320062
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389",
         rdfs:label "electricity demand"
     
     SubClassOf: 
@@ -2080,6 +2082,8 @@ Class: OEO_00320063
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389",
         rdfs:label "fuel demand"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2066,6 +2066,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/"@en,
         OEO_00140081
     
     
+Class: OEO_00320062
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
+        rdfs:label "electricity demand"
+    
+    SubClassOf: 
+        OEO_00140146
+    
+    
+Class: OEO_00320063
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
+        rdfs:label "fuel demand"
+    
+    SubClassOf: 
+        OEO_00140146
+    
+    
 Individual: OEO_00000160
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Straight forward addition of `electricity demand` and `fuel demand`.

## Type of change (CHANGELOG.md)

### Added
- `electricity demand`: _Electricity demand is the energy demand for electricity._
- `fuel demand`: _Fuel demand is the energy demand for fuel._

## Workflow checklist

### Automation
Closes #1366 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
