### PR TITLE
Add RED sector individuals #1443

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - has spatial region (#1441)
 - (renewable) electrolytic hydrogen, (fossil/abated) steam reforming hydrogen, renewable electrical energy (#1442)
 - energy transformation function and subclasses (#1445)
+- RED sector individuals (#1446)
 
 ### Changed
 - bearer of -> has characteristic (#1268)
@@ -46,6 +47,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - net capacity factor (#1435)
 - has study region, has considered region, has interacting region, has study region (#1441)
 - synthetic hydrogen, fossil hydrogen (#1442)
+- renewable_ energy_ directive_ sectors -> Renewable Energy Directive sector division (#1446)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2260,6 +2260,9 @@ Individual: OEO_00000355
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Renewable Energy Directive sector division is a sector division used in the Renewable Energy Directive of the European Union.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Relabel and add definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1443
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1446",
         rdfs:label "Renewable Energy Directive sector division"
     
     Types: 
@@ -4451,6 +4454,8 @@ Individual: OEO_00010389
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector electricity is an electricity sector defined by the Renewable Energy Directive sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1443
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1446",
         rdfs:label "RED sector: electricity"@en
     
     Types: 
@@ -4464,6 +4469,8 @@ Individual: OEO_00010390
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1443
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1446",
         rdfs:label "RED sector: heating and cooling"@en
     
     Types: 
@@ -4477,6 +4484,8 @@ Individual: OEO_00010391
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1443
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1446",
         rdfs:label "RED sector: transport"@en
     
     Types: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2257,9 +2257,10 @@ Individual: OEO_00000355
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The Renewable Energy Directive sector division is a sector division used in the Renewable Energy Directive of the European Union.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
-        rdfs:label "renewable_ energy_ directive_ sectors"
+        rdfs:label "Renewable Energy Directive sector division"
     
     Types: 
         OEO_00000368
@@ -4444,6 +4445,45 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1317",
     
     SameAs: 
         OEO_00010050
+    
+    
+Individual: OEO_00010389
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector electricity is an electricity sector defined by the Renewable Energy Directive sector division.",
+        rdfs:label "RED sector: electricity"@en
+    
+    Types: 
+        OEO_00000145
+    
+    Facts:  
+     OEO_00000504  OEO_00000355
+    
+    
+Individual: OEO_00010390
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division.",
+        rdfs:label "RED sector: heating and cooling"@en
+    
+    Types: 
+        OEO_00000213
+    
+    Facts:  
+     OEO_00000504  OEO_00000355
+    
+    
+Individual: OEO_00010391
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division.",
+        rdfs:label "RED sector: transport"@en
+    
+    Types: 
+        OEO_00000422
+    
+    Facts:  
+     OEO_00000504  OEO_00000355
     
     
 DisjointClasses: 


### PR DESCRIPTION
## Summary of the discussion

Add RED sectors individuals and add definition to existing individual.

## Type of change (CHANGELOG.md)

### Added
* `RED sector: electricity`: _The RED sector electricity is an electricity sector defined by the Renewable Energy Directive sector division._
* `RED sector: heating and cooling`: _The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division._
* `RED sector: transport`: _The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division._

### Updated
Relabel `renewable_ energy_ directive_ sectors` to `Renewable Energy Directive sector division` and add definition: _The Renewable Energy Directive sector division is a sector division used in the Renewable Energy Directive of the European Union._

## Workflow checklist

### Automation
Closes #1443

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
