### PR TITLE
Add charging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - thermo-chemical heat storage object, chemical heat storage object, sorption heat storage object, adsorption, desorption (#1363)
 - sensible heat storage object, sensible solid heat storage object, sensible fluid heat storage object (#1363)
 - phase transition, evaporation, melting, latent heat storage object, latent fluid-gaseous heat storage object, latent solid-fluid heat storage object (#1363)
+- charging (#1394)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10485,8 +10485,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
         OEO_00000350,
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000028>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000095>
-
-
+    
+    
 Class: OEO_00320058
 
     Annotations: 
@@ -10529,6 +10529,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
     SubClassOf: 
         OEO_00320039,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000220
+    
+    
+Class: OEO_00320064
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Charging is an electrical energy transfer where the transferred energy is stored in a battery.",
+        rdfs:label "charging"
+    
+    SubClassOf: 
+        OEO_00320036,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000068
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10535,6 +10535,8 @@ Class: OEO_00320064
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charging is an electrical energy transfer where the transferred energy is stored in a battery.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1368
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394",
         rdfs:label "charging"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Add `charging`.
Instead of adding `charging rate`, `power` can be used, which already has the axiom `'process attribute of' some 'energy transformation'`.

## Type of change (CHANGELOG.md)

### Added
- Added `charging`: _Charging is an electrical energy transfer where the transferred energy is stored in a battery._

## Workflow checklist

### Automation
Closes #1368 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
