### PR TITLE
add missing scenario subclasses #1329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.X.X] - 20XX-XX-XX
+
+### Added
+- sufficiency scenario (#1642)
+
+### Changed
+- economy, economic scenario, trarget driven scenario, explorative scenario, policy scenario (#1642)
+
+### Removed
 
 ## [1.16.1] - 2023-08-01
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1196,6 +1196,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00010115
+
+    
 Class: OEO_00010213
 
     Annotations: 
@@ -1743,10 +1746,17 @@ Class: OEO_00030008
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of  economic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of economic systems.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344 
+make equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "economic scenario"
+    
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010115)
     
     SubClassOf: 
         OEO_00000364

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1712,13 +1712,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
     
     
 Class: OEO_00020248
-    
+
     
 Class: OEO_00020252
 
     
 Class: OEO_00020309
 
+    
+Class: OEO_00020345
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sufficiency scenario is a scenario that comprises sufficiency strategies.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
+        rdfs:label "sufficiency scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
     
 Class: OEO_00030007
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1697,8 +1697,15 @@ Class: OEO_00020247
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A target driven scenario is a scenario that contains certain target constraints/ statements that in a possible future shall be realized. The path how the targets will be met is not predefined in the scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459
+make equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "target driven scenario"
+    
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020093)
     
     SubClassOf: 
         OEO_00000364

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1712,15 +1712,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
     
     
 Class: OEO_00020248
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An explorative scenario is a scenario that contains certain constraints / statements regarding measures that are taken in the near future / today to explore where these measures will lead to in a later future. The later future is not predefined in the scenario.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459",
-        rdfs:label "explorative scenario"
-    
-    SubClassOf: 
-        OEO_00000364
     
     
 Class: OEO_00020252

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1743,7 +1743,7 @@ Class: OEO_00030008
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of an economic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of  economic system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344",
         rdfs:label "economic scenario"

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2696,7 +2696,7 @@ Class: OEO_00010115
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
 move to oeo-shared, add alternative lable
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "economy"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4066,6 +4066,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
     
     
+Class: OEO_00020248
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An explorative scenario is a scenario that contains certain constraints / statements regarding measures that are taken in the near future / today to explore where these measures will lead to in a later future. The later future is not predefined in the scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
+        rdfs:label "explorative scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
 Class: OEO_00020252
 
     Annotations: 
@@ -4123,16 +4138,17 @@ Class: OEO_00020309
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy scenario is a scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "policy scenario"
     
     EquivalentTo: 
-        OEO_00000364
+        OEO_00020248
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00140149 or OEO_00140151))
     
     SubClassOf: 
-        OEO_00000364
+        OEO_00020248
     
     
 Class: OEO_00020310

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2686,6 +2686,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
         OEO_00000207
     
     
+Class: OEO_00010115
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "economic system",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+move to oeo-shared, add alternative lable
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
+        rdfs:label "economy"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+    
 Class: OEO_00010116
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -686,16 +686,6 @@ Class: OEO_00010083
     
 Class: OEO_00010115
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "economy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
     
 Class: OEO_00010116
 


### PR DESCRIPTION
## Summary of the discussion

Finsh the scenario subclasses from #1329 

## Type of change (CHANGELOG.md)

### Added
- `sufficiency scenario`: _A sufficiency scenario is a scenario that comprises sufficiency strategies._ The class should be made equivalent when #1553 is implemented.

### Updated
- `economy`: moved to oeo-shared and added alternative lable `economic system`
- `economic scenario`: add equivalence axiom `scenario and ('is about' some economy)`
- `target driven scenario`: add equivalence axiom `scenario and ('is about' some 'target description')`
- `explorative scenario`: moved to oeo-shared
- `policy scenario`: make subclass of `explorative scenario`

## Workflow checklist

### Automation
Closes #1329

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
