### PR TITLE
Added Axioms to energy subclasses #1600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - technology (#1591)
 - quantity value (#1606)
 - secondary energy production (#1619)
-- energy subclasses (#1620)
+- hydro energy, solar energy, wind energy (#1620)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - technology (#1591)
 - quantity value (#1606)
 - secondary energy production (#1619)
+- energy subclasses (#1620)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2433,6 +2433,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     
     SubClassOf: 
         OEO_00230020,
+        OEO_00010121 some OEO_00000441,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3352,7 +3353,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
     
     SubClassOf: 
         OEO_00020040,
-        OEO_00000530 some OEO_00030004
+        OEO_00000530 some OEO_00030004,
+        OEO_00010121 some OEO_00230021
     
     
 Class: OEO_00000386
@@ -3772,6 +3774,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
+        OEO_00010121 some OEO_00000054,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2428,7 +2428,10 @@ Class: OEO_00000218
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
 change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+added axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620",
         rdfs:label "hydro energy"
     
     SubClassOf: 
@@ -3348,7 +3351,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 remove disposition renewable fuel
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
+added axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620",
         rdfs:label "solar energy"
     
     SubClassOf: 
@@ -3768,7 +3774,10 @@ remove disposition renewable fuel
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
 add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+added axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620",
         rdfs:label "wind energy"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Added the following axioms:
'wind energy' 'has bearer' some air
'hydro energy' 'has bearer' some water
'solar energy' 'has bearer' some photon

## Type of change (CHANGELOG.md)

### Updated

## Workflow checklist

### Automation
Closes #1600 

### PR-Assignee
- [x ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
