### PR TITLE
Add utilisation value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - source category (#1428)
 - scenario bundle (#1429)
 - rotary heat exchanger, plate heat exchanger, boiler, tube collector, flat-plate collector (#1432)
+- utilisation value (#1435)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)
@@ -35,6 +36,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - global warming potential, binary file format, text file format, source code file format, generation time series, optimisation, simulation (#1410)
 - has economic value, economic value of (#1422)
 - solar thermal collector (#1432)
+- net capacity factor (#1435)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10584,7 +10584,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320072
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A utilisation value is a fraction value that describes how much of a capacity of an artificial object, process, organisation or agent is used.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A utilisation value is a fraction value that describes the instantaneous share of a maximum value that is utilised.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
         rdfs:label "utilisation value"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8994,7 +8994,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
 
 make subclass of 'fraction value':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1144
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146
+
+make subclass of 'utilisation value':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
         rdfs:label "net capacity factor"
     
     SubClassOf: 
@@ -10581,6 +10585,8 @@ Class: OEO_00320072
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A utilisation value is a fraction value that describes how much of a capacity of an artificial object, process, organisation or agent is used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
         rdfs:label "utilisation value"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8986,7 +8986,7 @@ Class: OEO_00240016
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a fraction value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
@@ -8998,7 +8998,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146",
         rdfs:label "net capacity factor"
     
     SubClassOf: 
-        OEO_00140127
+        OEO_00320072
     
     
 Class: OEO_00240018
@@ -10575,6 +10575,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
+    
+    
+Class: OEO_00320072
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A utilisation value is a fraction value that describes how much of a capacity of an artificial object, process, organisation or agent is used.",
+        rdfs:label "utilisation value"
+    
+    SubClassOf: 
+        OEO_00140127
     
     
 Individual: OEO_00000182


### PR DESCRIPTION
## Summary of the discussion

Add `utilisation value`: _A utilisation value is a fraction value that describes how much of a capacity of an artificial object, process, organisation or agent is used._
Make `net capacity factor` a subclass of it.

## Type of change (CHANGELOG.md)

### Added
- Added a new class `utilisation value`

### Updated
- Updated definition for `net capacity factor`


## Workflow checklist

### Automation
Closes #1377

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
