### PR TITLE
Add alternative labels to common report format #1535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.14.0] - 2023-03-30
 
 ### Added
+- Add alternative labels national report inventory to common report format (#1558)
 - CRF-based sector division, EU legislation sector division (#1462)
 - Brent crude, Western Texas Intermediate (#1478)
 - electricity cost (#1482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [1.14.0] - 2023-03-30
 
 ### Added
-- Add alternative labels national report inventory to common report format (#1558)
 - CRF-based sector division, EU legislation sector division (#1462)
 - Brent crude, Western Texas Intermediate (#1478)
 - electricity cost (#1482)
@@ -21,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - creative work licence (#1547)
 
 ### Changed
+- common report format (#1558)
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)
 - electricity grid (#1479)
 - Updated RO import source to [v2023-02-22](https://raw.githubusercontent.com/oborel/obo-relations/v2023-02-22/ro.owl)

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -678,10 +678,12 @@ Class: OEO_00010055
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NIR sector division",
         <http://purl.obolibrary.org/obo/IAO_0000118> "national inventory report sector division",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1535
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1558",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
+
+add alternative labels:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1535
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1558",
         rdfs:label "common reporting format"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -678,6 +678,8 @@ Class: OEO_00010055
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NIR sector division",
         <http://purl.obolibrary.org/obo/IAO_0000118> "national inventory report sector division",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1535
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1558",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "common reporting format"

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -676,6 +676,8 @@ Class: OEO_00010055
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "NIR sector division",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "national inventory report sector division",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578",
         rdfs:label "common reporting format"
@@ -944,7 +946,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462",
     SubClassOf: 
         OEO_00000368
     
-
+    
 Class: OEO_00010407
 
     


### PR DESCRIPTION
## Summary of the discussion

Since NIR uses same sector divisions as CRF add alternative labels to `common report format`: `national inventory report sector division` and
`NIR sector division`

## Type of change (CHANGELOG.md)

### Added
- Added new alternative labels [#1535 ](https://github.com/OpenEnergyPlatform/ontology/issues/)

## Workflow checklist

### Automation
Closes #1535

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
