### PR TITLE
Replaced owl:equivalentClass with may be identical to in Annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - renewable_ energy_ directive_ sectors -> Renewable Energy Directive sector division (#1446)
 - radiation (#1447)
 - german/eurostat energy balances -> German/Eurostat energy balance sector division; empirical/synthetic/test data set (#1463)
+- replaced owl:equivalentClass with 'may be identical to' in annotation properties
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -61,10 +61,7 @@ AnnotationProperty: dc:contributor
     
 AnnotationProperty: dc:description
 
-    
-AnnotationProperty: owl:equivalentClass
 
-    
 AnnotationProperty: rdfs:comment
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -38,6 +38,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -808,11 +811,11 @@ Class: OEO_00000006
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        rdfs:label "carbon dioxide",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16526"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16526",
+        rdfs:label "carbon dioxide"
     
     SubClassOf: 
         OEO_00000331,
@@ -1048,11 +1051,11 @@ Class: OEO_00000025
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
-        rdfs:label "methane",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16183"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16183",
+        rdfs:label "methane"
     
     SubClassOf: 
         OEO_00140159,
@@ -1087,11 +1090,11 @@ Class: OEO_00000027
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0000118> "dinitrogen oxide",
-        rdfs:label "nitrous oxide",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17045"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17045",
+        rdfs:label "nitrous oxide"
     
     SubClassOf: 
         OEO_00000331,
@@ -1315,11 +1318,11 @@ Class: OEO_00000040
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
-        rdfs:label "uranium",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33499"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33499",
+        rdfs:label "uranium"
     
     SubClassOf: 
         OEO_00000331,
@@ -1359,11 +1362,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
 add 'has bearer' axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "waste role",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000665"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000665",
+        rdfs:label "waste role"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -1377,11 +1380,11 @@ Class: OEO_00000043
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
-        rdfs:label "wind",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000793"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000793",
+        rdfs:label "wind"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -1453,11 +1456,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 make subclass of gas mixture and improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "air",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002005"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002005",
+        rdfs:label "air"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
@@ -1475,11 +1478,11 @@ Class: OEO_00000055
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
-        rdfs:label "air pollution",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500037"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02500037",
+        rdfs:label "air pollution"
     
     SubClassOf: 
         OEO_00000330,
@@ -1505,12 +1508,12 @@ Class: OEO_00000058
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000011"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000011",
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite"
     
     SubClassOf: 
         OEO_00000204
@@ -1651,11 +1654,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:label "biogas",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000556"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000556",
+        rdfs:label "biogas"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
@@ -1716,11 +1719,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        rdfs:label "charcoal",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000560"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000560",
+        rdfs:label "charcoal"
     
     SubClassOf: 
         OEO_00000331,
@@ -1737,12 +1740,12 @@ Class: OEO_00000088
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
-        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen. Coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
-        rdfs:label "coal",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000091"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000091",
+        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen. Coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
+        rdfs:label "coal"
     
     SubClassOf: 
         OEO_00000331,
@@ -1763,11 +1766,11 @@ Class: OEO_00000089
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "coal power plant",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000038"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000038",
+        rdfs:label "coal power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2212,11 +2215,11 @@ Class: OEO_00000191
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
-        rdfs:label "geothermal energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000034"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000034",
+        rdfs:label "geothermal energy"
     
     SubClassOf: 
         OEO_00000207,
@@ -2230,11 +2233,11 @@ Class: OEO_00000192
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "geothermal power plant",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002215"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002215",
+        rdfs:label "geothermal power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2378,11 +2381,11 @@ Class: OEO_00000220
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
-        rdfs:label "hydrogen",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_18276"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_18276",
+        rdfs:label "hydrogen"
     
     SubClassOf: 
         OEO_00000331,
@@ -2547,14 +2550,14 @@ Class: OEO_00000251
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
-
-This includes the portion of the oil shale or tar sands consumed in the transformation process.",
-        rdfs:label "lignite",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000008"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000008",
+        rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
+
+This includes the portion of the oil shale or tar sands consumed in the transformation process.",
+        rdfs:label "lignite"
     
     SubClassOf: 
         OEO_00000088,
@@ -2572,11 +2575,11 @@ Class: OEO_00000252
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "lignite power plant",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000040"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000040",
+        rdfs:label "lignite power plant"
     
     SubClassOf: 
         OEO_00000089,
@@ -2748,14 +2751,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 improve definition and make subclass of gas mixture and add disjoints:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
-        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
-
-It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
-        rdfs:label "natural gas",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000552"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000552",
+        rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
+
+It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
+        rdfs:label "natural gas"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
@@ -2857,11 +2860,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 conversion to nuclear binding energy
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        rdfs:label "nuclear binding energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000025"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000025",
+        rdfs:label "nuclear binding energy"
     
     SubClassOf: 
         OEO_00000150,
@@ -2893,11 +2896,11 @@ Class: OEO_00000303
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "nuclear power plant",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002271"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002271",
+        rdfs:label "nuclear power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -2957,11 +2960,11 @@ Class: OEO_00000318
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "particulate matter",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000060"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000060",
+        rdfs:label "particulate matter"
     
     SubClassOf: 
         OEO_00000331,
@@ -2977,11 +2980,11 @@ Class: OEO_00000320
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
-        rdfs:label "peat",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00005774"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00005774",
+        rdfs:label "peat"
     
     SubClassOf: 
         OEO_00000331,
@@ -3030,11 +3033,11 @@ Class: OEO_00000330
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
-        rdfs:label "pollution",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02500036"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02500036",
+        rdfs:label "pollution"
     
     SubClassOf: 
         OEO_00000147
@@ -3275,11 +3278,11 @@ Class: OEO_00000386
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
-        rdfs:label "solar power plant",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000041"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000041",
+        rdfs:label "solar power plant"
     
     SubClassOf: 
         OEO_00000031,
@@ -3435,11 +3438,11 @@ Class: OEO_00000401
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "sub bituminous coal",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000009"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000009",
+        rdfs:label "sub bituminous coal"
     
     SubClassOf: 
         OEO_00000088
@@ -3541,11 +3544,11 @@ Class: OEO_00000437
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "volatile organic compound",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_134179"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_134179",
+        rdfs:label "volatile organic compound"
     
     EquivalentTo: 
         OEO_00000025 or OEO_00000298
@@ -3624,11 +3627,11 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 remove origin 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        rdfs:label "water",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_15377"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_15377",
+        rdfs:label "water"
     
     SubClassOf: 
         OEO_00000331,
@@ -3783,11 +3786,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
 Adapt definition and axioms, add alternative terms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
-        rdfs:label "ammonia"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16134"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16134",
+        rdfs:label "ammonia"@en
     
     SubClassOf: 
         OEO_00000331,
@@ -3805,11 +3808,11 @@ Class: OEO_00010001
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "carbon monoxide"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_17245"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17245",
+        rdfs:label "carbon monoxide"@en
     
     SubClassOf: 
         OEO_00000331,
@@ -3825,11 +3828,11 @@ Class: OEO_00010002
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "nitrogen oxides"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_35196"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_35196",
+        rdfs:label "nitrogen oxides"@en
     
     SubClassOf: 
         OEO_00000331,
@@ -3892,11 +3895,11 @@ Class: OEO_00010009
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM10"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000405"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000405",
+        rdfs:label "PM10"@en
     
     SubClassOf: 
         OEO_00000318
@@ -3910,11 +3913,11 @@ Class: OEO_00010010
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
-        rdfs:label "PM2.5"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000415"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000415",
+        rdfs:label "PM2.5"@en
     
     SubClassOf: 
         OEO_00000318
@@ -4366,11 +4369,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "motor",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000610"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000610",
+        rdfs:label "motor"
     
     SubClassOf: 
         OEO_00000011,
@@ -4691,8 +4694,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
 Make river a subclass of water body:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "river"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00000022"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00000022",
+        rdfs:label "river"@en
     
     SubClassOf: 
         OEO_00010104,
@@ -4848,8 +4851,8 @@ Class: OEO_00010101
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        rdfs:label "tidal flow"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001342"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001342",
+        rdfs:label "tidal flow"@en
     
     SubClassOf: 
         OEO_00110002
@@ -6738,11 +6741,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
 axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
-        rdfs:label "ethanol"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_16236"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16236",
+        rdfs:label "ethanol"@en
     
     SubClassOf: 
         OEO_00000331,
@@ -6848,11 +6851,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1031
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447",
-        rdfs:label "radiation",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001023"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001023",
+        rdfs:label "radiation"
     
     SubClassOf: 
         OEO_00020103,
@@ -6872,11 +6875,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
 Add alternative label and editor note:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
-        rdfs:label "solar radiation",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01001862"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001862",
+        rdfs:label "solar radiation"
     
     SubClassOf: 
         OEO_00020037
@@ -6892,11 +6895,11 @@ Class: OEO_00020040
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
-        rdfs:label "radiative energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000030"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000030",
+        rdfs:label "radiative energy"
     
     SubClassOf: 
         OEO_00000150
@@ -6928,12 +6931,12 @@ Class: OEO_00020045
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
-        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000016"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000016",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy"
     
     SubClassOf: 
         OEO_00000150
@@ -8851,8 +8854,8 @@ Class: OEO_00140162
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
-        rdfs:label "power plant with electro motive generator"@en,
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_00002214"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002214",
+        rdfs:label "power plant with electro motive generator"@en
     
     EquivalentTo: 
         OEO_00000031
@@ -9022,11 +9025,11 @@ Class: OEO_00230020
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        rdfs:label "kinetic energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000017"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000017",
+        rdfs:label "kinetic energy"@en
     
     SubClassOf: 
         OEO_00000150
@@ -9047,11 +9050,11 @@ remove origin
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 classify as material entity
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
-        rdfs:label "photon"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_30212"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_30212",
+        rdfs:label "photon"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000040>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -61,10 +61,7 @@ AnnotationProperty: dc:contributor
     
 AnnotationProperty: dc:description
 
-    
-AnnotationProperty: owl:equivalentClass
 
-    
 AnnotationProperty: rdfs:comment
 
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -42,6 +42,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -1332,11 +1335,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "fuel role",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_33292"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
+        rdfs:label "fuel role"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -1353,11 +1356,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "chemical energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000023"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000023",
+        rdfs:label "chemical energy"
     
     SubClassOf: 
         OEO_00000150
@@ -1664,11 +1667,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 move class to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "electrical energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000020"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000020",
+        rdfs:label "electrical energy"
     
     SubClassOf: 
         OEO_00000150,
@@ -1787,12 +1790,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
 Axiomatise relations between origin, energy and portion of matter:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000015"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
@@ -1897,11 +1900,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "greenhouse effect disposition",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/CHEBI_76413"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
+        rdfs:label "greenhouse effect disposition"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -1984,11 +1987,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390"@en,
-        rdfs:label "thermal energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_2000032"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000032",
+        rdfs:label "thermal energy"@en
     
     SubClassOf: 
         OEO_00000150
@@ -2263,11 +2266,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
-        rdfs:label "quantity value",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000032"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000032",
+        rdfs:label "quantity value"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
@@ -2391,11 +2394,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        rdfs:label "vehicle",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_01000604"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000604",
+        rdfs:label "vehicle"
     
     SubClassOf: 
         OEO_00000061,
@@ -3796,11 +3799,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time series",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/IAO_0000584"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000584",
+        rdfs:label "time series"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>,
@@ -3988,11 +3991,11 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
 add has participant axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1271
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309",
-        rdfs:label "transport"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        owl:equivalentClass "http://purl.obolibrary.org/obo/ENVO_02000125"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000125",
+        rdfs:label "transport"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -85,10 +85,7 @@ AnnotationProperty: dc:description
 
     
 AnnotationProperty: dc:identifier
-
     
-AnnotationProperty: owl:equivalentClass
-
     
 AnnotationProperty: rdfs:comment
 


### PR DESCRIPTION
## Summary of the discussion

Part of issue #1430 
## Type of change (CHANGELOG.md)

### Updated
- Annotation properties relating to classes in external ontologies now are `may be identical to` instead of `owl:equivalentClass`
## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
