### PR TITLE
Add bidirectional vehicle charging station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - thermo-chemical heat storage object, chemical heat storage object, sorption heat storage object, adsorption, desorption (#1363)
 - sensible heat storage object, sensible solid heat storage object, sensible fluid heat storage object (#1363)
 - phase transition, evaporation, melting, latent heat storage object, latent fluid-gaseous heat storage object, latent solid-fluid heat storage object (#1363)
+- bidirectional vehicle charging station (#1393)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10485,8 +10485,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
         OEO_00000350,
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000028>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000095>
-
-
+    
+    
 Class: OEO_00320058
 
     Annotations: 
@@ -10529,6 +10529,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
     SubClassOf: 
         OEO_00320039,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000220
+    
+    
+Class: OEO_00320065
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bidirectional vehicle charging station is a vehicle charging station that can also feed electrical energy from the traction battery back into the electricity grid.",
+        rdfs:label "bidirectional vehicle charging station"
+    
+    SubClassOf: 
+        OEO_00320040
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10535,6 +10535,8 @@ Class: OEO_00320065
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidirectional vehicle charging station is a vehicle charging station that can also feed electrical energy from the traction battery back into the electricity grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1369
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1393",
         rdfs:label "bidirectional vehicle charging station"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

New term  `bidirectional vehicle charging station`.

## Type of change (CHANGELOG.md)

### Added
- `bidirectional vehicle charging station`: _A bidirectional vehicle charging station is a vehicle charging station that can also feed electrical energy from the traction battery back into the electricity grid._


## Workflow checklist

### Automation
Closes #1369

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
