### PR TITLE
Add `Brent crude` and `Western Texas Intermediate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.X.X] - 20XX-XX-XX
 
 ### Added
+* Brent crude, Western Texas Intermediate (#1478)
+
 ### Changed
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6741,6 +6741,7 @@ Class: OEO_00010409
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Western Texas Intermediate (WTI) is a crude oil that is extracted on US territory and traded at NYMEX New York.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WTI",
         rdfs:label "Western Texas Intermediate"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6730,6 +6730,8 @@ Class: OEO_00010408
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Brent crude is a crude oil that is extracted in the North Sea and traded at ICE London.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "Brent crude"@en
     
     SubClassOf: 
@@ -6742,6 +6744,8 @@ Class: OEO_00010409
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Western Texas Intermediate (WTI) is a crude oil that is extracted on US territory and traded at NYMEX New York.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "WTI",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "Western Texas Intermediate"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -61,7 +61,7 @@ AnnotationProperty: dc:contributor
     
 AnnotationProperty: dc:description
 
-
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -275,6 +275,9 @@ ObjectProperty: OEO_00010235
 
     
 ObjectProperty: OEO_00020056
+
+    
+ObjectProperty: OEO_00020070
 
     
 ObjectProperty: OEO_00020180
@@ -6723,6 +6726,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456",
         OEO_00000334
     
     
+Class: OEO_00010408
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Brent crude is a crude oil that is extracted in the North Sea and traded at ICE London.",
+        rdfs:label "Brent crude"@en
+    
+    SubClassOf: 
+        OEO_00000115,
+        OEO_00020070 some OEO_00020060
+    
+    
+Class: OEO_00010409
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Western Texas Intermediate (WTI) is a crude oil that is extracted on US territory and traded at NYMEX New York.",
+        rdfs:label "Western Texas Intermediate"@en
+    
+    SubClassOf: 
+        OEO_00000115,
+        OEO_00020070 some OEO_00020060
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -7097,6 +7122,9 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         OEO_00140101,
         OEO_00010234 only OEO_00000191
     
+    
+Class: OEO_00020060
+
     
 Class: OEO_00020066
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2441,10 +2441,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
 Class: OEO_00010082
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "trade"@en
     
     SubClassOf: 
@@ -2455,14 +2459,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
 Class: OEO_00010083
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
 
 update definition and improve axiom:
 https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019",
+https://github.com/OpenEnergyPlatform/ontology/pull/1019
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "market participant"@en
     
     SubClassOf: 
@@ -3036,11 +3044,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
 Class: OEO_00020060
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "fuel market exchange"
     
     SubClassOf: 
@@ -3070,10 +3082,14 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020065
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "energy market exchange"
     
     SubClassOf: 
@@ -3135,9 +3151,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00020069
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "market exchange"
     
     EquivalentTo: 
@@ -3916,7 +3936,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
 Class: OEO_00040002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market",
@@ -3928,7 +3948,11 @@ https://github.com/OpenEnergyPlatform/ontology/issues/677
 https://github.com/OpenEnergyPlatform/ontology/pull/740
 
 change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "market exchange role"@en,
         rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -85,7 +85,7 @@ AnnotationProperty: dc:description
 
     
 AnnotationProperty: dc:identifier
-    
+
     
 AnnotationProperty: rdfs:comment
 
@@ -911,6 +911,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
     InverseOf: 
         OEO_00140002
     
+    
+ObjectProperty: OEO_00020071
+
     
 ObjectProperty: OEO_00020179
 
@@ -2435,6 +2438,38 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
     
     
+Class: OEO_00010082
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
+        rdfs:label "trade"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00040011
+    
+    
+Class: OEO_00010083
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+update definition and improve axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019",
+        rdfs:label "market participant"@en
+    
+    SubClassOf: 
+        OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
+    
+    
 Class: OEO_00010114
 
     Annotations: 
@@ -2998,6 +3033,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
         <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
+Class: OEO_00020060
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel market exchange"
+    
+    SubClassOf: 
+        OEO_00020065,
+        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
+    
+    
 Class: OEO_00020063
 
     Annotations: 
@@ -3015,6 +3065,19 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         OEO_00020015,
         OEO_00020180 some OEO_00020154,
         OEO_00140002 some OEO_00010079
+    
+    
+Class: OEO_00020065
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "energy market exchange"
+    
+    SubClassOf: 
+        OEO_00020069
     
     
 Class: OEO_00020066
@@ -3067,6 +3130,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     SubClassOf: 
         OEO_00020067
+    
+    
+Class: OEO_00020069
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
+    
+    SubClassOf: 
+        OEO_00030022,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019"
+        <http://purl.obolibrary.org/obo/RO_0000056> some 
+            (OEO_00010082
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
     
     
 Class: OEO_00020085
@@ -3827,6 +3911,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
         OEO_00000350,
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
+    
+    
+Class: OEO_00040002
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
+https://github.com/OpenEnergyPlatform/ontology/pull/639
+
+https://github.com/OpenEnergyPlatform/ontology/issues/677
+https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+change label to market exchange role
+https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "market exchange role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: OEO_00040003

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -677,35 +677,9 @@ Class: OEO_00010079
     
 Class: OEO_00010082
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one commodity or service is exchanged for another commodity or service.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745",
-        rdfs:label "trade"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00040011
-    
     
 Class: OEO_00010083
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-update definition and improve axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019",
-        rdfs:label "market participant"@en
-    
-    SubClassOf: 
-        OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
-    
     
 Class: OEO_00010115
 
@@ -901,18 +875,6 @@ Class: OEO_00020015
     
 Class: OEO_00020060
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel market exchange"
-    
-    SubClassOf: 
-        OEO_00020065,
-        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
-    
     
 Class: OEO_00020063
 
@@ -933,16 +895,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     
 Class: OEO_00020065
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "energy market exchange"
-    
-    SubClassOf: 
-        OEO_00020069
-    
     
 Class: OEO_00020066
 
@@ -964,24 +916,6 @@ Class: OEO_00020068
     
 Class: OEO_00020069
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    SubClassOf: 
-        OEO_00030022,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019"
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (OEO_00010082
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
-    
     
 Class: OEO_00020075
 
@@ -1478,26 +1412,6 @@ Class: OEO_00030035
     
 Class: OEO_00040002
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639
-
-https://github.com/OpenEnergyPlatform/ontology/issues/677
-https://github.com/OpenEnergyPlatform/ontology/pull/740
-
-change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "market exchange role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
     
 Class: OEO_00040003
 


### PR DESCRIPTION
## Summary of the discussion

Add the two commercially most important crude oil types: Brent crude and Western Texas Intermediate.
The implementation of the axioms `'is traded at' 'fuel market exchange'` requires the move of some classes to oeo-shared.

## Type of change (CHANGELOG.md)

### Add
* `Brent crude`: _Brent crude is a crude oil that is extracted in the North Sea and traded at ICE London._
* `Western Texas Intermediate`: _Western Texas Intermediate (WTI) is a crude oil that is extracted on US territory and traded at NYMEX New York._

### Update
Move to oeo-shared:
* `fuel market exchange`
* `energy market exchange`
* `market exchange`
* `market exchange role`
* `trade`
* `market participant`

## Workflow checklist

### Automation
No automation, the issue #1458 stays open as additional axioms need further discussion.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
