### PR TITLE
Add `sustainable biofuel` and `non-sustainable biofuel` #872

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - charging (#1394)
 - non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
-- sustainable biofuel, non-sustainable biofuel (#1409)
+- sustainable biofuel, non-sustainable biofuel; competency questions Q1 and Q2 (#1409)
 - source category (#1428)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - bidirectional vehicle charging station (#1393)
 - charging (#1394)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
+- sustainable biofuel, non-sustainable biofuel (#1409)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - charging (#1394)
 - non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
-- sustainable biofuel, non-sustainable biofuel; competency questions Q1 and Q2 (#1409)
+- sustainable biofuel, non-sustainable biofuel (#1409)
 - source category (#1428)
 
 ### Changed
@@ -29,7 +29,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - model descriptor (#1387)
 - passenger-kilometre, ton-kilometre (#1388)
 - SMES -> superconducting magnetic energy storage (#1396)
-- biofuel (#1409)
+- biofuel; competency questions Q1 and Q2 (#1409)
 - has economic value, economic value of (#1422)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - model descriptor (#1387)
 - passenger-kilometre, ton-kilometre (#1388)
 - SMES -> superconducting magnetic energy storage (#1396)
+- biofuel (#1409)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6562,6 +6562,40 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00010336
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable biofuel is a biofuel that does conform to sustainability criteria.",
+        rdfs:label "sustainable biofuel"@en
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010333)
+    
+    SubClassOf: 
+        OEO_00000072
+    
+    DisjointWith: 
+        OEO_00010337
+    
+    
+Class: OEO_00010337
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-sustainable biofuel is a biofuel that does not conform to sustainability criteria.",
+        rdfs:label "non-sustainable biofuel"@en
+    
+    EquivalentTo: 
+        OEO_00000072
+         and (not (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010333))
+    
+    SubClassOf: 
+        OEO_00000072
+    
+    DisjointWith: 
+        OEO_00010336
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6566,6 +6566,8 @@ Class: OEO_00010336
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable biofuel is a biofuel that does conform to sustainability criteria.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         rdfs:label "sustainable biofuel"@en
     
     EquivalentTo: 
@@ -6583,6 +6585,8 @@ Class: OEO_00010337
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-sustainable biofuel is a biofuel that does not conform to sustainability criteria.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         rdfs:label "non-sustainable biofuel"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1628,7 +1628,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
 
 alternative term and disjoint:
 https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+delete 'renewable energy carrier disposition':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         rdfs:label "biofuel"
     
     EquivalentTo: 
@@ -1638,8 +1642,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
     SubClassOf: 
         OEO_00000099,
         OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     DisjointWith: 
         OEO_00000014
@@ -6575,7 +6578,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
          and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010333)
     
     SubClassOf: 
-        OEO_00000072
+        OEO_00000072,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020086
     
     DisjointWith: 
         OEO_00010337
@@ -6594,7 +6598,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
          and (not (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00010333))
     
     SubClassOf: 
-        OEO_00000072
+        OEO_00000072,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00020148
     
     DisjointWith: 
         OEO_00010336

--- a/tests/competency_questions/q29.omn
+++ b/tests/competency_questions/q29.omn
@@ -11,3 +11,5 @@ Class: OEO_00000033
 
 Class: OEO_00000072
     SubClassOf: OEO_00000033
+
+# This competency question gets deprecated with this pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409

--- a/tests/competency_questions/run_questions.sh
+++ b/tests/competency_questions/run_questions.sh
@@ -4,9 +4,9 @@ COMMAND=$1
 MERGED=$2
 EXPECTED_RESULT=$3
 
-INFER="q2.omn q3.omn q4.omn q5.omn q6.omn q7.omn q8.omn q9.omn q10.omn q11.omn q12.omn q13.omn q14.omn q15.omn q16.omn q17.omn q18.omn q19.omn q20.omn q21.omn q22.omn q23.omn q24.omn q25.omn q26.omn q27.omn q28.omn q29.omn q30.omn q31.omn q32.omn q33.omn q34.omn q35.omn q36.omn q37.omn q38.omn q39.omn q40.omn q41.omn q51.omn "
+INFER="q2.omn q3.omn q4.omn q5.omn q6.omn q7.omn q8.omn q9.omn q10.omn q11.omn q12.omn q13.omn q14.omn q15.omn q16.omn q17.omn q18.omn q19.omn q20.omn q21.omn q22.omn q23.omn q24.omn q25.omn q26.omn q27.omn q28.omn q30.omn q31.omn q32.omn q33.omn q34.omn q35.omn q36.omn q37.omn q38.omn q39.omn q40.omn q41.omn q51.omn "
 NON_INFERABLE_BUT_SHOULD="q42.omn q43.omn q44.omn q46.omn q47.omn q48.omn q49.omn q50.omn"
-DONT_INFER="q1.omn q45.omn"
+DONT_INFER="q1.omn q29.omn q45.omn"
 
 if [ "$EXPECTED_RESULT" = "true" ]
 then


### PR DESCRIPTION
## Summary of the discussion

Last part of the long issue on biofuels #872: Add the classes `sustainable biofuel` and `non-sustainable biofuel`.

With the implementation the competency questions 1 and 29 gets deprecated. The questions are:
* Q1: Is  biofuel renewable fuel?
* Q29: Is a biofuel classified as renewable fuel?

We now distinguish between `sustainable biofuel` and `non-sustainable biofuel` and only a `sustainable biofuel` is a `renewable fuel`. We decided in OEO that we do not want to change the original competency questions. As workaround for a proper solution for the competency questions, Q1 and Q29 are marked by a comment as deprecated. Further, Q1 and Q29 get excluded from the script.

## Type of change (CHANGELOG.md)

## Type of change (CHANGELOG.md)

### Added axioms
* _A sustainable biofuel is a biofuel that does conform to sustainability criteria._
`'sustainable biofuel' EquivalentTo: biofuel and ('has disposition' some 'material sustainability')`
`'sustainable biofuel' SubClassOf: 'has disposition' some 'renewable energy carrier disposition'`
* _A non-sustainable biofuel is a biofuel that does not conform to sustainability criteria._
`'non-sustainable biofuel' EquivalentTo: biofuel and not ('has disposition' some 'material sustainability')`
`'non-sustainable biofuel' SubClassOf: 'has disposition' some 'conventional energy carrier disposition'`

### Deleted axiom
* `biofuel SubClassOf: 'has disposition' some 'renewable energy carrier disposition'`

### Changes in competency questions
* Comment in competency questions `q1.omn` and `q29.omn` to mark these as deprecated.
* Move `q1.omn` and `q29.omn` from `INFER` to `DONT_INFER` in the script `run_questions.sh`.

## Workflow checklist

### Automation
Closes #872

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
