### PR TITLE
Add class `energy transfer function` #1454

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - energy storage level, energy storage content (#1486)
 - compressed-air energy storage unit (#1499)
 - added built ontology to the pipeline artifacts (#1475)
+- energy transfer function (#1515)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6788,6 +6788,8 @@ Class: OEO_00010410
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1454
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1515",
         rdfs:label "energy transfer function"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6784,6 +6784,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         OEO_00020070 some OEO_00020060
     
     
+Class: OEO_00010410
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.",
+        rdfs:label "energy transfer function"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000034>,
+        OEO_00010121 some OEO_00000061
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.properties
+++ b/src/ontology/edits/oeo-physical.properties
@@ -1,5 +1,0 @@
-#Fri Mar 03 11:07:35 CET 2023
-jdbc.url=
-jdbc.driver=
-jdbc.user=
-jdbc.password=


### PR DESCRIPTION
## Summary of the discussion

Add class `energy transfer function` in parallel to `energy transformation function`.

## Type of change (CHANGELOG.md)

### Add
- `energy transfer function`: _An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance._

## Workflow checklist

### Automation
Closes #1454

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
