### PR TITLE
Add energy balance related classes

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1319,8 +1319,43 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020013
     
     
+Class: OEO_00010296
+
+    
 Class: OEO_00010362
 
+    
+Class: OEO_00010404
+
+    Annotations: 
+        rdfs:label "energy balance"
+    
+    SubClassOf: 
+        OEO_00000149
+    
+    
+Class: OEO_00010405
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance collection is a dataset of energy balances for various time steps and/or temporal region.",
+        rdfs:label "energy balance collection"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010404
+    
+    
+Class: OEO_00010406
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance calculation method is a methodology to calculate an energy balance.",
+        rdfs:label "energy balance calculation method"@en
+    
+    SubClassOf: 
+        OEO_00020166,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
+    
     
 Class: OEO_00020011
 
@@ -1731,6 +1766,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         OEO_00030034,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
     
+    
+Class: OEO_00020166
+
     
 Class: OEO_00020227
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -107,6 +107,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
 ObjectProperty: OEO_00000503
 
     
+ObjectProperty: OEO_00000504
+
+    
 ObjectProperty: OEO_00000511
 
     Annotations: 
@@ -1053,6 +1056,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000367
 
     
+Class: OEO_00000368
+
+    
 Class: OEO_00000370
 
     Annotations: 
@@ -1355,6 +1361,16 @@ Class: OEO_00010406
         OEO_00020166,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
+    
+    
+Class: OEO_00010407
+
+    Annotations: 
+        rdfs:label "energy balance sector division"@en
+    
+    SubClassOf: 
+        OEO_00000368,
+        OEO_00000504 some OEO_00010406
     
     
 Class: OEO_00020011

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6097,16 +6097,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
     
 Class: OEO_00010296
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
-        rdfs:label "primary energy consumption calculation method"@en
-    
-    SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
-    
     
 Class: OEO_00010297
 
@@ -6761,8 +6751,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456",
     
     SubClassOf: 
         OEO_00000334
-
-
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -397,6 +397,26 @@ https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)",
         OEO_00000501
     
     
+ObjectProperty: OEO_00000504
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
+
+domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+
+adapt domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "is defined by"
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    
 ObjectProperty: OEO_00000505
 
     Annotations: 
@@ -2240,6 +2260,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
 moved to oeo-shared
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
         rdfs:label "sector"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
+    
+Class: OEO_00000368
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
+        rdfs:label "sector division"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2535,6 +2535,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
         OEO_00020154
     
     
+Class: OEO_00010296
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+        rdfs:label "primary energy consumption calculation method"@en
+    
+    SubClassOf: 
+        OEO_00020166,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
+    
+    
 Class: OEO_00010315
 
     Annotations: 
@@ -3731,6 +3744,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     SubClassOf: 
         OEO_00010117
     
+    
+Class: OEO_00050018
+
     
 Class: OEO_00050019
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -106,23 +106,6 @@ ObjectProperty: OEO_00000503
     
 ObjectProperty: OEO_00000504
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
-
-domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-
-adapt domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "is defined by"
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00000505
 
@@ -579,15 +562,6 @@ Class: OEO_00000367
     
 Class: OEO_00000368
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
     
 Class: OEO_00000379
 
@@ -918,6 +892,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1428",
     SubClassOf: 
         OEO_00000367
     
+    
+Class: OEO_00010407
+
     
 Class: OEO_00020015
 
@@ -2166,10 +2143,10 @@ Individual: OEO_00000160
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This is a general description of an energy balance. A link to a complete Eurostat energy balance is provided under the URL for 'definition source'",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php/Energy_balance#What_is_an_energy_balance.3F",
-        rdfs:label "eurostat energy balances"
+        rdfs:label "Eurostat energy balance sector division"
     
     Types: 
-        OEO_00000368
+        OEO_00010407
     
     
 Individual: OEO_00000193
@@ -2204,10 +2181,10 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
     Bestandsveränderungen, getrennt erfasst nach Bestandsentnahmen und -aufstockungen",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115",
-        rdfs:label "german energy balances"
+        rdfs:label "German energy balance sector division"
     
     Types: 
-        OEO_00000368
+        OEO_00010407
     
     
 Individual: OEO_00000242
@@ -5167,8 +5144,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1440",
     Facts:  
      OEO_00000504  OEO_00000242,
      <http://purl.obolibrary.org/obo/BFO_0000050>  OEO_00010172
-
-
+    
+    
 Individual: OEO_00010389
 
     Annotations: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -195,3 +195,4 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000038>
 Class: <http://purl.obolibrary.org/obo/BFO_0000141>
 
     
+


### PR DESCRIPTION
## Summary of the discussion

Distinguish clearer between an energy balances and the sector divisions of energy balances.

## Type of change (CHANGELOG.md)

### Added
* `energy balance`: _An energy balance is an empirical data set that describes a specified set of energy transformations and a specified st of energy carriers in a spatial region for a specific time step (usually a year)._
* `energy balance collection`: _An energy balance collection is a dataset of energy balances for various time steps and/or temporal region._
* `energy balance calculation method`: _An energy balance calculation method is a methodology to calculate an energy balance._
* `energy balance sector division`: _An energy balance sector division is a sector division that is defined by an energy balance calculation method._

### Updated
* Relabel `german energy balances` to `German energy balance sector division`
* Relabel `eurostat energy balances` to `Eurostat energy balance sector division`

## Workflow checklist

### Automation
Closes #1400

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
