### PR TITLE
Feature 1490 1491 hydrogen colours nuclear origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - propulsion/energy-to-motion (#1541)
 - forecast (#1544)
 - creative work licence (#1547)
+- nuclear, nuclear electric hydrogen, nuclear electrical energy, solar electric hydrogen, solar electrical energy (#1559)
 
 ### Changed
 - NC/BR sector division and sector individuals; KSG sector division;  EU sectors/divisions; EU climate policy (#1462)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6817,7 +6817,8 @@ Class: OEO_00010417
         rdfs:label "nuclear electrical energy"@en
     
     SubClassOf: 
-        OEO_00000139
+        OEO_00000139,
+        OEO_00000530 some OEO_00010415
     
     
 Class: OEO_00010418
@@ -6844,7 +6845,8 @@ Class: OEO_00010419
              and (OEO_00010234 some OEO_00010417)))
     
     SubClassOf: 
-        OEO_00000139
+        OEO_00000139,
+        OEO_00020184 some OEO_00020046
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6787,6 +6787,8 @@ Class: OEO_00010415
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear is a conventional origin that indicates that the energy comes originally from nuclear binding energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1491
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         rdfs:label "nuclear"@en
     
     SubClassOf: 
@@ -6798,6 +6800,8 @@ Class: OEO_00010416
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "pink hydrogen",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         rdfs:label "nuclear electric hydrogen"@en
     
     EquivalentTo: 
@@ -6814,11 +6818,16 @@ Class: OEO_00010417
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrical energy is electrical energy with a nuclear origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         rdfs:label "nuclear electrical energy"@en
     
+    EquivalentTo: 
+        OEO_00000139
+         and (OEO_00000530 some OEO_00010415)
+    
     SubClassOf: 
-        OEO_00000139,
-        OEO_00000530 some OEO_00010415
+        OEO_00000139
     
     
 Class: OEO_00010418
@@ -6826,7 +6835,15 @@ Class: OEO_00010418
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrolytic hydrogen is electrolytic hydrogen that is produced with solar electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "yellow hydrogen",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         rdfs:label "solar electrolytic hydrogen"@en
+    
+    EquivalentTo: 
+        OEO_00010379
+         and (OEO_00240025 some 
+            (OEO_00010219
+             and (OEO_00010234 some OEO_00010419)))
     
     SubClassOf: 
         OEO_00010379
@@ -6836,13 +6853,13 @@ Class: OEO_00010419
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrical energy is electrical energy that is energy output of a solar energy transformation.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         rdfs:label "solar electrical energy"@en
     
     EquivalentTo: 
-        OEO_00010379
-         and (OEO_00240025 some 
-            (OEO_00010219
-             and (OEO_00010234 some OEO_00010417)))
+        OEO_00000139
+         and (OEO_00020184 some OEO_00020046)
     
     SubClassOf: 
         OEO_00000139,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6783,6 +6783,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1515",
         OEO_00010121 some OEO_00000061
     
     
+Class: OEO_00010415
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear is a conventional origin that indicates that the energy comes originally from nuclear binding energy.",
+        rdfs:label "nuclear"@en
+    
+    SubClassOf: 
+        OEO_00020147
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6797,6 +6797,7 @@ Class: OEO_00010416
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "pink hydrogen",
         rdfs:label "nuclear electric hydrogen"@en
     
     EquivalentTo: 
@@ -6814,6 +6815,33 @@ Class: OEO_00010417
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrical energy is electrical energy with a nuclear origin.",
         rdfs:label "nuclear electrical energy"@en
+    
+    SubClassOf: 
+        OEO_00000139
+    
+    
+Class: OEO_00010418
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrolytic hydrogen is electrolytic hydrogen that is produced with solar electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "yellow hydrogen",
+        rdfs:label "solar electrolytic hydrogen"@en
+    
+    SubClassOf: 
+        OEO_00010379
+    
+    
+Class: OEO_00010419
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrical energy is electrical energy that is energy output of a solar energy transformation.",
+        rdfs:label "solar electrical energy"@en
+    
+    EquivalentTo: 
+        OEO_00010379
+         and (OEO_00240025 some 
+            (OEO_00010219
+             and (OEO_00010234 some OEO_00010417)))
     
     SubClassOf: 
         OEO_00000139

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6793,6 +6793,32 @@ Class: OEO_00010415
         OEO_00020147
     
     
+Class: OEO_00010416
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy.",
+        rdfs:label "nuclear electric hydrogen"@en
+    
+    EquivalentTo: 
+        OEO_00010379
+         and (OEO_00240025 some 
+            (OEO_00010219
+             and (OEO_00010234 some OEO_00010417)))
+    
+    SubClassOf: 
+        OEO_00010379
+    
+    
+Class: OEO_00010417
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrical energy is electrical energy with a nuclear origin.",
+        rdfs:label "nuclear electrical energy"@en
+    
+    SubClassOf: 
+        OEO_00000139
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6863,6 +6863,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
     
     SubClassOf: 
         OEO_00000139,
+        OEO_00000530 some OEO_00030004,
         OEO_00020184 some OEO_00020046
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6863,8 +6863,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
     
     SubClassOf: 
         OEO_00000139,
-        OEO_00000530 some OEO_00030004,
-        OEO_00020184 some OEO_00020046
+        OEO_00000530 some OEO_00030004
     
     
 Class: OEO_00020001


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Add
- class `nuclear`:
  - Definition: _Nuclear is a conventional origin that indicates that the energy comes originally from nuclear binding energy._
- class `nuclear electric hydrogen`:
  - Definition: _Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy._
  - Axiom: `EquivalentTo: 'electrolytic hydrogen'  and ('physical output of' some ('water electrolysis process' and ('has energy input' some 'nuclear electrical energy')))`
- class `nuclear electrical energy`:
  - Definition: _Nuclear electrical energy is electrical energy with a nuclear origin._
  - Axiom: `EquivalentTo: 'electrical energy' and 'has origin' some nuclear`
- class `solar electric hydrogen`:
  - Definition: _Solar electrolytic hydrogen is electrolytic hydrogen that is produced with solar electrical energy._
  - Axiom: `'electrolytic hydrogen'  and ('physical output of' some ('water electrolysis process' and ('has energy input' some 'solar electrical energy')))`
- class `solar electrical energy`:
  - Definition: _Solar electrical energy is electrical energy that is energy output of a solar energy transformation._
  - Axiom: `EquivalentTo: 'electrical energy' and 'is energy output of' some 'solar energy transformation'` 
  - Axiom: `'has origin' some renewable`

## Workflow checklist

### Automation
Closes #1490 
Closes #1491

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
