### PR TITLE
Add `has participant` axioms #1327

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - phase transition, evaporation, melting, latent heat storage object, latent fluid-gaseous heat storage object, latent solid-fluid heat storage object (#1363)
 - bidirectional vehicle charging station (#1393)
 - charging (#1394)
+- non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -915,6 +915,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000304
     
     
+Class: OEO_00000323
+
+    
 Class: OEO_00000327
 
     Annotations: 
@@ -1898,7 +1901,8 @@ https://github.com/OpenEnergyPlatform/ontology/pull/808",
         rdfs:label "cooperative programming"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> min 2 OEO_00000323
     
     
 Class: OEO_00140167

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1896,8 +1896,12 @@ Class: OEO_00140161
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/254
-https://github.com/OpenEnergyPlatform/ontology/pull/808",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/808
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "cooperative programming"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1935,38 +1935,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
     
 Class: OEO_00000139
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
-
-alternative term electricity:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
-
-add commodity role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
-
-add axiom to electricity im/exports:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
     
 Class: OEO_00000143
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5564,7 +5564,11 @@ Class: OEO_00010211
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "non-energy use"@en
     
     SubClassOf: 
@@ -8784,7 +8788,11 @@ Class: OEO_00160001
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "frequency control"@en
     
     SubClassOf: 
@@ -9333,7 +9341,11 @@ Class: OEO_00260003
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "cold start"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5568,7 +5568,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950",
         rdfs:label "non-energy use"@en
     
     SubClassOf: 
-        OEO_00140039
+        OEO_00140039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
     
     DisjointWith: 
         OEO_00010210
@@ -8787,7 +8788,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
         rdfs:label "frequency control"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000061
+             and (OEO_00010235 some OEO_00000139))
     
     
 Class: OEO_00160002
@@ -9334,7 +9338,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-         and (OEO_00000500 some OEO_00260002)
+         and (OEO_00000500 some OEO_00260002),
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
     
     
 Class: OEO_00290000
@@ -10542,8 +10547,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394",
     SubClassOf: 
         OEO_00320036,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000068
-
-
+    
+    
 Class: OEO_00320065
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1537,6 +1537,42 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
     
 Class: OEO_00000139
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
+
+alternative term electricity:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
+
+add commodity role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+add axiom to electricity im/exports:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+move class to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
+        rdfs:label "electrical energy",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
+    
+    SubClassOf: 
+        OEO_00000150,
+        OEO_00020182 some OEO_00020207,
+        OEO_00020182 some OEO_00020208,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
     
 Class: OEO_00000147
 
@@ -3570,6 +3606,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
     
 Class: OEO_00140124
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
+
+add 'has participant axiom' and move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
+        rdfs:label "service"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
+    
     
 Class: OEO_00140159
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1535,6 +1535,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00000139
+
+    
 Class: OEO_00000147
 
     Annotations: 
@@ -2849,7 +2852,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
         rdfs:label "import"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
     
     
 Class: OEO_00020202
@@ -2863,7 +2867,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
         rdfs:label "export"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
     
     
 Class: OEO_00020204
@@ -2919,7 +2924,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
     
     SubClassOf: 
         OEO_00020201,
-        OEO_00140002 some OEO_00020205
+        OEO_00140002 some OEO_00020205,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
     
     
 Class: OEO_00020208
@@ -2934,7 +2940,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
     
     SubClassOf: 
         OEO_00020202,
-        OEO_00140002 some OEO_00020206
+        OEO_00140002 some OEO_00020206,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
     
     
 Class: OEO_00030002
@@ -3429,7 +3436,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
         rdfs:label "chemical reaction"@en
     
     SubClassOf: 
-        OEO_00000419
+        OEO_00000419,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00140039
@@ -3539,6 +3547,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         OEO_00020180 some OEO_00020181,
         OEO_00140002 some OEO_00010079
     
+    
+Class: OEO_00140124
+
     
 Class: OEO_00140159
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2848,7 +2848,11 @@ Class: OEO_00020201
         <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "import"
     
     SubClassOf: 
@@ -2863,7 +2867,11 @@ Class: OEO_00020202
         <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "export"
     
     SubClassOf: 
@@ -2919,7 +2927,11 @@ Class: OEO_00020207
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "electricity import"
     
     SubClassOf: 
@@ -2935,7 +2947,11 @@ Class: OEO_00020208
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "electricity export"
     
     SubClassOf: 
@@ -3432,7 +3448,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
 
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "chemical reaction"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -786,7 +786,11 @@ Class: OEO_00010136
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "distribution"@en
     
     SubClassOf: 
@@ -1533,8 +1537,12 @@ Class: OEO_00040006
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/642
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "request"@en
     
     SubClassOf: 
@@ -1767,7 +1775,11 @@ Class: OEO_00140124
         <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         rdfs:label "service"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -98,6 +98,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
+
+    
 ObjectProperty: OEO_00000503
 
     
@@ -787,7 +790,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876",
         rdfs:label "distribution"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
     
     
 Class: OEO_00010212
@@ -1534,7 +1538,8 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
         rdfs:label "request"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> min 2 OEO_00000051
     
     
 Class: OEO_00040007
@@ -1759,14 +1764,15 @@ Class: OEO_00140124
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible actitvity performed by some agent for the benefit of another agent.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
         rdfs:label "service"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
     
     
 Class: OEO_00140125

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1770,22 +1770,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
     
 Class: OEO_00140124
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "service"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
-    
     
 Class: OEO_00140125
 


### PR DESCRIPTION
## Summary of the discussion

Add `has participant` axioms that follow from the definitions of the classes.

## Type of change (CHANGELOG.md)

### Added axioms
* `'non-energy use' 'has participant' some 'energy carrier'`
* `'cold start' 'has participant' some 'energy transformation unit'`
* `'cooperative programming' 'has participant' min 2 person`
* `distribution ('has participant' some good) or ('causally related to' some service)`
* `export ('has participant' some good) or ('causally related to' some service)`
* `import ('has participant' some good) or ('causally related to' some service)`
* `'electricity export' 'has participant' some 'electrical energy'`
* `'electricity import' 'has participant' some 'electrical energy'`
* `'frequency control' 'has participant' some ('artificial object' and 'has energy output' some 'electrical energy')`
* `request 'has participant' min 2 agent`
* `service 'has participant' some agent`
* `'chemical reaction' 'has participant' some 'material entity'`

## Workflow checklist

### Automation
Closes #1327

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
