### PR TITLE
Add solar radiation components #1076

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - (renewable) electrolytic hydrogen, (fossil/abated) steam reforming hydrogen, renewable electrical energy (#1442)
 - energy transformation function and subclasses (#1445)
 - RED sector individuals (#1446)
+- direct/diffuse solar radiation, non-scattered radiant flux density, (single/two axis) solar tracking, (single/two axis) solar tracked receiving surface #1448
 
 ### Changed
 - bearer of -> has characteristic (#1268)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6582,8 +6582,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
     
     SubClassOf: 
         OEO_00000139
-
-
+    
+    
 Class: OEO_00010385
 
     Annotations: 
@@ -6633,6 +6633,114 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445",
     
     SubClassOf: 
         OEO_00010385
+    
+    
+Class: OEO_00010392
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct solar radiation is radiation that is the non-scattered part of solar radiation from the Sun within the extent of the solar disk only.",
+        rdfs:label "direct solar radiation"@en
+    
+    SubClassOf: 
+        OEO_00020038
+    
+    DisjointWith: 
+        OEO_00010393
+    
+    
+Class: OEO_00010393
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diffuse solar radiation is radiation that is the part of solar radiation that has been scattered by gas molecules in the atmosphere and by particles such as cloud droplets and aerosols.",
+        rdfs:label "diffuse solar radiation"@en
+    
+    SubClassOf: 
+        OEO_00020038
+    
+    DisjointWith: 
+        OEO_00010392
+    
+    
+Class: OEO_00010394
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-scattered radiant flux density is an areal solar power density that measures the direct solar radiation within the extent of the solar disk only (half-angle 0.266 deg).",
+        rdfs:label "non-scattered radiant flux density"@en
+    
+    SubClassOf: 
+        OEO_00010076
+    
+    
+Class: OEO_00010395
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar tracking is a process of in which a radiation receiving surface is following the path of the sun on the sky.",
+        rdfs:label "solar tracking"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00010396
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Single axis tracking is solar tracking in which a radiation receiving surface is following the path of the sun by roting along a fixed axis. Typical axis orientations are North-South or East-West.",
+        rdfs:label "single axis tracking"@en
+    
+    SubClassOf: 
+        OEO_00010395
+    
+    
+Class: OEO_00010397
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Two axis tracking is solar tracking in which a radiation receiving surface is following the sun by rotating around two axes. The plane is always oriented normal.",
+        rdfs:label "two axis tracking"@en
+    
+    SubClassOf: 
+        OEO_00010395
+    
+    
+Class: OEO_00010398
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar tracked receiving surface is a solar radiation receiving surface that participates in solar tracking.",
+        rdfs:label "solar tracked receiving surface"@en
+    
+    EquivalentTo: 
+        OEO_00020199
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010395)
+    
+    SubClassOf: 
+        OEO_00020199
+    
+    
+Class: OEO_00010399
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A single axis tracked receiving surface is a solar radiation receiving surface that participates in single axis tracking.",
+        rdfs:label "single axis tracked receiving surface"@en
+    
+    EquivalentTo: 
+        OEO_00020199
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010396)
+    
+    SubClassOf: 
+        OEO_00020199
+    
+    
+Class: OEO_00010400
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A two axis tracked receiving surface is a solar radiation receiving surface that participates in two axis tracking.",
+        rdfs:label "two axis tracked receiving surface"@en
+    
+    EquivalentTo: 
+        OEO_00020199
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010397)
+    
+    SubClassOf: 
+        OEO_00020199
     
     
 Class: OEO_00020001
@@ -6773,6 +6881,7 @@ Class: OEO_00020038
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the merological sum of direct solar radiation and diffuse solar radiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
         rdfs:label "solar radiation",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6901,7 +6901,11 @@ Class: OEO_00020038
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the merological sum of direct solar radiation and diffuse solar radiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
+
+Add editor note:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar radiation",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6639,6 +6639,8 @@ Class: OEO_00010392
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Direct solar radiation is radiation that is the non-scattered part of solar radiation from the Sun within the extent of the solar disk only.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "direct solar radiation"@en
     
     SubClassOf: 
@@ -6652,6 +6654,8 @@ Class: OEO_00010393
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Diffuse solar radiation is radiation that is the part of solar radiation that has been scattered by gas molecules in the atmosphere and by particles such as cloud droplets and aerosols.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "diffuse solar radiation"@en
     
     SubClassOf: 
@@ -6665,6 +6669,8 @@ Class: OEO_00010394
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-scattered radiant flux density is an areal solar power density that measures the direct solar radiation within the extent of the solar disk only (half-angle 0.266 deg).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "non-scattered radiant flux density"@en
     
     SubClassOf: 
@@ -6675,6 +6681,8 @@ Class: OEO_00010395
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar tracking is a process of in which a radiation receiving surface is following the path of the sun on the sky.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar tracking"@en
     
     SubClassOf: 
@@ -6685,6 +6693,8 @@ Class: OEO_00010396
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Single axis tracking is solar tracking in which a radiation receiving surface is following the path of the sun by roting along a fixed axis. Typical axis orientations are North-South or East-West.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "single axis tracking"@en
     
     SubClassOf: 
@@ -6695,6 +6705,8 @@ Class: OEO_00010397
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Two axis tracking is solar tracking in which a radiation receiving surface is following the sun by rotating around two axes. The plane is always oriented normal.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "two axis tracking"@en
     
     SubClassOf: 
@@ -6705,6 +6717,8 @@ Class: OEO_00010398
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar tracked receiving surface is a solar radiation receiving surface that participates in solar tracking.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar tracked receiving surface"@en
     
     EquivalentTo: 
@@ -6719,6 +6733,8 @@ Class: OEO_00010399
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A single axis tracked receiving surface is a solar radiation receiving surface that participates in single axis tracking.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "single axis tracked receiving surface"@en
     
     EquivalentTo: 
@@ -6733,6 +6749,8 @@ Class: OEO_00010400
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A two axis tracked receiving surface is a solar radiation receiving surface that participates in two axis tracking.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "two axis tracked receiving surface"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6673,6 +6673,9 @@ Class: OEO_00010394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "non-scattered radiant flux density"@en
     
+    EquivalentTo: 
+        OEO_00020056 some OEO_00010392
+    
     SubClassOf: 
         OEO_00010076
     
@@ -6900,10 +6903,11 @@ Class: OEO_00020038
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the merological sum of direct solar radiation and diffuse solar radiation",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "global radiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
 
-Add editor note:
+Add alternative label and editor note:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar radiation",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6638,7 +6638,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445",
 Class: OEO_00010392
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct solar radiation is radiation that is the non-scattered part of solar radiation from the Sun within the extent of the solar disk only.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Direct solar radiation is radiation that is the non-scattered part of solar radiation from the sun within the extent of the solar disk only.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "direct solar radiation"@en
@@ -6683,7 +6683,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010395
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar tracking is a process of in which a radiation receiving surface is following the path of the sun on the sky.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar tracking is a process in which a radiation receiving surface is following the path of the sun on the sky.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar tracking"@en
@@ -6707,7 +6707,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010397
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Two axis tracking is solar tracking in which a radiation receiving surface is following the sun by rotating around two axes. The plane is always oriented normal.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Two axis tracking is solar tracking in which a radiation receiving surface is following the sun by rotating around two axes. The surface is always oriented normal.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "two axis tracking"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6902,7 +6902,7 @@ Class: OEO_00020038
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the merological sum of direct solar radiation and diffuse solar radiation",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the mereological sum of direct solar radiation and diffuse solar radiation",
         <http://purl.obolibrary.org/obo/IAO_0000118> "global radiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600


### PR DESCRIPTION
# Summary of the discussion

Add subclasses of solar radiation and add concepts related to solar tracking.

## Type of change (CHANGELOG.md)

### Added
* `direct solar radiation`
* `diffuse solar radiation`
* `non-scattered radiant flux density`
* `solar tracking`
* `single axis tracking`
* `two axis tracking`
* `solar tracked receiving surface`
* `single axis tracked receiving surface`
* `two axis tracked receiving surface`

### Updated
Add editor note to `solar radiation`

## Workflow checklist

### Automation
No automation, implements only parts of #1076.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
