### PR TITLE
add compressed-air storage unit #1495

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - electricity cost (#1482)
 - power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1483)
 - energy storage level, energy storage content (#1486)
+- compressed-air energy storage unit (#1495)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)
+- air (#1499)
 - storage capacity -> energy storage capacity (#1486)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - electricity cost (#1482)
 - power-to-fuel system, power-to-fuel process, power-to-ammonia system, power-to-liquid process (#1483)
 - energy storage level, energy storage content (#1486)
-- compressed-air energy storage unit (#1495)
+- compressed-air energy storage unit (#1499)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -374,7 +374,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portions of matter and that has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         rdfs:label "gas mixture"@en
     
     SubClassOf: 
@@ -1455,7 +1455,7 @@ remove origin
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 make subclass of gas mixture and improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 
 remove axiom 'is used by' some 'energy storage unit'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
@@ -1656,7 +1656,7 @@ Class: OEO_00000074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -2661,7 +2661,7 @@ Class: OEO_00000263
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
@@ -2753,7 +2753,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 
 improve definition and make subclass of gas mixture and add disjoints:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -5459,7 +5459,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         rdfs:label "biomethane"@en
     
     SubClassOf: 
@@ -8904,7 +8904,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931
 
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11168,7 +11168,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00330013
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage level"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -760,32 +760,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000270>
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
-Class: OEO_00330012
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
-        rdfs:label "energy storage content"@en
-    
-    SubClassOf: 
-        OEO_00050019,
-        OEO_00020056 some OEO_00000159
-    
-    
-Class: OEO_00330013
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
-        rdfs:label "energy storage level"@en
-    
-    SubClassOf: 
-        OEO_00320072,
-        OEO_00020056 some OEO_00000159
-    
-    
 Class: OEO_00000001
 
     
@@ -7572,6 +7546,17 @@ Class: OEO_00020210
         OEO_00000531 value OEO_00000256
     
     
+Class: OEO_00020249
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed-air energy storage unit is an energy storage unit that uses compressed air.",
+        rdfs:label "compressed-air energy storage unit"@de
+    
+    SubClassOf: 
+        OEO_00000399,
+        OEO_00000503 some OEO_00000102
+    
+    
 Class: OEO_00030000
 
     Annotations: 
@@ -11160,6 +11145,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
     SubClassOf: 
         OEO_00000335,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222
+    
+    
+Class: OEO_00330012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
+        rdfs:label "energy storage content"@en
+    
+    SubClassOf: 
+        OEO_00050019,
+        OEO_00020056 some OEO_00000159
+    
+    
+Class: OEO_00330013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An engergy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
+        rdfs:label "energy storage level"@en
+    
+    SubClassOf: 
+        OEO_00320072,
+        OEO_00020056 some OEO_00000159
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1455,7 +1455,11 @@ remove origin
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 make subclass of gas mixture and improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1007
+
+remove axiom 'is used by' some 'energy storage unit'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -1464,7 +1468,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
-        OEO_00000501 some OEO_00000399,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
         OEO_00000529 value OEO_00000182
@@ -7550,6 +7553,8 @@ Class: OEO_00020249
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed-air energy storage unit is an energy storage unit that uses compressed air.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
         rdfs:label "compressed-air energy storage unit"@de
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.properties
+++ b/src/ontology/edits/oeo-physical.properties
@@ -1,0 +1,5 @@
+#Fri Mar 03 10:41:54 CET 2023
+jdbc.url=
+jdbc.driver=
+jdbc.user=
+jdbc.password=

--- a/src/ontology/edits/oeo-physical.properties
+++ b/src/ontology/edits/oeo-physical.properties
@@ -1,4 +1,4 @@
-#Fri Mar 03 10:41:54 CET 2023
+#Fri Mar 03 11:04:03 CET 2023
 jdbc.url=
 jdbc.driver=
 jdbc.user=

--- a/src/ontology/edits/oeo-physical.properties
+++ b/src/ontology/edits/oeo-physical.properties
@@ -1,4 +1,4 @@
-#Fri Mar 03 11:04:03 CET 2023
+#Fri Mar 03 11:07:35 CET 2023
 jdbc.url=
 jdbc.driver=
 jdbc.user=


### PR DESCRIPTION
## Summary of the discussion

Introduce new class `compressed-air energy storage unit` and remove wrong axiom `air 'is used by' some 'energy storage unit'`. #1495 

## Type of change (CHANGELOG.md)

### Added
- `compressed-air energy storage unit` #1495

### Updated
- `air` #1495

### Removed
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #1495

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
