### PR TITLE
Added reasoning to the creation of oeo-full.omn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(VERSIONDIR)/%.omn: $(ONTOLOGY_SOURCE)/%.omn
 
 $(VERSIONDIR)/oeo-full.omn : | base
 	$(ROBOT) merge --catalog $(VERSIONDIR)/catalog-v001.xml $(foreach f, $(VERSIONDIR)/oeo.omn $(OMN_COPY) $(OWL_COPY), --input $(f)) annotate --ontology-iri http://openenergy-platform.org/ontology/oeo/ --output $@
-
+	$(ROBOT) reason --input $@ --output $@
 $(VERSIONDIR)/oeo-full.owl : $(VERSIONDIR)/oeo-full.omn
 	$(call translate_to_owl,$@,$<)
 	$(call replace_omns,$@)


### PR DESCRIPTION
## Summary of the discussion

Related to #1124

## Type of change (CHANGELOG.md)

### Added
- Reasoner is called after building the full ontology

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
