### PR TITLE
make a class equivalent #1577

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - production (#1575)
 - technology (#1591)
 - quantity value (#1606)
+- secondary energy production (#1618)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3246,7 +3246,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
     
     
 Class: OEO_00000350
-    
+
     
 Class: OEO_00000356
 
@@ -5168,6 +5168,10 @@ Class: OEO_00010117
     
 Class: OEO_00010127
 
+    EquivalentTo: 
+        OEO_00240003
+         and (OEO_00000533 some OEO_00140079)
+    
     
 Class: OEO_00010137
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2726,7 +2726,10 @@ pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
 
 Move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1577
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/1618",
         rdfs:label "secondary energy production"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2730,7 +2730,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
 
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1577
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/1618",
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/1618"
 
 make equivalent and add axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1523


### PR DESCRIPTION
I made secondary energy carrier production an equivalent class by changing secondary energy production to be equivalent to a production and 'has physical output' some 'secondary energy carrier'

## Type of change (CHANGELOG.md)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

## Workflow checklist

### Automation
Closes #1577 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
