### PR TITLE
amortisation time and economic life time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - source category (#1428)
 - scenario bundle (#1429)
 - rotary heat exchanger, plate heat exchanger, boiler, tube collector, flat-plate collector (#1432)
+- amortisation time, economic life time (#1436)
 
 ### Changed
 - internal combustion vehicle, plug-in hybrid electric vehicle, fuel cell electric vehicle, tank ship, gas turbine vehicle (#1356)

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4005,6 +4005,8 @@ Class: OEO_00320073
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
         rdfs:label "amortisation time"
     
     SubClassOf: 
@@ -4015,6 +4017,8 @@ Class: OEO_00320074
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an object is profitable to the owner.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
         rdfs:label "economic life time"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4001,6 +4001,16 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
         OEO_00320001
     
     
+Class: OEO_00320073
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
+        rdfs:label "amortisation time"
+    
+    SubClassOf: 
+        OEO_00030035
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4016,7 +4016,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
 Class: OEO_00320074
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an object is profitable to the owner.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
         rdfs:label "economic life time"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4011,6 +4011,16 @@ Class: OEO_00320073
         OEO_00030035
     
     
+Class: OEO_00320074
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an object is profitable to the owner.",
+        rdfs:label "economic life time"
+    
+    SubClassOf: 
+        OEO_00020178
+    
+    
 Individual: OEO_00000182
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

`amortisation time`: _An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment._
`economic life time`: _An economic life time is the operational life time during which an object is profitable to the owner._

## Type of change (CHANGELOG.md)

### Added
- Added a new class `amortisation time`
- Added a new class `economic life time`


## Workflow checklist

### Automation
Closes #1380

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
