### PR TITLE
Improve definition of `superconducting magnetic energy storage` #1349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)
 - model descriptor (#1387)
 - passenger-kilometre, ton-kilometre (#1388)
+- SMES -> superconducting magnetic energy storage (#1396)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3367,7 +3367,7 @@ Class: OEO_00000374
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Shorten definition and new label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1349

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3369,6 +3369,9 @@ Class: OEO_00000374
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Shorten definition and new label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1349
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1396",
         rdfs:label "superconducting magnetic energy storage"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3367,10 +3367,9 @@ Class: OEO_00000374
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Superconducting magnetic energy storage (SMES) systems store energy in the magnetic field created by the flow of direct current in a superconducting coil which has been cryogenically cooled to a temperature below its superconducting critical temperature.
-          A typical smes system includes three parts: superconducting coil, power conditioning system and cryogenically cooled refrigerator. Once the superconducting coil is charged, the current will not decay and the magnetic energy can be stored indefinitely."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Superconducting_magnetic_energy_storage&oldid=902190687",
-        rdfs:label "SMES"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
+        rdfs:label "superconducting magnetic energy storage"
     
     SubClassOf: 
         OEO_00000159
@@ -10542,8 +10541,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394",
     SubClassOf: 
         OEO_00320036,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000068
-
-
+    
+    
 Class: OEO_00320065
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Shorten definition of `superconducting magnetic energy storage` and use `SMES` as alternative label
## Type of change (CHANGELOG.md)

### Updated
- `SMES` -> `superconducting magnetic energy storage`

## Workflow checklist

### Automation
Closes #1349

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
