### PR TITLE
Add undisputed heat terms #1254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - biofuel; competency questions Q1 and Q2 (#1409)
 - global warming potential, binary file format, text file format, source code file format, generation time series, optimisation, simulation (#1410)
 - has economic value, economic value of (#1422)
+- solar thermal collector (#1432)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - sustainable biofuel, non-sustainable biofuel (#1409)
 - source category (#1428)
 - scenario bundle (#1429)
+- rotary heat exchanger, plate heat exchanger, boiler, tube collector, flat-plate collector (#1432)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9310,9 +9310,8 @@ Class: OEO_00310009
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rotary heat exchanger is a heat exchanger that uses a wheel for a heat transfer process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "jajksdhjksdhfjkashdfk",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "rotary heat exchanger"
     
     SubClassOf: 
@@ -9325,7 +9324,7 @@ Class: OEO_00310010
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plate heat exchanger is a heat exchanger that uses a plate for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "plate heat exchanger"
     
     SubClassOf: 
@@ -9338,7 +9337,7 @@ Class: OEO_00310013
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "boiler"
     
     SubClassOf: 
@@ -9352,7 +9351,7 @@ Class: OEO_00310021
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tube collector is a solar thermal collector that consists of tubes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "tube collector"
     
     SubClassOf: 
@@ -9364,7 +9363,7 @@ Class: OEO_00310022
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         OEO_00040001 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flat-plate collector is a solar thermal collector that consists of flat-plates.",
         rdfs:label "flat-plate collector"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3310,14 +3310,18 @@ Class: OEO_00000387
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that absorbs solar radiation to convert it into heat."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that converts solar energy to solar thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 add axiom to 'has part some solar radiation receiving surface'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
+
+improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "solar thermal collector"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9305,6 +9305,73 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         OEO_00140104
     
     
+Class: OEO_00310009
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A rotary heat exchanger is a heat exchanger that uses a wheel for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "jajksdhjksdhfjkashdfk",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+        rdfs:label "rotary heat exchanger"
+    
+    SubClassOf: 
+        OEO_00140102
+    
+    
+Class: OEO_00310010
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plate heat exchanger is a heat exchanger that uses a plate for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+        rdfs:label "plate heat exchanger"
+    
+    SubClassOf: 
+        OEO_00140102
+    
+    
+Class: OEO_00310013
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+        rdfs:label "boiler"
+    
+    SubClassOf: 
+        OEO_00000210,
+        OEO_00000503 some OEO_00140116
+    
+    
+Class: OEO_00310021
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tube collector is a solar thermal collector that consists of tubes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+        rdfs:label "tube collector"
+    
+    SubClassOf: 
+        OEO_00000387
+    
+    
+Class: OEO_00310022
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flat-plate collector is a solar thermal collector that consists of flat-plates.",
+        rdfs:label "flat-plate collector"
+    
+    SubClassOf: 
+        OEO_00000387
+    
+    
 Class: OEO_00310032
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

This PR extracts the undisputed part of PR #1360.
The classes `geothermal heat unit` and `geothermal heat plant` cannot be transferred to this PR as they depend on `heat generating plant`.

## Type of change (CHANGELOG.md)

### Added
- rotary heat exchanger
- plate heat exchanger
- boiler
- tube collector
- flat-plate collector

### Changed
- solar thermal collector

## Workflow checklist

### Automation
Part of #1254, but does not solve the issue completely.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
