### PR TITLE
Redefine `policy instrument` and change `guides` #1507

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - has copyright license -> has licence; information content entity; data set, database, modelling software, software, document, software documentation, factsheet, report (#1547)
 - heat generation process, fuel-powered electricity generation (process), combined heat and power generation (CHP) (process), electricity generation process (#1562)
 - RE-share -> renewable energy share (#1561)
+- policy instrument, guides (#1563)
 
 ## [1.13.0] - 2023-02-01
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -140,7 +140,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
         rdfs:label "guides"@en
     
     SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000056>
+        <http://purl.obolibrary.org/obo/IAO_0000136>
     
     Domain: 
         OEO_00140151
@@ -1917,17 +1917,18 @@ Class: OEO_00140151
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a specifically dependent continuant that is an action by the government that is intended to promote the adoption of a (transformative) measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
         rdfs:label "policy instrument"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149
+        OEO_00010119 some OEO_00140149,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
     
     
 Class: OEO_00140171

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -136,7 +136,11 @@ ObjectProperty: OEO_00010119
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+Make subproperty of 'is about':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563",
         rdfs:label "guides"@en
     
     SubPropertyOf: 
@@ -1919,7 +1923,11 @@ Class: OEO_00140151
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+Redefine as 'plan specification' and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563",
         rdfs:label "policy instrument"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Redefine `policy instrument` as a `plan specification`.

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Update
* Redefine `policy instrument` to: _A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures._
* Add axiom `'policy instrument' 'is about' some organisation'`
* Make `guides` a subproperty of `is about`

## Workflow checklist

### Automation
Closes #1507

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
