### PR TITLE
add shared-axioms module

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-shared-axioms.omn" uri="edits/oeo-shared-axioms.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-import-edits.owl" uri="edits/oeo-import-edits.owl"/>
     <uri id="User Entered Import Resolution" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical-axioms.omn" uri="edits/oeo-physical-axioms.owl"/>
     <uri id="User Edited Redirect" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical-axioms.owl" uri="edits/oeo-physical-axioms.owl"/>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn" uri="oeo-social.omn"/>
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn" uri="oeo-model.omn"/>
     <uri id="User Edited Redirect" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn" uri="oeo-physical.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn" uri="oeo-shared.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/iao-minimal-module.owl" uri="../imports/iao-minimal-module.owl"/>

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1,0 +1,15 @@
+Prefix: : <http://www.semanticweb.org/stappel/ontologies/2023/8/untitled-ontology-257/>
+Prefix: owl: <http://www.w3.org/2002/07/owl#>
+Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: xml: <http://www.w3.org/XML/1998/namespace>
+Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+
+Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared-axioms/>
+<http://openenergy-platform.org/ontology/oeo/dev/oeo-shared-axioms.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
+

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1,4 +1,5 @@
 Prefix: : <http://www.semanticweb.org/stappel/ontologies/2023/8/untitled-ontology-257/>
+Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -13,3 +14,316 @@ Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
+Datatype: rdf:PlainLiteral
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000506>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00000514>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00010119>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020180>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020189>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020190>
+
+    
+ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00140002>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000064>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000147>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000199>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000367>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000407>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00000061>
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010296>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00050018>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010404>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020039>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://openenergy-platform.org/ontology/oeo/OEO_00030033>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00010406>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00010296>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00010404>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020003>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000506> some (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00000064>),
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/RO_0002353> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020016>
+
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000274>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020018>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020032>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020035>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020039>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020063>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020180> some <http://openenergy-platform.org/ontology/oeo/OEO_00020154>,
+        <http://openenergy-platform.org/ontology/oeo/OEO_00140002> some <http://openenergy-platform.org/ontology/oeo/OEO_00010079>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020072>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000367>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020018>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020032>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020035>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020097>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020098>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020097>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020098>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020102>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020154>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020166>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000050> some <http://openenergy-platform.org/ontology/oeo/OEO_00020011>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020248>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020267>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00020102>
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/OEO_00020003>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020309>
+
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00020248>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00140149> or <http://openenergy-platform.org/ontology/oeo/OEO_00140151>))
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020313>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020314>
+
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some <http://openenergy-platform.org/ontology/oeo/OEO_00020313>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020317>
+
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000199>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030009>
+
+    EquivalentTo: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000364>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000147>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030029>
+
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020189> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030030>
+
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020190> some <http://openenergy-platform.org/ontology/oeo/OEO_00000275>)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00000350>
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030031>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030032>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030033>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030034>
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030031>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030032>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <http://openenergy-platform.org/ontology/oeo/OEO_00030035>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (<http://openenergy-platform.org/ontology/oeo/OEO_00030033> or <http://purl.obolibrary.org/obo/BFO_0000148>)
+    
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00030035>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050018>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140149>
+
+    
+Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140151>
+
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
+        <http://openenergy-platform.org/ontology/oeo/OEO_00010119> some <http://openenergy-platform.org/ontology/oeo/OEO_00140149>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00030022>
+    
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000006>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000015>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000148>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000027>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000100>
+
+    SubClassOf: 
+        <http://openenergy-platform.org/ontology/oeo/OEO_00000514> some <http://openenergy-platform.org/ontology/oeo/OEO_00020121>
+    
+    

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1345,9 +1345,6 @@ Add 'has licence' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
     
-    SubClassOf: 
-        OEO_00000514 some OEO_00020121
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
 
@@ -2456,8 +2453,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
         rdfs:label "scenario"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00000367
@@ -2550,10 +2546,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
         rdfs:label "technology"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00000061
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>))
+        <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
 Class: OEO_00000419
@@ -2973,8 +2966,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
         rdfs:label "primary energy consumption calculation method"@en
     
     SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
+        OEO_00020166
     
     
 Class: OEO_00010315
@@ -3117,10 +3109,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
         rdfs:label "energy balance"
     
     SubClassOf: 
-        OEO_00000149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 OEO_00030033,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://purl.obolibrary.org/obo/BFO_0000006>
+        OEO_00000149
     
     
 Class: OEO_00010406
@@ -3132,9 +3121,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
         rdfs:label "energy balance calculation method"@en
     
     SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
+        OEO_00020166
     
     
 Class: OEO_00010407
@@ -3284,16 +3271,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
         rdfs:label "study report"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000088>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000506 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064),
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002353> some OEO_00020011
+        <http://purl.obolibrary.org/obo/IAO_0000088>
     
     
 Class: OEO_00020015
@@ -3325,10 +3303,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
         rdfs:label "model descriptor"@en
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
@@ -3346,8 +3320,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
         rdfs:label "methodical focus"@en
     
     SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
+        OEO_00020016
     
     
 Class: OEO_00020032
@@ -3439,9 +3412,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
         rdfs:label "emission certificate"
     
     SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
+        OEO_00020015
     
     
 Class: OEO_00020065
@@ -3552,13 +3523,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286",
         rdfs:label "analysis scope"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020085
@@ -3844,8 +3809,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "methodology"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
+        <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
 Class: OEO_00020175
@@ -4157,10 +4121,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
         rdfs:label "energy technology"
     
     SubClassOf: 
-        OEO_00000407,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00020102
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
+        OEO_00000407
     
     
 Class: OEO_00020309
@@ -4171,11 +4132,6 @@ Class: OEO_00020309
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "policy scenario"
-    
-    EquivalentTo: 
-        OEO_00020248
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00140149 or OEO_00140151))
     
     SubClassOf: 
         OEO_00020248
@@ -4247,10 +4203,6 @@ Class: OEO_00020314
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "reference scenario"
     
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020313)
-    
     SubClassOf: 
         OEO_00000364
     
@@ -4262,10 +4214,6 @@ Class: OEO_00020317
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
         rdfs:label "greenhouse gas emission scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199)
     
     SubClassOf: 
         OEO_00030009
@@ -4372,10 +4320,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
         rdfs:label "emission scenario"
     
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000147)
-    
     SubClassOf: 
         OEO_00000364
     
@@ -4481,13 +4425,8 @@ add relation to quantity value:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
         rdfs:label "exogenous data"
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020189 some OEO_00000275)
-    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+        <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
 Class: OEO_00030030
@@ -4505,13 +4444,8 @@ add relation to quantity value:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
         rdfs:label "endogenous data"
     
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020190 some OEO_00000275)
-    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+        <http://purl.obolibrary.org/obo/IAO_0000027>
     
     
 Class: OEO_00030031
@@ -4580,12 +4514,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         rdfs:label "time series"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
+        <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 Class: OEO_00030035
@@ -5168,12 +5097,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
         rdfs:label "policy instrument"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
+        <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
 Class: OEO_00140159

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -17,6 +17,7 @@ Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-import-edits.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-physical-axioms.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn>
+Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared-axioms.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 


### PR DESCRIPTION
## Summary of the discussion

See #1592.
I added a new module, which contains only intermodular axioms (currently only from `information content artifact` subclasses for testing).

## Type of change (CHANGELOG.md)

### Added
- Added a new class [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Removed
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
