### PR TITLE
add ptx technologies #1592

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - regionalisation (#1639)
 - sufficiency scenario (#1642)
 - New files for new UO v2023-05-25 import process (#1633)
+- power-to-fuel technology and subclasses (#1647)
 
 ### Changed
 - energy transformation (#1625)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8161,6 +8161,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020348
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas technology is a power-to-fuel technology that describes how to combine power-to-gas systems in power-to-gas processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-gas technology"
@@ -8177,6 +8178,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020349
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia technology is an power-to-gas technology that describes how to combine power-to-ammonia systems in power-to-ammonia processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-ammonia technology"
@@ -8193,6 +8195,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020350
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane technology is an power-to-gas technology that describes how to combine power-to-methane systems in power-to-methane processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-methane technology"
@@ -8209,6 +8212,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020351
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid technology is an power-to-fuel technology that describes how to combine power-to-liquid systems in power-to-liquid processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-liquid technology"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3146,7 +3146,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
     
 Class: OEO_00000333
 
-      
+    
 Class: OEO_00000334
 
     
@@ -8138,6 +8138,60 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
         OEO_00030009
     
     
+Class: OEO_00020346
+
+    Annotations: 
+        rdfs:label "fuel generation technology"
+    
+    SubClassOf: 
+        OEO_00020267
+    
+    
+Class: OEO_00020347
+
+    Annotations: 
+        rdfs:label "power-to-x technology"
+    
+    SubClassOf: 
+        OEO_00020346
+    
+    
+Class: OEO_00020348
+
+    Annotations: 
+        rdfs:label "power-to-gas technology"
+    
+    SubClassOf: 
+        OEO_00020347
+    
+    
+Class: OEO_00020349
+
+    Annotations: 
+        rdfs:label "power-to-ammonia technology"
+    
+    SubClassOf: 
+        OEO_00020348
+    
+    
+Class: OEO_00020350
+
+    Annotations: 
+        rdfs:label "power-to-methane technology"
+    
+    SubClassOf: 
+        OEO_00020348
+    
+    
+Class: OEO_00020351
+
+    Annotations: 
+        rdfs:label "power-to-liquid technology"
+    
+    SubClassOf: 
+        OEO_00020347
+    
+    
 Class: OEO_00030000
 
     Annotations: 
@@ -10307,9 +10361,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310022
 
     Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         OEO_00040001 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flat-plate collector is a solar thermal collector that consists of flat-plates.",
         rdfs:label "flat-plate collector"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8138,27 +8138,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
         OEO_00030009
     
     
-Class: OEO_00020346
+Class: OEO_00020347
 
     Annotations: 
-        rdfs:label "fuel generation technology"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel technology is an energy technology that describes how to combine power-to-fuel systems in power-to-fuel processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "p2x technology",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-x technology",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "ptx technology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
+        rdfs:label "power-to-fuel technology"
     
     SubClassOf: 
         OEO_00020267
     
     
-Class: OEO_00020347
-
-    Annotations: 
-        rdfs:label "power-to-x technology"
-    
-    SubClassOf: 
-        OEO_00020346
-    
-    
 Class: OEO_00020348
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-gas technology"
     
     SubClassOf: 
@@ -8168,6 +8167,8 @@ Class: OEO_00020348
 Class: OEO_00020349
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-ammonia technology"
     
     SubClassOf: 
@@ -8177,6 +8178,8 @@ Class: OEO_00020349
 Class: OEO_00020350
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-methane technology"
     
     SubClassOf: 
@@ -8186,6 +8189,8 @@ Class: OEO_00020350
 Class: OEO_00020351
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-liquid technology"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8149,6 +8149,11 @@ Class: OEO_00020347
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-fuel technology"
     
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00330009
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330007))
+    
     SubClassOf: 
         OEO_00020267
     
@@ -8159,6 +8164,11 @@ Class: OEO_00020348
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-gas technology"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00000335
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216))
     
     SubClassOf: 
         OEO_00020347
@@ -8171,6 +8181,11 @@ Class: OEO_00020349
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-ammonia technology"
     
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00330010
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222))
+    
     SubClassOf: 
         OEO_00020348
     
@@ -8182,6 +8197,11 @@ Class: OEO_00020350
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-methane technology"
     
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00000269
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010217))
+    
     SubClassOf: 
         OEO_00020348
     
@@ -8192,6 +8212,11 @@ Class: OEO_00020351
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-liquid technology"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00010020
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330008))
     
     SubClassOf: 
         OEO_00020347

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8149,13 +8149,11 @@ Class: OEO_00020347
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-fuel technology"
     
-    EquivalentTo: 
+    SubClassOf: 
+        OEO_00020267,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00330009
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330007))
-    
-    SubClassOf: 
-        OEO_00020267
     
     
 Class: OEO_00020348
@@ -8166,13 +8164,11 @@ Class: OEO_00020348
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-gas technology"
     
-    EquivalentTo: 
+    SubClassOf: 
+        OEO_00020347,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00000335
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010216))
-    
-    SubClassOf: 
-        OEO_00020347
     
     
 Class: OEO_00020349
@@ -8183,13 +8179,11 @@ Class: OEO_00020349
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-ammonia technology"
     
-    EquivalentTo: 
+    SubClassOf: 
+        OEO_00020348,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00330010
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010222))
-    
-    SubClassOf: 
-        OEO_00020348
     
     
 Class: OEO_00020350
@@ -8200,13 +8194,11 @@ Class: OEO_00020350
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-methane technology"
     
-    EquivalentTo: 
+    SubClassOf: 
+        OEO_00020348,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00000269
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010217))
-    
-    SubClassOf: 
-        OEO_00020348
     
     
 Class: OEO_00020351
@@ -8217,13 +8209,11 @@ Class: OEO_00020351
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         rdfs:label "power-to-liquid technology"
     
-    EquivalentTo: 
+    SubClassOf: 
+        OEO_00020347,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00010020
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330008))
-    
-    SubClassOf: 
-        OEO_00020347
     
     
 Class: OEO_00030000


### PR DESCRIPTION
## Summary of the discussion
Add power-to-fuel technologies and subclasses, see #1572.

## Type of change (CHANGELOG.md)

### Added
- `power-to-fuel technology` as subclass of `energy technology`
- `power-to-gas technology` as subclass of `power-to-x technology`
- `power-to-ammonia technology` as subclass of `power-to-gas technology`
- `power-to-methane technology` as subclass of `power-to-gas technology`
- `power-to-liquid technology` as subclass of `power-to-x technology`

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
