### PR TITLE
remove axiom #1405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - boolean variable, true, false (#1255)
 - production (#1575)
 - technology (#1591)
+- quantity value (#1606)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3246,9 +3246,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
     
     
 Class: OEO_00000350
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
 Class: OEO_00000356

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2346,7 +2346,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1405
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"


### PR DESCRIPTION
## Summary of the discussion

I removed the axiom 'quantity value' 'is about' some 'spatial region' from oeo-physical as mentioned in issue #1405 

## Type of change (CHANGELOG.md)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/1405)

## Workflow checklist

### Automation
Closes #1405

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
