### PR TITLE
Harmonise use of word "process" #1455

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - update oeo.omn description (#1509)
 - propulsion/traction (#1541)
 - has copyright license -> has licence; information content entity; data set, database, modelling software, software, document, software documentation, factsheet, report (#1547)
+- heat generation process, fuel-powered electricity generation (process), combined heat and power generation (CHP) (process), electricity generation process (#1562)
 
 ## [1.13.0] - 2023-02-01
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -583,7 +583,11 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "heat generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130
+
+Add alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
         rdfs:label "heat generation process"@en
     
     EquivalentTo: 
@@ -7921,7 +7925,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
 
 Update definition and axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240
+
+Relabel and add old label as alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
         rdfs:label "fuel-powered electricity generation process"@en
     
     EquivalentTo: 
@@ -9283,7 +9291,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Relabel and add old label as alternative label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
         rdfs:label "combined heat and power generation process"
     
     SubClassOf: 
@@ -9384,6 +9396,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
     
 Class: OEO_00240014
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation"
+    
     SubClassOf: 
         OEO_00020003,
         OEO_00000500 some OEO_00240012,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -581,6 +581,7 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "heat generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130",
         rdfs:label "heat generation process"@en
@@ -6805,8 +6806,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
     
     SubClassOf: 
         OEO_00140102
-
-
+    
+    
 Class: OEO_00010415
 
     Annotations: 
@@ -6888,7 +6889,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
     SubClassOf: 
         OEO_00000139,
         OEO_00000530 some OEO_00030004
-
+    
     
 Class: OEO_00020001
 
@@ -7913,14 +7914,15 @@ Class: OEO_00050001
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel-powered electricity generation is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel-powered electricity generation process is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fuel-powered electricity generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
 
 Update definition and axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/936
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240",
-        rdfs:label "fuel-powered electricity generation"@en
+        rdfs:label "fuel-powered electricity generation process"@en
     
     EquivalentTo: 
         OEO_00240014
@@ -9272,16 +9274,17 @@ Class: OEO_00240009
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Combined heat and power generation (CHP) is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generation (CHP) process is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "combined heat and power generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
 https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        rdfs:label "combined heat and power generation"
+        rdfs:label "combined heat and power generation process"
     
     SubClassOf: 
         OEO_00020003,

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4569,7 +4569,7 @@ Class: OEO_00240014
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4575,7 +4575,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Add alternative label and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
         rdfs:label "electricity generation process"
     
     EquivalentTo: 


### PR DESCRIPTION
## Summary of the discussion
Harmonise use of word "process". All process classes `X generation` should have label `X generation process` and alternative term `X generation`. Parts of what was discussed in the issue were already implemented in other pull requests.

## Type of change (CHANGELOG.md)

### Update
- Add alternative term `heat generation` to class `heat generation process`
- Relabel `fuel-powered electricity generation` to `fuel-power electricity generation process`, add old label as alternative label and improve definition
- Relabel `combined heat and power generation` to `combined heat and power generation process`, add old label as alternative label and improve definition
- Add alternative label `electricity generation` to `electricity generation process` and improve definition

## Workflow checklist

### Automation
Closes #1455

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
