### PR TITLE
Make `radiation` a subclass of `energy transfer` #1031

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - has study region, has considered region, has interacting region, has study region (#1441)
 - synthetic hydrogen, fossil hydrogen (#1442)
 - renewable_ energy_ directive_ sectors -> Renewable Energy Directive sector division (#1446)
+- radiation (#1447)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6582,8 +6582,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
     
     SubClassOf: 
         OEO_00000139
-
-
+    
+    
 Class: OEO_00010385
 
     Annotations: 
@@ -6753,10 +6753,13 @@ Class: OEO_00020037
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is the process of emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is an energy transfer by emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1031
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447",
         rdfs:label "radiation",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -6764,7 +6767,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00020103,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00230021
     
     


### PR DESCRIPTION
## Summary of the discussion

Part of #1031: Make `radiation` a subclass of `energy transfer`

## Type of change (CHANGELOG.md)

### Updated
- `radiation`

## Workflow checklist

### Automation
No automation

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
