### PR TITLE
scenario subclasses #1329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - material transformation, fuel production (#1575)
 - life cycle assessment (#1576)
 - energy technology (#1591)
+- policy scenario, reference role, reference scenario (#1614)
+
 
 ### Changed
 - boolean variable, true, false (#1255)
 - production (#1575)
 - technology (#1591)
 - quantity value (#1606)
+- moved to oeo-shared: scneario, analysis scope, study/considered region, scenario year/horizon, model descriptor, methodical focus, policy instrument, transformative measure, guides (#1614)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - production (#1575)
 - technology (#1591)
 - quantity value (#1606)
-- moved to oeo-shared: scneario, analysis scope, study/considered region, scenario year/horizon, model descriptor, methodical focus, policy instrument, transformative measure, guides (#1614)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1409,24 +1409,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
     
 Class: OEO_00020016
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-
-Add SubclassOf axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020017
@@ -1445,20 +1427,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
     
     
 Class: OEO_00020018
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
     
     
 Class: OEO_00020019

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1841,6 +1841,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
         OEO_00000364
     
     
+Class: OEO_00020309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "",
+        rdfs:label "policy scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1532,20 +1532,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
     
     
 Class: OEO_00020035
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "considered region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
 Class: OEO_00020036
@@ -1570,26 +1556,6 @@ Class: OEO_00020039
 
     
 Class: OEO_00020072
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'is about' axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286",
-        rdfs:label "analysis scope"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
     
     
 Class: OEO_00020089

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1021,25 +1021,6 @@ Class: OEO_00000353
     
 
 Class: OEO_00000364
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'narrative' and 'storyline' as alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
     
     
 Class: OEO_00000365
@@ -1734,15 +1715,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
     
 Class: OEO_00020309
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "policy scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00030007
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1021,25 +1021,6 @@ Class: OEO_00000353
     
     
 Class: OEO_00000364
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'narrative' and 'storyline' as alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
     
     
 Class: OEO_00000365
@@ -1842,14 +1823,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
     
     
 Class: OEO_00020309
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "",
-        rdfs:label "policy scenario"
-    
-    SubClassOf: 
-        OEO_00000364
     
     
 Class: OEO_00030007

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1019,8 +1019,27 @@ Class: OEO_00000353
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
-    
+
 Class: OEO_00000364
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'narrative' and 'storyline' as alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
     
     
 Class: OEO_00000365
@@ -1512,20 +1531,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1302",
     
     
 Class: OEO_00020032
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
 Class: OEO_00020033
@@ -1823,6 +1828,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
     
     
 Class: OEO_00020309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "policy scenario"
+    
+    SubClassOf: 
+        OEO_00000364
     
     
 Class: OEO_00030007

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1701,38 +1701,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
     
     
 Class: OEO_00020097
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario year"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
     
     
 Class: OEO_00020098
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario horizon"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
     
     
 Class: OEO_00020099

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3184,20 +3184,64 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: OEO_00020032
+Class: OEO_00020016
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+
+Add SubclassOf axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "model descriptor"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
+Class: OEO_00020018
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+
+alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "methodical focus"@en
+    
+    SubClassOf: 
+        OEO_00020016,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
+    
+    
+Class: OEO_00020032
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
 The union of the study region and the interacting/ external region ist the considered region.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
         rdfs:label "study region"
     
     SubClassOf: 
@@ -3382,14 +3426,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
 Class: OEO_00020097
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario year"
     
     SubClassOf: 
@@ -3404,14 +3444,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
 Class: OEO_00020098
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         rdfs:label "scenario horizon"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -836,6 +836,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         OEO_00240025
     
     
+ObjectProperty: OEO_00010119
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+Make subproperty of 'is about':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "guides"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00140151
+    
+    Range: 
+        OEO_00140149
+    
+    
 ObjectProperty: OEO_00010121
 
     Annotations: 
@@ -2370,7 +2396,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000364
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
@@ -2381,11 +2407,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
 
 Add 'narrative' and 'storyline' as alternative label
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
         rdfs:label "scenario"
     
     SubClassOf: 
@@ -4797,6 +4819,49 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
+    
+    
+Class: OEO_00140149
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "transformative measure"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140151
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+Redefine as 'plan specification' and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "policy instrument"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
+        OEO_00010119 some OEO_00140149,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
     
     
 Class: OEO_00140159

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3187,18 +3187,14 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
 Class: OEO_00020016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
 
 Add SubclassOf axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
         rdfs:label "model descriptor"@en
     
     EquivalentTo: 
@@ -3212,18 +3208,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
 Class: OEO_00020018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-
 alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
         rdfs:label "methodical focus"@en
     
     SubClassOf: 
@@ -3243,6 +3234,23 @@ The union of the study region and the interacting/ external region ist the consi
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
         rdfs:label "study region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00020035
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+        rdfs:label "considered region"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000006>
@@ -3400,6 +3408,33 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1019"
         <http://purl.obolibrary.org/obo/RO_0000056> some 
             (OEO_00010082
              and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
+    
+    
+Class: OEO_00020072
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'is about' axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "analysis scope"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
     
     
 Class: OEO_00020085

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2376,28 +2376,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
-Class: OEO_00000364
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'narrative' and 'storyline' as alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
-
-
 Class: OEO_00000368
 
     Annotations: 
@@ -3200,6 +3178,26 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00020032
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "study region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
 Class: OEO_00020039
 
     Annotations: 
@@ -3887,18 +3885,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
             (OEO_00020102
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
     
-
-Class: OEO_00020309
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "policy scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-
     
 Class: OEO_00030002
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4053,13 +4053,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
 Class: OEO_00020309
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy scenario is a scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "policy scenario"
     
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00140149 or OEO_00140151))
+    
     SubClassOf: 
         OEO_00000364
+    
+    
+Class: OEO_00020310
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A without measures scenario (WOM) is a policy scenario that excludes all policy instruments and transformative measures which are planned, adopted or implemented.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "without measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
     
     
 Class: OEO_00030002
@@ -4826,10 +4846,11 @@ Class: OEO_00140149
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
 
-move to oeo-shared
+move to oeo-shared, alternative label
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "transformative measure"@en
@@ -4843,6 +4864,7 @@ Class: OEO_00140151
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
 
@@ -4850,7 +4872,7 @@ Redefine as 'plan specification' and add axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
 
-move to oeo-shared
+move to oeo-shared, alternative label
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "policy instrument"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2376,6 +2376,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
         <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
+Class: OEO_00000364
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'narrative' and 'storyline' as alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
+
+
 Class: OEO_00000368
 
     Annotations: 
@@ -3865,6 +3887,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
             (OEO_00020102
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
     
+
+Class: OEO_00020309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "policy scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+
     
 Class: OEO_00030002
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4111,6 +4111,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         OEO_00020309
     
     
+Class: OEO_00020313
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an information content entity, that indicates a benchmark, e.g. in a comparison.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Although contradicting to BFO2, we add the reference role to the generically dependent \"information content entity\", aware of the ongoing discussion.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "reference role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00020314
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference scenario is a scenario that is used as a reference, e.g. in a scenario comparison. It has the reference role.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "reference scenario"
+    
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020313)
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
 Class: OEO_00030002
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -102,6 +102,9 @@ AnnotationProperty: rdfs:seeAlso
 Datatype: rdf:PlainLiteral
 
     
+Datatype: xsd:integer
+
+    
 Datatype: xsd:string
 
     
@@ -1346,6 +1349,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000002>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000003>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000036>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
@@ -3371,6 +3377,49 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
     SubClassOf: 
         OEO_00000150
+    
+    
+Class: OEO_00020097
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "scenario year"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
+    
+    
+Class: OEO_00020098
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "scenario horizon"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
     
     
 Class: OEO_00020102

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4071,12 +4071,41 @@ Class: OEO_00020310
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A without measures scenario (WOM) is a policy scenario that excludes all policy instruments and transformative measures which are planned, adopted or implemented.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM scenario",
         <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "without measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
+    
+    
+Class: OEO_00020311
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A with existing measures scenario (WEM) is a policy scenario that includes policy instruments and transformative measures that have been adopted and implemented.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WEM scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "with existing measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
+    
+    
+Class: OEO_00020312
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A with additional measures scenario (WAM) is a policy scenario that includes policy instruments and transformative measures which have been adopted and implemented to mitigate climate change or meet energy objectives, as well as policy instruments and transformative measures which are planned for that purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WAM scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "with additional measures scenario"
     
     SubClassOf: 
         OEO_00020309

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2367,6 +2367,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
     
     
+Class: OEO_00000364
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'narrative' and 'storyline' as alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
+    
+    
 Class: OEO_00000367
 
     Annotations: 
@@ -3413,18 +3439,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1019"
 Class: OEO_00020072
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared"^^xsd:string,
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
 
 Add 'is about' axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286",
         rdfs:label "analysis scope"
     
     SubClassOf: 
@@ -4004,6 +4026,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00020102
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
+    
+    
+Class: OEO_00020309
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+        rdfs:label "policy scenario"
+    
+    SubClassOf: 
+        OEO_00000364
     
     
 Class: OEO_00030002

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -132,25 +132,6 @@ ObjectProperty: OEO_00000522
 
     
 ObjectProperty: OEO_00010119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-Make subproperty of 'is about':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563",
-        rdfs:label "guides"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    Domain: 
-        OEO_00140151
-    
-    Range: 
-        OEO_00140149
     
     
 ObjectProperty: OEO_00010121
@@ -1884,18 +1865,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
     SubClassOf: 
         OEO_00140040
     
-    
+   
 Class: OEO_00140149
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797",
-        rdfs:label "transformative measure"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00140150
@@ -1918,25 +1889,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
     
     
 Class: OEO_00140151
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-Redefine as 'plan specification' and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563",
-        rdfs:label "policy instrument"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
     
     
 Class: OEO_00140171

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -132,7 +132,7 @@ ObjectProperty: OEO_00000522
 
     
 ObjectProperty: OEO_00010119
-    
+
     
 ObjectProperty: OEO_00010121
 
@@ -1865,21 +1865,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
     SubClassOf: 
         OEO_00140040
     
-   
-Class: OEO_00140149
     
+Class: OEO_00140149
+
     
 Class: OEO_00140150
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social"^^xsd:string,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
 
 relations:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "policy"@en
     
     SubClassOf: 
@@ -1889,7 +1894,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853",
     
     
 Class: OEO_00140151
-    
+
     
 Class: OEO_00140171
 


### PR DESCRIPTION
## Summary of the discussion

From #1329 
Still open: equivalences for energy, emission and climare scenario. I'll create a separate issue because this one is already big enough.

## Type of change (CHANGELOG.md)

### Added
- policy scenario
- reference role
- reference scenario

### Updated
move to oeo-shared 
- scenario
    - analysis scope 
        - study region
        - scenario year
        - scenario horizon
        - model descriptor
        - methodical focus
        - considered region
- policy instrument
- transformative measure 
- guides 

### Removed

## Workflow checklist

### Automation


### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
