### PR TITLE
Align economic properties with class hierarchy #1411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - model descriptor (#1387)
 - passenger-kilometre, ton-kilometre (#1388)
 - SMES -> superconducting magnetic energy storage (#1396)
+- has economic value, economic value of (#1422)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -871,7 +871,11 @@ ObjectProperty: OEO_00020179
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+Make subproperty of 'quantity value of' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
         rdfs:label "economic value of"
     
     SubPropertyOf: 
@@ -886,7 +890,11 @@ ObjectProperty: OEO_00020180
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+Make subproperty of 'has quatity value' and add range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
         rdfs:label "has economic value"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -875,7 +875,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         rdfs:label "economic value of"
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
+        OEO_00020056
+    
+    Domain: 
+        OEO_00140012
     
     
 ObjectProperty: OEO_00020180
@@ -887,7 +890,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         rdfs:label "has economic value"
     
     SubPropertyOf: 
-        OEO_00010231
+        OEO_00140002
+    
+    Range: 
+        OEO_00140012
     
     
 ObjectProperty: OEO_00020182

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -213,9 +213,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
 ObjectProperty: OEO_00020182
 
     
-
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     


### PR DESCRIPTION
## Summary of the discussion

The class `economic value` is a subclass of `quantity value`. The object properties should match that hierarchy.

## Type of change (CHANGELOG.md)

### Updated
* Make `has economic value` a subproperty of `has quantity value`.
* Make `economic value of` a subproperty of `quantity value of`.
* Add range/domain `economic value`.

## Workflow checklist

### Automation
Closes #1411

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
