### PR TITLE
specific energy transformations #1527

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - boolean variable, true, false (#1255)
 - production (#1575)
 - technology (#1591)
+- electricity generation process, heat generation process, heat transfer, chemical energy transfer, electrical energy transfer (#1599)
+- combined heat and power generation process, combustion thermal energy transformation, fuel-powered electricity generation process, hydro energy and hydroelectric transformation, nuclear energy transformation, solar energy transformation and subclasses, steam-electric process, wind energy transformation,  (#1599)
+- radiative, potential, kinetic energy (#1599)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -604,7 +604,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
     
     EquivalentTo: 
         OEO_00020003
-         and (not (OEO_00020257 some OEO_00000207))
          and (OEO_00020259 some OEO_00000207)
     
     SubClassOf: 
@@ -626,8 +625,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210",
     SubClassOf: 
         OEO_00020003,
         OEO_00000532 some OEO_00000099,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000207,
+        OEO_00020257 some OEO_00000007,
+        OEO_00020259 some OEO_00000207,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
         <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
     
@@ -7173,7 +7172,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000388,
+        OEO_00020259 some OEO_00000388,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
     
     
@@ -7248,11 +7247,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010234 some OEO_00000300,
+        OEO_00020257 some OEO_00000300,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000207
+        OEO_00020259 some OEO_00000207
     
     
 Class: OEO_00020058
@@ -9375,8 +9374,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010235 some OEO_00000139,
-        OEO_00010235 some OEO_00000207
+        OEO_00020259 some 
+            (OEO_00000139
+             and OEO_00000207)
     
     
 Class: OEO_00240010

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -608,7 +608,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     EquivalentTo: 
         OEO_00020003
+         and (OEO_00020257 some OEO_00000150)
          and (OEO_00020259 some OEO_00000207)
+         and (OEO_00020257 only 
+            (OEO_00000150 or (not (OEO_00000207))))
     
     SubClassOf: 
         OEO_00020003

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -311,75 +311,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     
     
 ObjectProperty: OEO_00020257
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
-        rdfs:label "has main energy input"
-    
-    SubPropertyOf: 
-        OEO_00010234
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
     
     
 ObjectProperty: OEO_00020258
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
-        rdfs:label "has auxilary energy input"
-    
-    SubPropertyOf: 
-        OEO_00010234
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
     
 ObjectProperty: OEO_00020259
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
-        rdfs:label "has main energy output"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
     
     
 ObjectProperty: OEO_00020260
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
-        rdfs:label "has waste energy output"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
     
     
 ObjectProperty: OEO_00040010

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-fPrefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -7077,6 +7077,20 @@ Class: OEO_00020039
 
     
 Class: OEO_00020040
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000030",
+        rdfs:label "radiative energy"
+    
+    SubClassOf: 
+        OEO_00000150
     
     
 Class: OEO_00020043
@@ -7091,17 +7105,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
     
     SubClassOf: 
         OEO_00020003,
-        (OEO_00020257 some OEO_00000446)
-         and (OEO_00020257 only OEO_00000446),
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        (OEO_00020259 some OEO_00000139)
-         and (OEO_00020259 only OEO_00000139),
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
+        OEO_00020259 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
+        OEO_00020257 only OEO_00000446
     
     
 Class: OEO_00020045
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000016",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy"
+    
+    SubClassOf: 
+        OEO_00000150
     
     
 Class: OEO_00020046
@@ -9265,6 +9291,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
     
     
 Class: OEO_00230020
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000017",
+        rdfs:label "kinetic energy"@en
+    
+    SubClassOf: 
+        OEO_00000150
     
     
 Class: OEO_00230021

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2881,7 +2881,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
     
     
 Class: OEO_00000300
-    
+
     
 Class: OEO_00000302
 
@@ -3175,7 +3175,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
     
     
 Class: OEO_00000350
-    
+
     
 Class: OEO_00000356
 
@@ -7098,12 +7098,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     SubClassOf: 
         OEO_00020003,
+        OEO_00020257 some OEO_00000446,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00020259 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
-        OEO_00020257 only OEO_00000446
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
     
     
 Class: OEO_00020045
@@ -7149,7 +7149,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00020257 only OEO_00000384
+        OEO_00020257 some OEO_00000384
     
     
 Class: OEO_00020047
@@ -7512,6 +7512,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
     
     
 Class: OEO_00020147
+
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        OEO_00030004
     
     
 Class: OEO_00020148
@@ -8229,13 +8235,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
     
     SubClassOf: 
         OEO_00020003,
+        OEO_00020257 some OEO_00000207,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00020259 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396,
-        OEO_00020257 only OEO_00000207
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
     
     
 Class: OEO_00090000
@@ -8335,7 +8341,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00020257 only OEO_00000218
+        OEO_00020257 some OEO_00000218
     
     
 Class: OEO_00110005
@@ -9379,6 +9385,12 @@ adjust input/output energy axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "combined heat and power generation process"
+    
+    EquivalentTo: 
+        OEO_00020257 some 
+            (OEO_00000150
+             and (not (OEO_00000139))
+             and (not (OEO_00000207)))
     
     SubClassOf: 
         OEO_00020003,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5757,7 +5757,11 @@ Class: OEO_00010267
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reforming process is a chemical reaction that converts hydrocarbons and steam to syngas. As it converts chemical energy and thermal energy to a different type of chemical energy (and waste heat), it is also an energy transformation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
+
+adjust output energy axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "steam reforming"@en
     
     SubClassOf: 
@@ -5767,7 +5771,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
         OEO_00000533 some OEO_00140160,
         OEO_00010234 some OEO_00000007,
         OEO_00010235 some OEO_00000007,
-        OEO_00010235 some OEO_00010114
+        OEO_00020260 some OEO_00010114
     
     
 Class: OEO_00010273

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -599,7 +599,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130
 
 Add alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+make equivalent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "heat generation process"@en
     
     EquivalentTo: 
@@ -619,7 +623,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130
 
 Add relation to emission
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "combustion thermal energy transformation"@en
     
     SubClassOf: 
@@ -4515,7 +4523,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "solar-steam-electric process"@en
     
     EquivalentTo: 
@@ -7099,7 +7111,11 @@ Class: OEO_00020043
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "wind energy transformation"
     
     SubClassOf: 
@@ -7146,7 +7162,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "solar energy transformation"
     
     SubClassOf: 
@@ -7164,7 +7184,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "solar thermal energy transformation"
     
     SubClassOf: 
@@ -7186,7 +7210,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "photovoltaic energy transformation"
     
     SubClassOf: 
@@ -7242,7 +7270,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "nuclear energy transformation"
     
     SubClassOf: 
@@ -7990,7 +8022,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240
 
 Relabel and add old label as alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "fuel-powered electricity generation process"@en
     
     EquivalentTo: 
@@ -8228,7 +8264,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
         rdfs:label "steam-electric process"@en
     
     SubClassOf: 
@@ -8330,7 +8370,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
         rdfs:label "hydro energy transformation"@en
     
     SubClassOf: 
@@ -8348,7 +8392,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
         rdfs:label "hydroelectric energy transformation"@en
     
     SubClassOf: 
@@ -9369,7 +9417,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 Relabel and add old label as alternative label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+adjust input/output energy axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "combined heat and power generation process"
     
     SubClassOf: 
@@ -10793,7 +10845,11 @@ Class: OEO_00320036
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
+
+make equivalent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "electrical energy transfer"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2881,25 +2881,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
     
     
 Class: OEO_00000300
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-conversion to nuclear binding energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000025",
-        rdfs:label "nuclear binding energy"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00000530 some OEO_00020147
     
     
 Class: OEO_00000302
@@ -7531,28 +7512,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
     
     
 Class: OEO_00020147
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
-        rdfs:label "conventional"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000150
-    
-    DisjointWith: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
-        OEO_00030004
     
     
 Class: OEO_00020148

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4525,7 +4525,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     
     SubClassOf: 
         OEO_00020046,
-        OEO_00010235 some OEO_00000139,
+        OEO_00020259 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
     
@@ -7105,11 +7105,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010234 some OEO_00000446,
+        (OEO_00020257 some OEO_00000446)
+         and (OEO_00020257 only OEO_00000446),
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
+        (OEO_00020259 some OEO_00000139)
+         and (OEO_00020259 only OEO_00000139),
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
     
     
@@ -7152,7 +7154,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010234 some OEO_00000384
+        OEO_00020257 only OEO_00000384
     
     
 Class: OEO_00020047
@@ -7195,7 +7197,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000139,
+        OEO_00020259 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
     
     
@@ -7999,13 +8001,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
          and (OEO_00000532 some OEO_00000099)
     
     SubClassOf: 
-        OEO_00240014,
         OEO_00000500 some OEO_00000148,
         OEO_00000533 some OEO_00000331,
-        OEO_00010234 some OEO_00000007,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
-        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
+        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
+        OEO_00020257 only OEO_00000007,
+        OEO_00020259 only OEO_00000139
     
     
 Class: OEO_00050002
@@ -8234,13 +8236,13 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010234 some OEO_00000207,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
+        OEO_00020259 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396,
+        OEO_00020257 only OEO_00000207
     
     
 Class: OEO_00090000
@@ -8336,7 +8338,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00010234 some OEO_00000218
+        OEO_00020257 only OEO_00000218
     
     
 Class: OEO_00110005
@@ -8357,7 +8359,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139
+        OEO_00020259 some OEO_00000139
     
     
 Class: OEO_00140000
@@ -9477,8 +9479,7 @@ Class: OEO_00240014
     SubClassOf: 
         OEO_00020003,
         OEO_00000500 some OEO_00240012,
-        OEO_00000500 some OEO_00240013,
-        OEO_00010235 some OEO_00000139
+        OEO_00000500 some OEO_00240013
     
     
 Class: OEO_00240015

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+fPrefix: : <http://openenergy-platform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -7077,20 +7077,6 @@ Class: OEO_00020039
 
     
 Class: OEO_00020040
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000030",
-        rdfs:label "radiative energy"
-    
-    SubClassOf: 
-        OEO_00000150
     
     
 Class: OEO_00020043
@@ -7116,20 +7102,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
     
     
 Class: OEO_00020045
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000016",
-        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy"
-    
-    SubClassOf: 
-        OEO_00000150
     
     
 Class: OEO_00020046
@@ -9293,20 +9265,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
     
     
 Class: OEO_00230020
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000017",
-        rdfs:label "kinetic energy"@en
-    
-    SubClassOf: 
-        OEO_00000150
     
     
 Class: OEO_00230021

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -311,16 +311,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     
     
 ObjectProperty: OEO_00020257
-    
+
     
 ObjectProperty: OEO_00020258
 
     
 ObjectProperty: OEO_00020259
-    
+
     
 ObjectProperty: OEO_00020260
-    
+
     
 ObjectProperty: OEO_00040010
 
@@ -604,7 +604,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
     
     EquivalentTo: 
         OEO_00020003
-         and (OEO_00010235 some OEO_00000207)
+         and (not (OEO_00020257 some OEO_00000207))
+         and (OEO_00020259 some OEO_00000207)
     
     SubClassOf: 
         OEO_00020003
@@ -8831,8 +8832,17 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 Shorten definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
+
+change equivalence axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "heat transfer"@en
+    
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00020257 some OEO_00000207)
+         and (OEO_00020259 some OEO_00000207)
     
     SubClassOf: 
         OEO_00020103,
@@ -10787,6 +10797,11 @@ Class: OEO_00320036
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         rdfs:label "electrical energy transfer"@en
     
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00020257 some OEO_00000139)
+         and (OEO_00020259 some OEO_00000139)
+    
     SubClassOf: 
         OEO_00020103,
         OEO_00010234 some OEO_00000139,
@@ -10799,8 +10814,16 @@ Class: OEO_00320037
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
+make equivalent class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "chemical energy transfer"@en
+    
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00020257 some OEO_00000007)
+         and (OEO_00020259 some OEO_00000007)
     
     SubClassOf: 
         OEO_00020103,

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1089,9 +1089,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     SubPropertyOf: 
         OEO_00010234
     
-    Characteristics: 
-        Functional
-    
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
@@ -1133,9 +1130,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     SubPropertyOf: 
         OEO_00010235
-    
-    Characteristics: 
-        Functional
     
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -3289,7 +3283,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
     
     
 Class: OEO_00020040
-    
+
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
@@ -3303,11 +3297,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000150
-
+    
     
 Class: OEO_00020045
-    
-        Annotations: 
+
+    Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
@@ -3320,8 +3314,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000150
-
-
+    
+    
 Class: OEO_00020060
 
     Annotations: 
@@ -4768,7 +4762,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00230020
-  
+
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
@@ -4782,7 +4776,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000150
-
+    
     
 Class: OEO_00240003
 
@@ -4811,7 +4805,7 @@ Class: OEO_00240014
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as main energy output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4897,7 +4897,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         OEO_00020003
          and (OEO_00020259 some OEO_00000139)
          and (OEO_00020257 only 
-            (OEO_00000007 or OEO_00000207 or OEO_00020040 or OEO_00020045 or OEO_00230020))
+            (OEO_00000007 or OEO_00000207 or OEO_00000300 or OEO_00020040 or OEO_00020045 or OEO_00230020))
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1073,6 +1073,78 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+
+
+ObjectProperty: OEO_00020257
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+        rdfs:label "has main energy input"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00020258
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+        rdfs:label "has auxilary energy input"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00020259
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+        rdfs:label "has main energy output"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    
+ObjectProperty: OEO_00020260
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+        rdfs:label "has waste energy output"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00040010

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1073,14 +1073,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-
-
+    
+    
 ObjectProperty: OEO_00020257
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "has main energy input"
     
     SubPropertyOf: 
@@ -1098,7 +1101,10 @@ ObjectProperty: OEO_00020258
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "has auxilary energy input"
     
     SubPropertyOf: 
@@ -1116,7 +1122,10 @@ ObjectProperty: OEO_00020259
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "has main energy output"
     
     SubPropertyOf: 
@@ -1134,7 +1143,11 @@ ObjectProperty: OEO_00020260
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "has waste energy output"
     
     SubPropertyOf: 
@@ -4751,12 +4764,17 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 Add alternative label and improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+change equivalence axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         rdfs:label "electricity generation process"
     
     EquivalentTo: 
         OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
+         and (not (OEO_00020257 some OEO_00000139))
+         and (OEO_00020259 some OEO_00000139)
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3285,10 +3285,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
 Class: OEO_00020040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -3302,9 +3305,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020045
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -4764,10 +4770,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
 Class: OEO_00230020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3289,7 +3289,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
     
     
 Class: OEO_00020040
-
+    
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
@@ -3306,8 +3306,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 
     
 Class: OEO_00020045
-
-    Annotations: 
+    
+        Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
@@ -3320,7 +3320,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000150
-    
+
 
 Class: OEO_00020060
 
@@ -4768,7 +4768,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00230020
-
+  
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1089,6 +1089,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     SubPropertyOf: 
         OEO_00010234
     
+    Characteristics: 
+        Functional
+    
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
@@ -1130,6 +1133,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     SubPropertyOf: 
         OEO_00010235
+    
+    Characteristics: 
+        Functional
     
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -3282,6 +3288,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
         <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
+Class: OEO_00020040
+
+    
+Class: OEO_00020045
+
+    
 Class: OEO_00020060
 
     Annotations: 
@@ -4727,6 +4739,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
+Class: OEO_00230020
+
+    
 Class: OEO_00240003
 
     Annotations: 
@@ -4773,8 +4788,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     EquivalentTo: 
         OEO_00020003
-         and (not (OEO_00020257 some OEO_00000139))
          and (OEO_00020259 some OEO_00000139)
+         and (OEO_00020257 only 
+            (OEO_00000007 or OEO_00000207 or OEO_00020040 or OEO_00020045 or OEO_00230020))
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4895,9 +4895,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
     
     EquivalentTo: 
         OEO_00020003
+         and (OEO_00020257 some OEO_00000150)
          and (OEO_00020259 some OEO_00000139)
          and (OEO_00020257 only 
-            (OEO_00000007 or OEO_00000207 or OEO_00000300 or OEO_00020040 or OEO_00020045 or OEO_00230020))
+            (OEO_00000150 or (not (OEO_00000139))))
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2267,6 +2267,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
     
     
+Class: OEO_00000300
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+conversion to nuclear binding energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000025",
+        rdfs:label "nuclear binding energy"
+    
+    SubClassOf: 
+        OEO_00000150,
+        OEO_00000530 some OEO_00020147
+    
+    
 Class: OEO_00000315
 
     Annotations: 
@@ -3652,6 +3677,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
     
     
+Class: OEO_00020147
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1527
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1599",
+        rdfs:label "conventional"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some OEO_00000150
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        OEO_00030004
+    
+    
 Class: OEO_00020154
 
     Annotations: 
@@ -4077,6 +4130,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     SubClassOf: 
         OEO_00000316,
         OEO_00010121 some OEO_00000150
+    
+    DisjointWith: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
+        OEO_00020147
     
     
 Class: OEO_00030015

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3290,10 +3290,38 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
     
 Class: OEO_00020040
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000030",
+        rdfs:label "radiative energy"
+    
+    SubClassOf: 
+        OEO_00000150
+
     
 Class: OEO_00020045
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000016",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy"
     
+    SubClassOf: 
+        OEO_00000150
+    
+
 Class: OEO_00020060
 
     Annotations: 
@@ -4740,6 +4768,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00230020
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000017",
+        rdfs:label "kinetic energy"@en
+    
+    SubClassOf: 
+        OEO_00000150
 
     
 Class: OEO_00240003


### PR DESCRIPTION
## Summary of the discussion

Relations are moved to oeo-shared and classes are made equivalent classes.
TODO: 
- fix axiom such that the previous subclasses are still being inferred. 
- add "main input/output" to some/most/all classes, to be clarifyed in the issue

## Type of change (CHANGELOG.md)

### Updated
- has main/auxillary energy input/output (oeo shared)
- make equivalent classes:
    - heat generation proces
    - electricity generation process
    - heat transfer
    - electrical energy transfer
    - chemical energy transfer

## Workflow checklist

### Automation
Closes #1527 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
