### PR TITLE
Add `heat exchanger` subclasses #1361

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6783,6 +6783,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1515",
         OEO_00010121 some OEO_00000061
     
     
+Class: OEO_00010413
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subsurface collector is a heat exchanger that transfers ambient thermal energy to a working fluid. It consists of plastic pipes laid horizontally.",
+        rdfs:label "subsurface collector"@en
+    
+    SubClassOf: 
+        OEO_00140102
+    
+    
+Class: OEO_00010414
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A downhole heat exchanger is a heat exchanger that transfers ambient thermal energy or geothermal energy to a working fluid. It consists of plastic pipes installed vertically or inclined in a borehole.",
+        rdfs:label "downhole heat exchanger"@en
+    
+    SubClassOf: 
+        OEO_00140102
+    
+    
 Class: OEO_00020001
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Add two subclasses of `heat exchanger` that are collect geothermal and ambient thermal energy.

## Type of change (CHANGELOG.md)

### Add
* `subsurface collector`: _A subsurface collector is a heat exchanger that transfers ambient thermal energy to a working fluid. It consists of plastic pipes laid horizontally._
* `downhole heat exchanger`: _A downhole heat exchanger is a heat exchanger that transfers ambient thermal energy or geothermal energy to a working fluid. It consists of plastic pipes installed vertically or inclined in a borehole._

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
