### PR TITLE
Add `power-only generating unit` #1439

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - (renewable) electrolytic hydrogen, (fossil/abated) steam reforming hydrogen, renewable electrical energy (#1442)
 - energy transformation function and subclasses (#1445)
 - RED sector individuals (#1446)
+- power-only generating unit (#1456)
 
 ### Changed
 - bearer of -> has characteristic (#1268)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6473,6 +6473,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         OEO_00010336
     
     
+Class: OEO_00010362
+
+    
 Class: OEO_00010379
 
     Annotations: 
@@ -6594,12 +6597,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
 Class: OEO_00010385
 
     
-Class: OEO_00010362
-
-    
-Class: OEO_00010385
-
-    
 Class: OEO_00010386
 
     
@@ -6618,6 +6615,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445",
     
 Class: OEO_00010388
 
+    
+Class: OEO_00010401
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-only generating unit is a power generating unit that has only the function to produce electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456",
+        rdfs:label "power-only generating unit"@en
+    
+    EquivalentTo: 
+        OEO_00000334
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
+         and (<http://purl.obolibrary.org/obo/RO_0000085> only 
+            (OEO_00010386 or (not (OEO_00010385))))
+    
+    SubClassOf: 
+        OEO_00000334
+    
     
 Class: OEO_00020001
 
@@ -10973,19 +10988,3 @@ DisjointClasses:
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
 
-Class: OEO_00010401
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-only generating unit is a power generating unit that has only the function to produce electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1453",
-        rdfs:label "power-only generating unit"@en
-
-    EquivalentTo: 
-        OEO_00000334
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
-         and (<http://purl.obolibrary.org/obo/RO_0000085> only 
-            (OEO_00010386 or (not (OEO_00010385))))
-
-    SubClassOf: 
-        OEO_00000334

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10973,3 +10973,19 @@ DisjointClasses:
 DisjointClasses: 
     OEO_00000188,OEO_00000210,OEO_00000425
 
+Class: OEO_00010401
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-only generating unit is a power generating unit that has only the function to produce electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1453",
+        rdfs:label "power-only generating unit"@en
+
+    EquivalentTo: 
+        OEO_00000334
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
+         and (<http://purl.obolibrary.org/obo/RO_0000085> only 
+            (OEO_00010386 or (not (OEO_00010385))))
+
+    SubClassOf: 
+        OEO_00000334


### PR DESCRIPTION
## Summary of the discussion

Add a class for such power generating units that produce only power and nothing else.

## Type of change (CHANGELOG.md)

### Added
* `power-only generating unit`: _A power-only generating unit is a power generating unit that has only the function to produce electrical energy._

## Workflow checklist

### Automation
Closes #1439

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
