### PR TITLE
Feature 1477 power to liquid process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.X.X] - 20XX-XX-XX
 
 ### Added
-- power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1477)
 - CRF-based sector division, EU legislation sector division (#1462)
 - Brent crude, Western Texas Intermediate (#1478)
 - electricity cost (#1482)
+- power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1483)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.X.X] - 20XX-XX-XX
 
 ### Added
+- power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1477)
 - CRF-based sector division, EU legislation sector division (#1462)
 - Brent crude, Western Texas Intermediate (#1478)
 - electricity cost (#1482)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -764,7 +764,8 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-fuel process"@en
     
     SubClassOf: 
@@ -775,6 +776,8 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330008>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-liquid process"@en
     
     SubClassOf: 
@@ -785,6 +788,8 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-fuel system"@en
     
     SubClassOf: 
@@ -795,6 +800,8 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330010>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-ammonia system"@en
     
     SubClassOf: 
@@ -3146,7 +3153,11 @@ Class: OEO_00000335
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+created new parent class 'power-to-fuel system'
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-gas system"
     
     SubClassOf: 
@@ -4134,7 +4145,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
 Align with 'power-to-gas system':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
+
+created new parent class 'power-to-fuel system'
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-liquid system"
     
     SubClassOf: 
@@ -5511,7 +5526,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+changed to subclass of  newly added 'power-to-fuel process'
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-gas process"@en
     
     SubClassOf: 
@@ -5533,7 +5552,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+added new parent class `power-to-fuel proces' upstream
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-methane process"@en
     
     SubClassOf: 
@@ -5626,7 +5649,11 @@ Class: OEO_00010222
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959
+
+added new parent class `power-to-fuel proces' upstream
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-ammonia process"@en
     
     SubClassOf: 
@@ -7117,6 +7144,9 @@ Class: OEO_00020054
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: 
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -810,8 +810,6 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330010>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-methane process.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-ammonia process.",
-	0408433d41ec94512f38e0763016562db569a74c
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-ammonia system"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,7 +760,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
+Class: OEO_00330007
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
@@ -776,7 +776,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
          and (OEO_00010235 some OEO_00000007)
     
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330008>
+Class: OEO_00330008
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
@@ -785,14 +785,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-liquid process"@en
     
     SubClassOf: 
-        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>,
+        OEO_00330007,
         (OEO_00000532 some OEO_00000331)
          and (OEO_00010234 some OEO_00000139),
         (OEO_00000533 some OEO_00010019)
          and (OEO_00010235 some OEO_00000007)
     
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>
+Class: OEO_00330009
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
@@ -803,10 +803,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
     SubClassOf: 
         OEO_00020102,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
-        <http://purl.obolibrary.org/obo/RO_0000056> some <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330007
     
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330010>
+Class: OEO_00330010
 
     Annotations: 
 
@@ -3173,7 +3173,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-gas system"
     
     SubClassOf: 
-        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>,
+        OEO_00330009,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
     
@@ -4165,7 +4165,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-liquid system"
     
     SubClassOf: 
-        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>,
+        OEO_00330009,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021
     
     
@@ -5546,7 +5546,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-gas process"@en
     
     SubClassOf: 
-        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>,
+        OEO_00330007,
         (OEO_00000532 some OEO_00000331)
          and (OEO_00010234 some OEO_00000139),
         (OEO_00000533 some OEO_00010155)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -769,7 +769,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-fuel process"@en
     
     SubClassOf: 
-        OEO_00020003
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010017)
+         and (OEO_00010235 some OEO_00000007)
     
     
 Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330008>
@@ -781,7 +785,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-liquid process"@en
     
     SubClassOf: 
-        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
+        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>,
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010019)
+         and (OEO_00010235 some OEO_00000007)
     
     
 Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>
@@ -793,19 +801,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-fuel system"@en
     
     SubClassOf: 
-        OEO_00020102
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
+        <http://purl.obolibrary.org/obo/RO_0000056> some <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
     
     
 Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330010>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-methane process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         rdfs:label "power-to-ammonia system"@en
     
     SubClassOf: 
-        OEO_00000335
+        OEO_00000335,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222
     
     
 Class: OEO_00000001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,6 +760,46 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
+        rdfs:label "power-to-fuel process"@en
+    
+    SubClassOf: 
+        OEO_00020003
+    
+    
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330008>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
+        rdfs:label "power-to-liquid process"@en
+    
+    SubClassOf: 
+        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
+    
+    
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
+        rdfs:label "power-to-fuel system"@en
+    
+    SubClassOf: 
+        OEO_00020102
+    
+    
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330010>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
+        rdfs:label "power-to-ammonia system"@en
+    
+    SubClassOf: 
+        OEO_00000335
+    
+    
 Class: OEO_00000001
 
     
@@ -3099,7 +3139,7 @@ Class: OEO_00000335
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is an energy transformation unit that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is a power-to-fuel system that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
@@ -3109,7 +3149,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         rdfs:label "power-to-gas system"
     
     SubClassOf: 
-        OEO_00020102,
+        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216
     
@@ -4085,7 +4125,7 @@ Class: OEO_00010020
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is an energy transformation unit that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is a power-to-fuel system that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
@@ -4097,7 +4137,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         rdfs:label "power-to-liquid system"
     
     SubClassOf: 
-        OEO_00020102,
+        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330009>,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021
     
     
@@ -5460,7 +5500,7 @@ Class: OEO_00010216
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
@@ -5474,7 +5514,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         rdfs:label "power-to-gas process"@en
     
     SubClassOf: 
-        OEO_00020003,
+        <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>,
         (OEO_00000532 some OEO_00000331)
          and (OEO_00010234 some OEO_00000139),
         (OEO_00000533 some OEO_00010155)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,66 +760,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: OEO_00330007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        rdfs:label "power-to-fuel process"@en
-    
-    SubClassOf: 
-        OEO_00020003,
-        (OEO_00000532 some OEO_00000331)
-         and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00010017)
-         and (OEO_00010235 some OEO_00000007)
-    
-    
-Class: OEO_00330008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        rdfs:label "power-to-liquid process"@en
-    
-    SubClassOf: 
-        OEO_00330007,
-        (OEO_00000532 some OEO_00000331)
-         and (OEO_00010234 some OEO_00000139),
-        (OEO_00000533 some OEO_00010019)
-         and (OEO_00010235 some OEO_00000007)
-    
-    
-Class: OEO_00330009
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        rdfs:label "power-to-fuel system"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330007
-    
-    
-Class: OEO_00330010
-
-    Annotations: 
-
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-ammonia process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        rdfs:label "power-to-ammonia system"@en
-    
-    SubClassOf: 
-        OEO_00000335,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222
-    
-    
 Class: OEO_00000001
 
     
@@ -7156,9 +7096,6 @@ Class: OEO_00020054
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: 
-https://github.com/OpenEnergyPlatform/ontology/issues/1477
-https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
@@ -11126,6 +11063,65 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
     
     SubClassOf: 
         OEO_00140127
+    
+    
+Class: OEO_00330007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
+        rdfs:label "power-to-fuel process"@en
+    
+    SubClassOf: 
+        OEO_00020003,
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010017)
+         and (OEO_00010235 some OEO_00000007)
+    
+    
+Class: OEO_00330008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
+        rdfs:label "power-to-liquid process"@en
+    
+    SubClassOf: 
+        OEO_00330007,
+        (OEO_00000532 some OEO_00000331)
+         and (OEO_00010234 some OEO_00000139),
+        (OEO_00000533 some OEO_00010019)
+         and (OEO_00010235 some OEO_00000007)
+    
+    
+Class: OEO_00330009
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
+        rdfs:label "power-to-fuel system"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010021,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330007
+    
+    
+Class: OEO_00330010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-ammonia process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
+        rdfs:label "power-to-ammonia system"@en
+    
+    SubClassOf: 
+        OEO_00000335,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -764,6 +764,7 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330007>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "",
         rdfs:label "power-to-fuel process"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Some gap filling and systematizing in the field of `power-to-X` classes 

## Type of change (CHANGELOG.md)

### Added
- `power-to-liquid process` , `power-to-ammonia system` , 
- `power-to-fuel process` , `power-to-fuel system` as superclasses for `power-to-gas process/power-to-fuel process` / `power-to-gas system/power-to-fuel system`. [#1477 ](https://github.com/OpenEnergyPlatform/ontology/issues/1477)

### Updated

### Removed


## Workflow checklist

### Automation
Closes #1477 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
