### PR TITLE
add object property `based on` #1346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - sustainability criterion, material sustainability, process sustainability, process sustainability, sustainable process (#1385)
 - vehicle-kilometre (#1388)
 - electricity demand, fuel demand (#1389)
+- based on (#1391)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -290,7 +290,7 @@ ObjectProperty: OEO_00020226
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario study or projection and a scenario, that indicates the scenario that provides the assumptions on which the respective scenatio study or projection is based on.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1346
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
-        rdfs:label "based on"
+        rdfs:label "is based on"
     
     SubPropertyOf: 
         owl:topObjectProperty

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -293,7 +293,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         rdfs:label "is based on"
     
     SubPropertyOf: 
-        owl:topObjectProperty
+        <http://purl.obolibrary.org/obo/RO_0000057>
     
     Domain: 
         OEO_00010262 or <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010252>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -288,6 +288,8 @@ ObjectProperty: OEO_00020226
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario study or projection and a scenario, that indicates the scenario that provides the assumptions on which the respective scenatio study or projection is based on.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1346
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         rdfs:label "based on"
     
     SubPropertyOf: 
@@ -388,11 +390,15 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010252>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario study is a study that investigates one or more scenarios.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1058
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131
+add based on axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1346
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         rdfs:label "scenario study"@en
     
     SubClassOf: 
         OEO_00020011,
+        OEO_00020226 some OEO_00000364,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364
     
     
@@ -1266,11 +1272,15 @@ Class: OEO_00010262
         <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more a variables of interest into the future.
 (Intentional: a research question is basis for the projection to be done)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/970
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1217
+add based on axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1346
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         rdfs:label "scenario projection"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00020226 some OEO_00000364,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -394,7 +394,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1131
 add based on axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1346
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
-        rdfs:label "scenario study"@en
+        rdfs:label "scenario study"
     
     SubClassOf: 
         OEO_00020011,

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -284,6 +284,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347",
         OEO_00020097
     
     
+ObjectProperty: OEO_00020226
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario study or projection and a scenario, that indicates the scenario that provides the assumptions on which the respective scenatio study or projection is based on.",
+        rdfs:label "based on"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00010262 or <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010252>
+    
+    Range: 
+        OEO_00000364
+    
+    
 ObjectProperty: OEO_00040010
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -398,8 +398,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
     
     SubClassOf: 
         OEO_00020011,
-        OEO_00020226 some OEO_00000364,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364
+        OEO_00020226 some OEO_00000364
     
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
@@ -1282,7 +1281,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         OEO_00020226 some OEO_00000364,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000275,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000364,
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
     
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -213,7 +213,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
 ObjectProperty: OEO_00020182
 
     
-ObjectProperty: OEO_00020226
 
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -214,7 +214,6 @@ ObjectProperty: OEO_00020182
 
     
 
-        <http://purl.obolibrary.org/obo/RO_0000057>
     
     
 ObjectProperty: owl:topObjectProperty

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -214,7 +214,6 @@ ObjectProperty: OEO_00020182
 
     
 
-    SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000057>
     
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -213,6 +213,12 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
 ObjectProperty: OEO_00020182
 
     
+ObjectProperty: OEO_00020226
+
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000057>
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Added
- object property `based on`: _A relation between a scenario study or projection and a scenario, that indicates the scenario that provides the assumptions on which the respective scenatio study or projection is based on._
- axioms `'scenario study' 'based on' some 'scenario'` and `'scenario projection' 'based on' some 'scenario'` 

### Updated

### Removed
- - axioms `'scenario study' 'has participant' some 'scenario'` and `'scenario projection' 'has participant' some 'scenario'` 


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
