### PR TITLE
add scenario bundle #1343

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
 - source category (#1428)
+- scenario bundle (#1420)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - non-energy use, cold start, cooperative programming, distribution, (electricity) export/import, frequency control, request, service, chemical reaction (#1395)
 - ton of oil equivalent, ton of coal equivalent, kilo ton of oil equivalent, kilo ton of coal equivalent, million ton of oil equivalent, million ton of coal equivalent (#1398)
 - source category (#1428)
-- scenario bundle (#1420)
+- scenario bundle (#1429)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1686,6 +1686,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
     
     
+Class: OEO_00020227
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario bundle is an information content entity that connects information about a scenario study and the associated scenario projections on the OEP via the OEKG.",
+        rdfs:label "scenario bundle"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1692,7 +1692,7 @@ Class: OEO_00020227
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario bundle is an information content entity that connects information about a scenario study and the associated scenario projections on the OEP via the OEKG.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1343
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1429",
-        rdfs:label "scenario bundle"@de
+        rdfs:label "scenario bundle"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1690,10 +1690,13 @@ Class: OEO_00020227
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario bundle is an information content entity that connects information about a scenario study and the associated scenario projections on the OEP via the OEKG.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1343
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1429",
         rdfs:label "scenario bundle"@de
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010252>
     
     
 Class: OEO_00030007


### PR DESCRIPTION
## Summary of the discussion
add `scenario bundle`: _A scenario bundle is an information content entity that connects information about a scenario study and the associated scenario projections on the OEP via the OEKG._

## Type of change (CHANGELOG.md)

### Added
- scenario bundle

## Workflow checklist

### Automation
closes #1343

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
