### PR TITLE
1554-add-regionalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.X.X] - 20XX-XX-XX
+
+### Added
+- regionalisation (#1639)
+
+### Changed
+
+### Removed
 
 ## [1.16.1] - 2023-08-01
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -438,6 +438,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
         OEO_00020226 some OEO_00000364
     
     
+Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/regionalisation>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies.",
+        rdfs:label "regionalisation"
+    
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-model/OEO_00010250>
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -442,6 +442,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-model/regionalisation>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1554
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1639",
         rdfs:label "regionalisation"
     
     SubClassOf: 


### PR DESCRIPTION
### Added Regionalisation
- Added the new term: regionalisation
- Added the definition: Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies. 

### Automation
Closes #1554 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
