### PR TITLE
Add class `source category` #1426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - charging (#1394)
 - non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
+- source category (#1428)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -902,6 +902,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1383",
         OEO_00010328
     
     
+Class: OEO_00010360
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A source category is a sector that is defined by a common reporting format.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CRF sector",
+        rdfs:label "source category"@en
+    
+    EquivalentTo: 
+        OEO_00000367
+         and (OEO_00000504 some OEO_00010055)
+    
+    SubClassOf: 
+        OEO_00000367
+    
+    
 Class: OEO_00020015
 
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -907,6 +907,8 @@ Class: OEO_00010360
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A source category is a sector that is defined by a common reporting format.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF sector",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1426
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1428",
         rdfs:label "source category"@en
     
     EquivalentTo: 


### PR DESCRIPTION
## Summary of the discussion

Add equivalent class which collects all sectors that are defined by a common reporting format sector division.

## Type of change (CHANGELOG.md)

### Added
Label: `source category`
Definition: _A source category is a sector that is defined by a common reporting format._
Alternative label: `CRF sector`
Axiom: `'source category' EquivalentTo: sector and ('is defined by' some 'common reporting format')`

## Workflow checklist

### Automation
Closes #1426

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
