### PR TITLE
Exclude competence question Q1 #872

### DIFF
--- a/tests/competency_questions/q1.omn
+++ b/tests/competency_questions/q1.omn
@@ -10,3 +10,4 @@ Class: OEO_00000072
 Class: OEO_00000072
   SubClassOf: OEO_00000033
     
+# This competency question gets deprecated with this pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409

--- a/tests/competency_questions/run_questions.sh
+++ b/tests/competency_questions/run_questions.sh
@@ -4,9 +4,9 @@ COMMAND=$1
 MERGED=$2
 EXPECTED_RESULT=$3
 
-INFER="q1.omn q2.omn q3.omn q4.omn q5.omn q6.omn q7.omn q8.omn q9.omn q10.omn q11.omn q12.omn q13.omn q14.omn q15.omn q16.omn q17.omn q18.omn q19.omn q20.omn q21.omn q22.omn q23.omn q24.omn q25.omn q26.omn q27.omn q28.omn q29.omn q30.omn q31.omn q32.omn q33.omn q34.omn q35.omn q36.omn q37.omn q38.omn q39.omn q40.omn q41.omn q51.omn "
+INFER="q2.omn q3.omn q4.omn q5.omn q6.omn q7.omn q8.omn q9.omn q10.omn q11.omn q12.omn q13.omn q14.omn q15.omn q16.omn q17.omn q18.omn q19.omn q20.omn q21.omn q22.omn q23.omn q24.omn q25.omn q26.omn q27.omn q28.omn q29.omn q30.omn q31.omn q32.omn q33.omn q34.omn q35.omn q36.omn q37.omn q38.omn q39.omn q40.omn q41.omn q51.omn "
 NON_INFERABLE_BUT_SHOULD="q42.omn q43.omn q44.omn q46.omn q47.omn q48.omn q49.omn q50.omn"
-DONT_INFER="q45.omn"
+DONT_INFER="q1.omn q45.omn"
 
 if [ "$EXPECTED_RESULT" = "true" ]
 then


### PR DESCRIPTION
## Summary of the discussion

With the implementation of issue #872 in pull request #1409 the competency question 1 gets deprecated. The question reads:
> Is  biofuel renewable fuel?

We now distinguish between `sustainable biofuel` and `non-sustainable biofuel` and only a `sustainable biofuel` is a `renewable fuel`. We decided in OEO that we do not want to change the original competency question. As workaround for a proper solution for the competency questions, Q1 is marked by a comment as deprecated. Further, Q1 gets excluded from the script.
## Type of change (CHANGELOG.md)

### Added
- Comment in q1.omn

### Updated
- Move Q1 from `INFER` to `DONT_INFER` in the script run_questions.sh

## Workflow checklist

### Automation
This PR is part of #872 and is a prerequisite for #1409 which then finally closes the issue.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
