### PR TITLE
subproperties of has energy participant #1530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - electrical energy share, renewable energy share value, electrical energy share value (#1561)
 - subsurface collector, downhole heat exchanger (#1557)
 - nuclear, nuclear electric hydrogen, nuclear electrical energy, solar electric hydrogen, solar electrical energy (#1559)
+- has energy main/auxilary input, has energy main/waste output (#1564)
 
 ### Changed
 - common report format (#1558)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -309,10 +309,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     SubPropertyOf: 
         OEO_00020182
     
-
+    
 ObjectProperty: OEO_00020257
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         rdfs:label "has main energy input"
     
     SubPropertyOf: 
@@ -322,6 +325,9 @@ ObjectProperty: OEO_00020257
 ObjectProperty: OEO_00020258
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         rdfs:label "has auxilary energy input"
     
     SubPropertyOf: 
@@ -331,6 +337,9 @@ ObjectProperty: OEO_00020258
 ObjectProperty: OEO_00020259
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         rdfs:label "has main energy output"
     
     SubPropertyOf: 
@@ -340,11 +349,14 @@ ObjectProperty: OEO_00020259
 ObjectProperty: OEO_00020260
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         rdfs:label "has waste energy output"
     
     SubPropertyOf: 
         OEO_00010235
-
+    
     
 ObjectProperty: OEO_00040010
 
@@ -6841,8 +6853,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
     
     SubClassOf: 
         OEO_00140102
-
-
+    
+    
 Class: OEO_00010415
 
     Annotations: 
@@ -6924,7 +6936,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
     SubClassOf: 
         OEO_00000139,
         OEO_00000530 some OEO_00030004
-
+    
     
 Class: OEO_00020001
 
@@ -7721,6 +7733,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
         OEO_00020003
     
     
+Class: OEO_00020252
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542",
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
+A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
+        rdfs:label "climate system"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
 Class: OEO_00020254
 
     Annotations: 
@@ -7762,21 +7788,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
     SubClassOf: 
         OEO_00140127,
         OEO_00020056 some OEO_00020254
-
-
-Class: OEO_00020252
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
-A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
-        rdfs:label "climate system"@en
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-
     
 Class: OEO_00030000
 
@@ -9023,8 +9035,8 @@ Class: OEO_00140133
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "RE share",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
-<http://purl.obolibrary.org/obo/IAO_0000118> "RE share",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780
 axiom to RE share value and alternative label

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -309,6 +309,42 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     SubPropertyOf: 
         OEO_00020182
     
+
+ObjectProperty: OEO_00020257
+
+    Annotations: 
+        rdfs:label "has main energy input"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    
+ObjectProperty: OEO_00020258
+
+    Annotations: 
+        rdfs:label "has auxilary energy input"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    
+ObjectProperty: OEO_00020259
+
+    Annotations: 
+        rdfs:label "has main energy output"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    
+ObjectProperty: OEO_00020260
+
+    Annotations: 
+        rdfs:label "has waste energy output"
+    
+    SubPropertyOf: 
+        OEO_00010235
+
     
 ObjectProperty: OEO_00040010
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -321,6 +321,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
     SubPropertyOf: 
         OEO_00010234
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
     
 ObjectProperty: OEO_00020258
 
@@ -332,6 +338,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
     
     SubPropertyOf: 
         OEO_00010234
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020259
@@ -345,6 +357,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
     SubPropertyOf: 
         OEO_00010235
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
     
 ObjectProperty: OEO_00020260
 
@@ -356,6 +374,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
     
     SubPropertyOf: 
         OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00040010


### PR DESCRIPTION
## Summary of the discussion
Include subproperties of `has energy participant` #1530 

## Type of change (CHANGELOG.md)

### Added
* `has main energy input` _A relation between a process p and a kind of energy e, where e is required as major energy input for p._
* `has main energy output` _A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage._
* `has auxilary energy input` _A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input._
* `has waste energy output` _A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat._


## Workflow checklist

### Automation
Closes #1530

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
