### PR TITLE
storage capacity #1466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - Brent crude, Western Texas Intermediate (#1478)
 - electricity cost (#1482)
 - power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1483)
+- energy storage level, energy storage content (#1486)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)
+- class name 'storage capacity' to 'energy storage capacity', made it subclass of 'maximum value' (#1486) 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)
-- class name 'storage capacity' to 'energy storage capacity', made it subclass of 'maximum value' (#1486) 
+- storage capacity -> energy storage capacity (#1486) (#1486) 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)
-- storage capacity -> energy storage capacity (#1486) (#1486) 
+- storage capacity -> energy storage capacity (#1486)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,6 +760,32 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330012>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+        rdfs:label "energy storage content"@en
+    
+    SubClassOf: 
+        OEO_00050019,
+        OEO_00020056 some OEO_00000159
+    
+    
+Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330013>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+        rdfs:label "energy storage level"@en
+    
+    SubClassOf: 
+        OEO_00320072,
+        OEO_00020056 some OEO_00000159
+    
+    
 Class: OEO_00000001
 
     
@@ -3421,11 +3447,15 @@ Class: OEO_00000399
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A storage unit is a grid component that stores energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage unit is a grid component that stores energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1338
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        rdfs:label "storage unit"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
+
+Changed 'storage unit' to 'energy storage unit'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+        rdfs:label "energy storage unit"
     
     EquivalentTo: 
         OEO_00020006
@@ -8978,13 +9008,17 @@ Class: OEO_00230000
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391",
-        rdfs:label "storage capacity"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
+
+Changed 'storage capacity' to 'energy storage capacity' 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+        rdfs:label "energy storage capacity"
     
     SubClassOf: 
-        OEO_00000350,
+        OEO_00010256,
         OEO_00020056 some OEO_00000159
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9012,7 +9012,7 @@ Class: OEO_00230000
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,7 +760,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330012>
+Class: OEO_00330012
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
@@ -773,7 +773,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         OEO_00020056 some OEO_00000159
     
     
-Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330013>
+Class: OEO_00330013
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5729,7 +5729,7 @@ Class: OEO_00010256
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
-Made 'anergy storage capacity' subclass of \"maximum value'
+Made 'energy storage capacity' subclass of \"maximum value'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "maximum value"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -765,7 +765,7 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330012>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage content"@en
     
     SubClassOf: 
@@ -778,7 +778,7 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330013>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage level"@en
     
     SubClassOf: 
@@ -3454,7 +3454,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 
 Changed 'storage unit' to 'energy storage unit'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage unit"
     
     EquivalentTo: 
@@ -5727,7 +5727,11 @@ Class: OEO_00010256
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
+
+Made 'anergy storage capacity' subclass of \"maximum value'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "maximum value"
     
     SubClassOf: 
@@ -9014,7 +9018,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 
 Changed 'storage capacity' to 'energy storage capacity' 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage capacity"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion


- rename `storage capacity`, `storage unit` to `energy storage capacity`, `energy storage unit` to make them more specific 
- make `energy storage capacity` subclass of `maximum value` since former `quantity value` doesn't match definition
- to differentiate different (levels of) filling status of an `energy storage object` new classes `energy storage level`, `energy storage content` were added plus new axioms.  

## Type of change (CHANGELOG.md)

### Added
- Added new classes `energy storage level`, `energy storage content` [#1466 ](https://github.com/OpenEnergyPlatform/ontology/issues/1466)

### Updated
- Updated a definition energ ystorage capacity [#1466 ](https://github.com/OpenEnergyPlatform/ontology/issues/1466)

### Removed


## Workflow checklist

### Automation
Closes #1466 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
