### PR TITLE
add new econmic concepts

### DIFF
--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -355,6 +355,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
 Class: <http://purl.obolibrary.org/obo/UO_0000187>
 
     
+Class: <http://purl.obolibrary.org/obo/UO_0000189>
+
+    
 Class: <http://purl.obolibrary.org/obo/UO_0000190>
 
     
@@ -371,6 +374,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1482",
     
     SubClassOf: 
         OEO_00020145
+        
+        
+Class: OEO_00350000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A population count is a quantity value to measure the size of a population.",
+        rdfs:label "population count"@en
+        
+    SubClassOf:
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000189>
+        
+        
+Class: OEO_00350001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Annual GDP growth is an economic value that quantifies the difference between GDP in one year compared to the previous year.",
+        rdfs:label "annual GDP growth"@en
+    
+    SubClassOf: 
+        OEO_00140012,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
     
     
 Class: OEO_00000006
@@ -1609,10 +1634,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
 alternative term:
 https://github.com/OpenEnergyPlatform/ontology/issues/675
 https://github.com/OpenEnergyPlatform/ontology/pull/676",
+        rdfs:comment "has unit some currency per time unit",
         rdfs:label "gross domestic product"@en
     
     SubClassOf: 
-        OEO_00140012
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
     
     
 Class: OEO_00140023


### PR DESCRIPTION
## Summary of the discussion

A number of macro-ecnomic and monetary concepts from issue #1487 were added and one definition updated, as agreed upon in the OEO dev meeting.
Since "'has unit' some 'currency per time unit'" could not be implemented directly, it was instead implemented as "has unit some currency" with a comment ("has unit some "currency per time unit"") added to the class.

## Type of change (CHANGELOG.md)

### Added
- Added new class population count (OEO_00350000)
- Added new class annual GDP growth (OEO_00350001)

### Updated
- Updated definition of gross domestic product (OEO_00140013) by adding "'has unit' some 'currency per time unit'"


## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
