### PR TITLE
1600-add-relations-between-energy-subclasses-and-its-bearers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - material transformation, fuel production (#1575)
 - life cycle assessment (#1576)
 - energy technology (#1591)
+- wind energy, hydro energy, solar energy (#1600)
 
 ### Changed
 - boolean variable, true, false (#1255)
 - production (#1575)
 - technology (#1591)
+- wind energy, hydro energy, solar energy (#1600)
 
 ### Removed
 

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -8,7 +8,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1688290034100" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1688290034100" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2426,6 +2426,9 @@ Class: OEO_00000218
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600#issue-1776186442
+pull request:https://github.com/OpenEnergyPlatform/ontology/pull/1608#issue-1789174976
+added axiom",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
 change axiom from participates in to is energy participant of
@@ -3345,6 +3348,9 @@ Class: OEO_00000384
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600#issue-1776186442
+pull request:https://github.com/OpenEnergyPlatform/ontology/pull/1608#issue-1789174976
+added axiom",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 restructure solar energy
@@ -3764,6 +3770,9 @@ Class: OEO_00000446
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600#issue-1776186442
+pull request:https://github.com/OpenEnergyPlatform/ontology/pull/1608#issue-1789174976
+added axiom",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 reclassify and change def

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1548,6 +1548,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010236>,
+        OEO_00010121 some OEO_00000054,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
         OEO_00000529 value OEO_00000182
@@ -2433,6 +2434,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     
     SubClassOf: 
         OEO_00230020,
+        OEO_00010121 some OEO_00000441,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3355,7 +3357,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
     
     SubClassOf: 
         OEO_00020040,
-        OEO_00000530 some OEO_00030004
+        OEO_00000530 some OEO_00030004,
+        OEO_00010121 some OEO_00230021
     
     
 Class: OEO_00000386
@@ -3716,6 +3719,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         OEO_00000331,
+        OEO_00010121 some OEO_00000441,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
         OEO_00000529 value OEO_00000256
     
@@ -3775,6 +3779,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
+        OEO_00010121 some OEO_00000054,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
@@ -9380,6 +9385,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000040>,
+        OEO_00010121 some OEO_00230021,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020040,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/726


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Added
- Added a new class [#](https://github.com/OpenEnergyPlatform/ontology/issues/)
- Added the following axioms:
'wind energy' 'has bearer' some air
'hydro energy' 'has bearer' some water
'solar energy' 'has bearer' some photon

## Workflow checklist

### Automation
Closes #1600

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
