### PR TITLE
Add `sector division axiom` #1449

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - air (#1499)
 - storage capacity -> energy storage capacity (#1486)
 - changed order in which the oeo-full files are compiled, owl now builds before omn (#1475)
+- sector division (#1506)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2311,7 +2311,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
         rdfs:label "sector division"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00000504 some 
+            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000395

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2307,7 +2307,11 @@ Class: OEO_00000368
 
 Move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+Add relation to organisation or person:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
         rdfs:label "sector division"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Part of #1449 

## Type of change (CHANGELOG.md)

### Add axiom
- `'sector division' 'is defined by' some (organisation or person)`

## Workflow checklist

### Automation
No automation

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
