### PR TITLE
make a class equivalent #1577

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3247,7 +3247,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
     
 Class: OEO_00000350
     
-    
 Class: OEO_00000356
 
     Annotations: 
@@ -8790,6 +8789,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
     
 Class: OEO_00140079
 
+    EquivalentTo: 
+        OEO_00240003
+         and (OEO_00000533 some OEO_00140079)
+    
     
 Class: OEO_00140080
 


### PR DESCRIPTION
I changed secondary energy production to be equivalent with production and has physical output some secondary energy carrier. 

## Type of change (CHANGELOG.md)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

## Workflow checklist

### Automation
Closes #1577

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
