### PR TITLE
Relabel and redefine `has copyright license` to `has license` #1275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - energy transfer function (#1515)
 - mineral oil refining process, mineral oil product (#1531)
 - propulsion/energy-to-motion (#1541)
+- creative work (#1547)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - uses, is used by (#1508)
 - update oeo.omn description (#1509)
 - propulsion/traction (#1541)
-- has copyright license -> has licence; information content entity (#1547)
+- has copyright license -> has licence; information content entity; data set, database, model, software, document, software documentation, factsheet, report (#1547)
 
 ## [1.13.0] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - uses, is used by (#1508)
 - update oeo.omn description (#1509)
 - propulsion/traction (#1541)
-- has copyright license -> has licence (#1547)
+- has copyright license -> has licence; information content entity (#1547)
 
 ## [1.13.0] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - mineral oil refining process, mineral oil product (#1531)
 - propulsion/energy-to-motion (#1541)
 - forecast (#1544)
-- creative work (#1547)
+- creative work licence (#1547)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - uses, is used by (#1508)
 - update oeo.omn description (#1509)
 - propulsion/traction (#1541)
+- has copyright license -> has licence (#1547)
 
 ## [1.13.0] - 2023-02-01
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -61,7 +61,7 @@ AnnotationProperty: dc:contributor
     
 AnnotationProperty: dc:description
 
-
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -210,6 +210,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441",
     
     
 ObjectProperty: OEO_00020056
+
+    
+ObjectProperty: OEO_00020188
 
     
 ObjectProperty: OEO_00020220
@@ -503,9 +506,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000088>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> ""
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
 
@@ -643,12 +643,16 @@ Class: OEO_00000118
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
         rdfs:label "database"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
+        OEO_00020188 some OEO_00020186,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
@@ -752,12 +756,17 @@ Class: OEO_00000162
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271
+
+Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:comment "this entity is general and not specific to the OEP factsheets.",
         rdfs:label "factsheet"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
+        <http://purl.obolibrary.org/obo/IAO_0000310>,
+        OEO_00020188 some OEO_00010412
     
     
 Class: OEO_00000172
@@ -1105,12 +1114,17 @@ Class: OEO_00000380
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285
+
+Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:comment "A software documentation is a document containing explanations and tutorials how to use a program and is delivered with that program.",
         rdfs:label "software documentation"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000310>
+        <http://purl.obolibrary.org/obo/IAO_0000310>,
+        OEO_00020188 some OEO_00010412
     
     
 Class: OEO_00000382
@@ -1328,6 +1342,9 @@ Class: OEO_00010406
 
     
 Class: OEO_00010407
+
+    
+Class: OEO_00010412
 
     
 Class: OEO_00020011
@@ -1744,6 +1761,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
     
     
 Class: OEO_00020166
+
+    
+Class: OEO_00020186
 
     
 Class: OEO_00020227

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -643,11 +643,12 @@ Class: OEO_00000118
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has licence' axiom:
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272
+
+Add 'has licence' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272",
         rdfs:label "database"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -874,11 +874,16 @@ Class: OEO_00000279
         <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
-        pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/345
+
+Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:label "modelling software"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000010>
+        <http://purl.obolibrary.org/obo/IAO_0000010>,
+        OEO_00020188 some OEO_00020187
     
     
 Class: OEO_00000281
@@ -1765,6 +1770,9 @@ Class: OEO_00020166
 
     
 Class: OEO_00020186
+
+    
+Class: OEO_00020187
 
     
 Class: OEO_00020227

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2112,16 +2112,11 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
 
 add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
         rdfs:label "model"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
-        OEO_00020188 some OEO_00020187,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1288,7 +1288,11 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
+
+Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
     
     SubClassOf: 
         OEO_00000514 some OEO_00020121
@@ -2107,11 +2111,16 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
 
 add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:label "model"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00020188 some OEO_00020187,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -995,10 +995,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
 ObjectProperty: OEO_00020188
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a copyright licence.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "has copyright license"
+        rdfs:label "has licence"
     
     SubPropertyOf: 
         OEO_00010231

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1274,10 +1274,11 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000030>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom has copyright license
 issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090"
-    
-    SubClassOf: 
-        OEO_00020188 some OEO_00020185
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Delete axiom has (copyright) licence:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
     
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
@@ -2961,6 +2962,8 @@ Class: OEO_00010412
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work license is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:label "creative work licence"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2957,6 +2957,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
         OEO_00000504 some OEO_00010406
     
     
+Class: OEO_00010412
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work license is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        rdfs:label "creative work licence"@en
+    
+    SubClassOf: 
+        OEO_00020185
+    
+    
 Class: OEO_00020003
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -996,6 +996,7 @@ ObjectProperty: OEO_00020188
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "has license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
 
@@ -2970,7 +2971,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
 Class: OEO_00010412
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work license is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:label "creative work licence"@en
@@ -3602,11 +3604,16 @@ Class: OEO_00020185
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright license is a license that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "copyright license"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
+issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
+        rdfs:label "copyright licence"
     
     SubClassOf: 
         OEO_00020015
@@ -3616,10 +3623,15 @@ Class: OEO_00020186
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data license is a license that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "data license"
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
+        rdfs:label "data licence"
     
     SubClassOf: 
         OEO_00020015
@@ -3629,10 +3641,15 @@ Class: OEO_00020187
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software license is a copyright license that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
-        rdfs:label "software license"
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
+        rdfs:label "software licence"
     
     SubClassOf: 
         

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -997,11 +997,21 @@ ObjectProperty: OEO_00020188
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Relabel, redefine and add domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
         rdfs:label "has licence"
     
     SubPropertyOf: 
         OEO_00010231
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00020015
     
     
 ObjectProperty: OEO_00020189

--- a/src/ontology/imports/iao-module.owl
+++ b/src/ontology/imports/iao-module.owl
@@ -97,6 +97,12 @@
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
+
+    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000136">
@@ -127,10 +133,34 @@ Some currently missing phenomena that should be considered &quot;about&quot; are
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000111 xml:lang="en">software</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115 xml:lang="en">Software is a plan specification composed of a series of instructions that can be 
@@ -141,6 +171,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">PERSON: Melanie Courtot</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP: OBI</obo:IAO_0000119>
+        <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
         <rdfs:label xml:lang="en">software</rdfs:label>
     </owl:Class>
     
@@ -246,6 +279,12 @@ Previous. An information content entity is a non-realizable information entity t
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000310"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000111 xml:lang="en">report</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Examples of reports are gene lists and investigation reports. These are not published (journal) articles but may be included in a journal article.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
@@ -265,6 +304,9 @@ whole sentence is deleted.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP: OBI</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000099</obo:IAO_0000119>
+        <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
         <rdfs:label xml:lang="en">report</rdfs:label>
     </owl:Class>
     
@@ -274,6 +316,12 @@ whole sentence is deleted.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000111 xml:lang="en">data set</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Intensity values in a CEL file or from multiple CEL files comprise a data set (as opposed to the CEL files themselves).</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
@@ -336,11 +384,20 @@ Request that IAO either clarify these or change definitions not to use them</rdf
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000111 xml:lang="en">document</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">A journal article, patent application, laboratory notebook, or a book</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115 xml:lang="en">A collection of information content entities intended to be understood together as a whole</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
+        <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
         <rdfs:label xml:lang="en">document</rdfs:label>
     </owl:Class>
     


### PR DESCRIPTION
## Summary of the discussion

Restructure licensing-related classes, object properties and axioms.

## Type of change (CHANGELOG.md)

### Add
- Add class `creative work licence`: _A creative work license is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections._
- Add axioms:
  - `'data set' 'has licence' some 'data licence'`
  - `'database' 'has licence' some 'data licence'`
  - `software 'has licence' some 'software licence'`
  - `modelling software' 'has licence' some 'software licence'`
  - `document 'has licence' some 'creative work licence'`
  - `software documentation' 'has licence' some 'creative work licence'`
  - `factsheet 'has licence' some 'creative work licence'`
  - `report 'has licence' some 'creative work licence'`

### Update
- `has copyright license` -> `has license`
  - New definition: _A relation that holds between an information content entity and a ~copyright~ licence._
  - Add domain `information content entity` and range `licence`.
- Harmonise use of British English (and add American English as alternative terms).

### Remove
- Delete axiom: `'information content entity' 'has copyright license' some 'copyright license'`

## Workflow checklist

### Automation
Closes #1275

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
