### PR TITLE
move classes from oeo-shared(-axioms) to original modules

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,7 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,8 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
-
+        <uri id="Automatically generated entry, Timestamp=1695908201901" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1695908201901" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -13,5 +13,6 @@
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
         <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
         <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+
     </group>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,7 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -64,6 +64,12 @@ Currently, it covers the `ro-extracted.owl`-file which is a subset of the Relati
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
+
+    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+    
+
+
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00140002 -->
 
     <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00140002"/>
@@ -231,9 +237,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0003301"/>
     
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
-
-    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -252,9 +255,27 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
+    
+
+
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020143 -->
 
     <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020143"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
     
 
 
@@ -326,22 +347,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>
     </owl:Class>
     
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-    
 
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
+    <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
-    
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -353,41 +362,51 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000088 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000100 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000100">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000310 -->
+
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -410,5 +429,5 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</obo:IAO_
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi -->
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2582,3 +2582,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         OEO_00140167
     
     
+Class: OEO_00030015
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "energy system model"@en
+    
+    SubClassOf: 
+        OEO_00000274

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -663,6 +663,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
     
 Class: OEO_00000119
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
+		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724
+		move to oeo-shared
+		issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+		rework module structure 
+		issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "data descriptor"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 Class: OEO_00000120
 
@@ -742,6 +758,23 @@ source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
     
 Class: OEO_00000149
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical data set is a dataset that is obtained from observations in the real world."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Move to oeo-shared and harmonise label:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "empirical data set"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    DisjointWith: 
+        OEO_00000403
+    
     
 Class: OEO_00000161
 
@@ -829,6 +862,23 @@ Class: OEO_00000239
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00000264
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy market model"
+    
+    SubClassOf: 
+        OEO_00000274
     
     
 Class: OEO_00000274
@@ -1144,6 +1194,9 @@ Class: OEO_00000392
     
 Class: OEO_00000403
 
+    DisjointWith: 
+        OEO_00000149
+    
     
 Class: OEO_00000408
 
@@ -1794,6 +1847,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
     SubClassOf: 
         OEO_00000364
+    
+    
+Class: OEO_00030015
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+        rdfs:label "energy system model"@en
+    
+    SubClassOf: 
+        OEO_00000274
     
     
 Class: OEO_00030024
@@ -2582,14 +2648,3 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         OEO_00140167
     
     
-Class: OEO_00030015
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        OEO_00000274

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1548,6 +1548,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1544",
     
 Class: OEO_00010412
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "creative work licence"@en
+    
+    SubClassOf: 
+        OEO_00020185
+    
     
 Class: OEO_00010422
 
@@ -1588,8 +1602,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
         OEO_00030030
     
     
+Class: OEO_00020015
+
+    
 Class: OEO_00020016
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+
+Add SubclassOf axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "model descriptor"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 Class: OEO_00020017
 
@@ -1608,6 +1647,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
     
 Class: OEO_00020018
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "methodical focus"@en
+    
+    SubClassOf: 
+        OEO_00020016,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
+    
     
 Class: OEO_00020019
 
@@ -1869,11 +1925,76 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020166
 
     
+Class: OEO_00020185
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
+issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "copyright licence"
+    
+    SubClassOf: 
+        OEO_00020015
+    
+    
 Class: OEO_00020186
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "data licence"
+    
+    SubClassOf: 
+        OEO_00020015
+    
     
 Class: OEO_00020187
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "software licence"
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
+        OEO_00020185
+    
     
 Class: OEO_00020227
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -883,9 +883,50 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000274
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
+
+add axiom to model calculation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "model"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
     
 Class: OEO_00000275
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "model calculation"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00140093 some OEO_00030029,
+        OEO_00140094 some OEO_00030030,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
+    
     
 Class: OEO_00000276
 
@@ -1072,6 +1113,29 @@ Class: OEO_00000353
     
 Class: OEO_00000364
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+add is about-relation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'narrative' and 'storyline' as alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "scenario"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
+    
     
 Class: OEO_00000365
 
@@ -1194,6 +1258,21 @@ Class: OEO_00000392
     
 Class: OEO_00000403
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic data set is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real-world dataset."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Harmonise label:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "synthetic data set"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
     DisjointWith: 
         OEO_00000149
     
@@ -1213,6 +1292,23 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00000419
 
+    
+Class: OEO_00000423
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity transshipment model"
+    
+    SubClassOf: 
+        OEO_00000274
+    
     
 Class: OEO_00000432
 
@@ -1363,12 +1459,44 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
     
 Class: OEO_00010296
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "primary energy consumption calculation method"@en
+    
+    SubClassOf: 
+        OEO_00020166
+    
     
 Class: OEO_00010362
 
     
 Class: OEO_00010404
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance is an empirical data set that describes a specified set of energy transformations and a specified set of energy carriers in a spatial region for a specific time step (usually a year).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy balance"
+    
+    SubClassOf: 
+        OEO_00000149,
+        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 OEO_00030033,
+        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://purl.obolibrary.org/obo/BFO_0000006>
+    
     
 Class: OEO_00010405
 
@@ -1387,6 +1515,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00010406
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance calculation method is a methodology to calculate an energy balance.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy balance calculation method"@en
+    
+    SubClassOf: 
+        OEO_00020166,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
+    
     
 Class: OEO_00010407
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1925,7 +1925,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
@@ -2473,10 +2472,6 @@ make equivalent
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
         rdfs:label "economic scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010115)
     
     SubClassOf: 
         OEO_00000364

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2525,7 +2525,10 @@ Class: OEO_00030015
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "energy system model"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1231,9 +1231,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000367
 
     
-Class: OEO_00000368
-
-    
 Class: OEO_00000370
 
     Annotations: 
@@ -1421,9 +1418,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: OEO_00010115
-
-    
 Class: OEO_00010213
 
     Annotations: 
@@ -1551,8 +1545,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00020166
-
-
+    
+    
 Class: OEO_00010297
 
     Annotations: 
@@ -1563,8 +1557,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
     
     SubClassOf: 
         OEO_00010296
-		
-
+    
+    
 Class: OEO_00010298
 
     Annotations: 
@@ -1575,8 +1569,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
     
     SubClassOf: 
         OEO_00010296
-		
-
+    
+    
 Class: OEO_00010299
 
     Annotations: 
@@ -1587,8 +1581,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
     
     SubClassOf: 
         OEO_00010296
-
-		
+    
+    
 Class: OEO_00010362
 
     
@@ -1642,9 +1636,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
     
-    
-Class: OEO_00010407
-
     
 Class: OEO_00010411
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -95,6 +95,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
     
@@ -2203,12 +2206,165 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
     
 Class: OEO_00020248
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An explorative scenario is a scenario that contains certain constraints / statements regarding measures that are taken in the near future / today to explore where these measures will lead to in a later future. The later future is not predefined in the scenario.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "explorative scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
     
 Class: OEO_00020252
 
     
 Class: OEO_00020309
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy scenario is a scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "policy scenario"
+    
+    SubClassOf: 
+        OEO_00020248
+    
+    
+Class: OEO_00020310
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A without measures scenario (WOM) is a policy scenario that excludes all policy instruments and transformative measures which are planned, adopted or implemented.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "without measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
+    
+    
+Class: OEO_00020311
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A with existing measures scenario (WEM) is a policy scenario that includes policy instruments and transformative measures that have been adopted and implemented.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WEM scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "with existing measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
+    
+    
+Class: OEO_00020312
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A with additional measures scenario (WAM) is a policy scenario that includes policy instruments and transformative measures which have been adopted and implemented to mitigate climate change or meet energy objectives, as well as policy instruments and transformative measures which are planned for that purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "WAM scenario",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "with additional measures scenario"
+    
+    SubClassOf: 
+        OEO_00020309
+    
+    
+Class: OEO_00020313
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an information content entity, that indicates a benchmark, e.g. in a comparison.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Although contradicting to BFO2, we add the reference role to the generically dependent \"information content entity\", aware of the ongoing discussion.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "reference role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00020314
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference scenario is a scenario that is used as a reference, e.g. in a scenario comparison. It has the reference role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "reference scenario"
+    
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020313)
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
+Class: OEO_00020317
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission scenario is an emission scenario that describes a possible greenhouse gas emission trajectory.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "greenhouse gas emission scenario"
+    
+    SubClassOf: 
+        OEO_00030009
+    
+    
+Class: OEO_00020321
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission scenario is an emission scenario that describes a possible CO2 emission trajectory.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "CO2 emission scenario"
+    
+    SubClassOf: 
+        OEO_00030009
+    
     
 Class: OEO_00020345
 
@@ -2264,6 +2420,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
     
 Class: OEO_00030009
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
+
+move to oeo-share
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission scenario"
+    
+    SubClassOf: 
+        OEO_00000364
+    
     
 Class: OEO_00030010
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -261,6 +261,9 @@ ObjectProperty: OEO_00000522
         OEO_00020011
     
     
+ObjectProperty: OEO_00010121
+
+    
 ObjectProperty: OEO_00010378
 
     Annotations: 
@@ -283,6 +286,12 @@ ObjectProperty: OEO_00020056
 
     
 ObjectProperty: OEO_00020188
+
+    
+ObjectProperty: OEO_00020189
+
+    
+ObjectProperty: OEO_00020190
 
     
 ObjectProperty: OEO_00020220
@@ -2091,12 +2100,67 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
     
 Class: OEO_00020121
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "resolution"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/IAO_0000100>
+    
     
 Class: OEO_00020122
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
+
+add individuals
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "temporal resolution"
+    
+    SubClassOf: 
+        OEO_00020121,
+        OEO_00010121 some OEO_00030034
+    
     
 Class: OEO_00020123
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "spatial resolution"
+    
+    SubClassOf: 
+        OEO_00020121
+    
     
 Class: OEO_00020166
 
@@ -2478,9 +2542,60 @@ Class: OEO_00030024
     
 Class: OEO_00030029
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "exogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (OEO_00020189 some OEO_00000275)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+    
     
 Class: OEO_00030030
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
+
+make equivalent class
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
+
+add relation to quantity value:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "endogenous data"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+         and (OEO_00020190 some OEO_00000275)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
+    
     
 Class: OEO_00030031
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1552,7 +1552,10 @@ Class: OEO_00010297
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "substitution method"@en
     
     SubClassOf: 
@@ -1564,7 +1567,10 @@ Class: OEO_00010298
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "direct equivalent method"@en
     
     SubClassOf: 
@@ -1576,7 +1582,10 @@ Class: OEO_00010299
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is a method to calculate primary energy consumption that quantifies renewable and nuclear energies by attributing an efficiency value each.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "physical method"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1551,8 +1551,44 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00020166
+
+
+Class: OEO_00010297
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+        rdfs:label "substitution method"@en
     
+    SubClassOf: 
+        OEO_00010296
+		
+
+Class: OEO_00010298
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+        rdfs:label "direct equivalent method"@en
     
+    SubClassOf: 
+        OEO_00010296
+		
+
+Class: OEO_00010299
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is a method to calculate primary energy consumption that quantifies renewable and nuclear energies by attributing an efficiency value each.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
+        rdfs:label "physical method"@en
+    
+    SubClassOf: 
+        OEO_00010296
+
+		
 Class: OEO_00010362
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1736,6 +1736,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1302",
     
 Class: OEO_00020032
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "study region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
     
 Class: OEO_00020033
 
@@ -1769,6 +1787,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
     
 Class: OEO_00020035
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "considered region"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
     
 Class: OEO_00020036
 
@@ -1793,6 +1829,30 @@ Class: OEO_00020039
     
 Class: OEO_00020072
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+
+Add 'is about' axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "analysis scope"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
+    
     
 Class: OEO_00020089
 
@@ -1872,9 +1932,46 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
     
 Class: OEO_00020097
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "scenario year"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
+             and (OEO_00140178 value 1))
+    
     
 Class: OEO_00020098
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "scenario horizon"
+    
+    SubClassOf: 
+        OEO_00030033,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some 
+            (OEO_00030035
+             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
+    
     
 Class: OEO_00020099
 
@@ -1921,6 +2018,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
         OEO_00030034,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097
     
+    
+Class: OEO_00020121
+
+    
+Class: OEO_00020122
+
+    
+Class: OEO_00020123
+
     
 Class: OEO_00020166
 
@@ -2778,6 +2884,76 @@ Individual: OEO_00020029
     
     Types: 
         OEO_00020018
+    
+    
+Individual: OEO_00020161
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "annual"
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: OEO_00020162
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "weekly"
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: OEO_00020163
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "daily"
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: OEO_00020164
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "hourly"
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: OEO_00020165
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "monthly"
+    
+    Types: 
+        OEO_00020122
     
     
 Individual: OEO_00140045

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -609,9 +609,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000036>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-    
     
 Class: OEO_00000031
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2140,6 +2140,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00020121,
         OEO_00010121 some OEO_00030034
     
+    DisjointWith: 
+        OEO_00020123
+    
     
 Class: OEO_00020123
 
@@ -2156,6 +2159,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00020121
+    
+    DisjointWith: 
+        OEO_00020122
     
     
 Class: OEO_00020166

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -35,6 +35,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -160,12 +163,76 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
     
 ObjectProperty: OEO_00000514
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+rework
+issue https://github.com/OpenEnergyPlatform/ontology/issues/849
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has resolution"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020121
+    
     
 ObjectProperty: OEO_00000515
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has spatial resolution"
+    
+    SubPropertyOf: 
+        OEO_00000514
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020123
+    
     
 ObjectProperty: OEO_00000516
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
+def and axioms
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
+fix def and add domain and range
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has temporal resolution"
+    
+    SubPropertyOf: 
+        OEO_00000514
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    Range: 
+        OEO_00020122
+    
     
 ObjectProperty: OEO_00000517
 
@@ -2243,15 +2310,93 @@ Class: OEO_00030030
     
 Class: OEO_00030031
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "start time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
     
 Class: OEO_00030032
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "ending time"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
     
 Class: OEO_00030033
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an ending time and thus a finite duration.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "time step"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000038>,
+        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
+    
     
 Class: OEO_00030034
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000584",
+        rdfs:label "time series"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
+    
     
 Class: OEO_00030035
 
@@ -2310,9 +2455,45 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
     
 Class: OEO_00140043
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "time stamp"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000148>
+    
     
 Class: OEO_00140044
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "time stamp alignment"@en
+    
+    SubClassOf: 
+        OEO_00000119
+    
     
 Class: OEO_00140068
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -842,6 +842,33 @@ Class: <http://purl.obolibrary.org/obo/UO_0010006>
     
 Class: OEO_00000001
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
+        rdfs:label "fuel role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00000331
+    
     
 Class: OEO_00000003
 
@@ -887,6 +914,28 @@ Class: OEO_00000005
     
 Class: OEO_00000006
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16526",
+        rdfs:label "carbon dioxide"
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
+        OEO_00000529 value OEO_00000182
+    
     
 Class: OEO_00000007
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -127,6 +127,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002328>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
 
     
@@ -939,6 +942,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000007
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000023",
+        rdfs:label "chemical energy"
+    
+    SubClassOf: 
+        OEO_00000150
+    
     
 Class: OEO_00000008
 
@@ -998,6 +1022,40 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
     
 Class: OEO_00000011
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+renaming to component
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+redefine
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
+        rdfs:label "energy converting component"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
+    
     
 Class: OEO_00000012
 
@@ -1033,6 +1091,31 @@ Class: OEO_00000013
     
 Class: OEO_00000014
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000099
+         and (OEO_00000530 some OEO_00030002)
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
+        OEO_00000099,
+        OEO_00000530 some OEO_00030003
+    
     DisjointWith: 
         OEO_00000072
     
@@ -1112,6 +1195,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000020
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+Add global warming potential axiom:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "greenhouse gas"
+    
+    EquivalentTo: 
+        OEO_00000331
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000524 some OEO_00010078,
+        OEO_00000529 value OEO_00000182
+    
     
 Class: OEO_00000021
 
@@ -1271,6 +1381,40 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000031
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+more precise axioms
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "power plant"
+    
+    EquivalentTo: 
+        OEO_00020102
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334)
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240014
+    
     
 Class: OEO_00000032
 
@@ -1638,6 +1782,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000061
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
+subclasses
+https://github.com/OpenEnergyPlatform/ontology/pull/128
+relation to space requirement
+https://github.com/OpenEnergyPlatform/ontology/pull/933
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "artificial object"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000030>,
+        <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
+    
     
 Class: OEO_00000062
 
@@ -1935,9 +2098,54 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1406",
     
 Class: OEO_00000097
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'realized in' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "combustible energy carrier disposition"
+    
+    SubClassOf: 
+        OEO_00000151,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140033
+    
     
 Class: OEO_00000099
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/931
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "combustion fuel"
+    
+    EquivalentTo: 
+        OEO_00000173
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
+    
+    SubClassOf: 
+        OEO_00000173
+    
     
 Class: OEO_00000102
 
@@ -1956,6 +2164,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
     
 Class: OEO_00000115
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024
+
+Add petroleum as alternative label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "crude oil"
+    
+    SubClassOf: 
+        OEO_00000331,
+        OEO_00000530 some OEO_00030002,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000529 value OEO_00000256
+    
     
 Class: OEO_00000117
 
@@ -2041,12 +2279,98 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
     
 Class: OEO_00000139
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
+
+alternative term electricity:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
+
+add commodity role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+add axiom to electricity im/exports:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+move class to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000020",
+        rdfs:label "electrical energy"
+    
+    SubClassOf: 
+        OEO_00000150,
+        OEO_00020182 some OEO_00020207,
+        OEO_00020182 some OEO_00020208,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
     
 Class: OEO_00000143
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+updated part relation between electricity grid and power line to have simple restrictions:
+
+replace min 1 restriction by some restriction
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1479
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity grid"
+    
+    SubClassOf: 
+        OEO_00000200,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000253
+    
     
 Class: OEO_00000144
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity grid component"
+    
+    EquivalentTo: 
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
+    
+    SubClassOf: 
+        OEO_00020006
+    
     
 Class: OEO_00000146
 
@@ -2077,15 +2401,114 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
     
 Class: OEO_00000147
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00000500 some OEO_00000148
+    
     
 Class: OEO_00000148
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission factor"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147,
+        OEO_00000502 some <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     
 Class: OEO_00000150
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
+fix grammar error:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
+adjust definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Add bearer:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00000530 some OEO_00000316,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00000151
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+
+add has bearer axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy carrier disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+    
     
 Class: OEO_00000159
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2566,6 +2566,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
     
 Class: OEO_00000173
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+add role fuel commodity
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+shorten definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187
+
+Add good role:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "fuel"
+    
+    EquivalentTo: 
+        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117
+    
     
 Class: OEO_00000174
 
@@ -2733,6 +2766,31 @@ The production of other coal gases (i.e. coke oven gas, blast furnace gas and ox
     
 Class: OEO_00000188
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "generator"
+    
+    SubClassOf: 
+        OEO_00000011,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
+    
     
 Class: OEO_00000189
 
@@ -2786,12 +2844,93 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000198
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
+
+Add 'realized in' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
+        rdfs:label "greenhouse effect disposition"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some 
+            (OEO_00000331
+             and (OEO_00000531 value OEO_00000182)),
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
+    
     
 Class: OEO_00000199
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
+
+make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "greenhouse gas emission"
+    
+    EquivalentTo: 
+        OEO_00000147
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020)
+    
+    SubClassOf: 
+        OEO_00000147
+    
     
 Class: OEO_00000200
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "supply grid"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>
+    
     
 Class: OEO_00000204
 
@@ -2822,8 +2961,51 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000021
     
     
+Class: OEO_00000206
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "hardware"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114
+    
+    
 Class: OEO_00000207
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000032",
+        rdfs:label "thermal energy"@en
+    
+    SubClassOf: 
+        OEO_00000150
+    
     
 Class: OEO_00000210
 
@@ -3132,9 +3314,44 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000253
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "power line"@en
+    
+    SubClassOf: 
+        OEO_00000255,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+    
     
 Class: OEO_00000255
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "grid component link"
+    
+    SubClassOf: 
+        OEO_00020006
+    
     DisjointWith: 
         OEO_00000296
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3587,12 +3587,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
     
 Class: OEO_00000423
 
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00000143
-    
     
 Class: OEO_00000425
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2806,7 +2806,11 @@ Class: OEO_00000189
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geographic coordinate system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "geographic coordinate"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13174,6 +13174,129 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
     SubClassOf: 
         OEO_00320072,
         OEO_00020056 some OEO_00000159
+
+    
+Class: OEO_00240019
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "energy consumption value"
+    
+    SubClassOf: 
+        OEO_00050019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
+
+Class: OEO_00240014
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Add alternative label and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity generation process"
+    
+     EquivalentTo: 
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000139)
+
+Class: OEO_00010116
+Class: OEO_00240003
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+reclassify and make equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "production"
+    
+    EquivalentTo: 
+        OEO_00000419
+         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
+         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
+    
+    SubClassOf: 
+        OEO_00000419,
+        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
+
+Class: OEO_00140159
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "hydrocarbon"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+
+Class: OEO_00020181
+
+Class: OEO_00140081
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+has quantity value axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to social cost of carbon
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission value"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147,
+        OEO_00020180 some OEO_00020181,
+        OEO_00140002 some OEO_00010079
+
 Class: OEO_00320002
 
     Annotations: 
@@ -13203,6 +13326,7 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "transport performance unit"
+
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12185,15 +12185,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
 
 Move to oeo-shared:
 https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4094,9 +4094,6 @@ Class: OEO_00000361
         OEO_00000165
     
     
-Class: OEO_00000364
-
-    
 Class: OEO_00000374
 
     Annotations: 
@@ -4392,9 +4389,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         OEO_00020006,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
     
-    
-Class: OEO_00000423
-
     
 Class: OEO_00000425
 
@@ -7219,18 +7213,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
         OEO_00020085
     
     
-Class: OEO_00010296
-
-    
-Class: OEO_00010297
-    
-    
-Class: OEO_00010298
-    
-    
-Class: OEO_00010299
-    
-    
 Class: OEO_00010300
 
     Annotations: 
@@ -8955,12 +8937,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
         OEO_00010234 only OEO_00000191
     
     
-Class: OEO_00020066
-
-    
-Class: OEO_00020068
-
-    
 Class: OEO_00020073
 
     Annotations: 
@@ -9435,9 +9411,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00020175
     
-    
-Class: OEO_00020181
-
     
 Class: OEO_00020196
 
@@ -10073,9 +10046,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
         OEO_00030000,
         OEO_00010121 some OEO_00000331
     
-    
-Class: OEO_00030009
-
     
 Class: OEO_00030019
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10077,15 +10077,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030009
 
     
-Class: OEO_00030015
-
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00030024
-    
-    
 Class: OEO_00030019
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7223,39 +7223,12 @@ Class: OEO_00010296
 
     
 Class: OEO_00010297
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A substitution method is a primary energy consumption calculation method that treats renewable energy carriers as if they have similar conversion losses as a specified fossil reference energy carrier.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
-        rdfs:label "substitution method"@en
-    
-    SubClassOf: 
-        OEO_00010296
     
     
 Class: OEO_00010298
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A direct equivalent method is a primary energy consumption calculation method that quantifies renewable and nuclear energies using its secondary energy content assuming no conversion losses.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
-        rdfs:label "direct equivalent method"@en
-    
-    SubClassOf: 
-        OEO_00010296
     
     
 Class: OEO_00010299
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A physical method is a method to calculate primary energy consumption that quantifies renewable and nuclear energies by attributing an efficiency value each.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306",
-        rdfs:label "physical method"@en
-    
-    SubClassOf: 
-        OEO_00010296
     
     
 Class: OEO_00010300

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8965,9 +8965,6 @@ Class: OEO_00020066
 
     
 Class: OEO_00020068
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
     
     
 Class: OEO_00020073

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -759,6 +759,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000017>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000018>
 
     
@@ -6078,6 +6081,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000207
     
     
+Class: OEO_00010116
+
+    
 Class: OEO_00010117
 
     
@@ -9470,9 +9476,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
             (OEO_00310008
              and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>))
     
-
-
-    
     
 Class: OEO_00020347
 
@@ -9649,6 +9652,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
     
     
 Class: OEO_00030019
+
+    
+Class: OEO_00030022
 
     
 Class: OEO_00030024
@@ -9981,6 +9987,25 @@ Class: OEO_00050018
     
 Class: OEO_00050019
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+moved to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy amount value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
+    
     
 Class: OEO_00050020
 
@@ -10159,12 +10184,142 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
     
 Class: OEO_00140003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+add performance axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1271
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000125",
+        rdfs:label "transport"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        OEO_00140002 some OEO_00320000,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000323 or OEO_00010116)
+    
+    
+Class: OEO_00140004
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "international transport"@en
+    
+    SubClassOf: 
+        OEO_00140003
+    
     
 Class: OEO_00140005
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Add axiom for goods as participant:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "freight transport"@en
+    
+    SubClassOf: 
+        OEO_00140003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
+    
+    
+Class: OEO_00140006
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "private transport"
+    
+    SubClassOf: 
+        OEO_00010263
+    
+    
+Class: OEO_00140007
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
+
+Make subclass of 'passenger transport'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "public transport"
+    
+    SubClassOf: 
+        OEO_00010263
+    
     
 Class: OEO_00140033
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "chemical reaction"@en
+    
+    SubClassOf: 
+        OEO_00000419,
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00140034
 
@@ -10234,12 +10389,92 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
     
 Class: OEO_00140039
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "consumption"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00140040
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "demand"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000017>,
+        OEO_00010121 some 
+            (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
+    
     
 Class: OEO_00140049
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
+
+moved to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy conversion efficiency"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003,
+        OEO_00140002 some OEO_00140050
+    
     
 Class: OEO_00140050
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
+
+moved to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
+
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "efficiency value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
     
 Class: OEO_00140051
 
@@ -10437,9 +10672,45 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
     
 Class: OEO_00140075
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "primary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
     
 Class: OEO_00140076
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "secondary energy carrier disposition"@en
+    
+    SubClassOf: 
+        OEO_00000151
+    
     
 Class: OEO_00140077
 
@@ -10474,6 +10745,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
     
 Class: OEO_00140079
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
+fix error in definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "secondary energy carrier"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
+    
+    SubClassOf: 
+        OEO_00020039
+    
     
 Class: OEO_00140080
 
@@ -11268,8 +11563,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
 Class: OEO_00240019
 
     
+Class: OEO_00240022
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "protected area"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
 Class: OEO_00240024
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand"
+    
+    SubClassOf: 
+        OEO_00140040,
+        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
+    
     
 Class: OEO_00240026
 
@@ -11407,6 +11733,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
     
     
+Class: OEO_00240038
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "personal living space"
+    
+    SubClassOf: 
+        OEO_00020136
+    
+    
 Class: OEO_00260001
 
     Annotations: 
@@ -11455,6 +11797,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
     
 Class: OEO_00260007
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "CO2 emission"@en
+    
+    EquivalentTo: 
+        OEO_00000147
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000006)
+    
+    SubClassOf: 
+        OEO_00000147
+    
     
 Class: OEO_00290000
 
@@ -12048,8 +12411,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
     
     
+Class: OEO_00320000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "transport performance value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00320001
+    
+    
 Class: OEO_00320001
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "transport performance unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+Class: OEO_00320002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+
+Add pkm as synonym:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
+        rdfs:label "passenger-kilometre"
+    
+    SubClassOf: 
+        OEO_00320001
+    
     
 Class: OEO_00320003
 
@@ -12625,6 +13036,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
     
     
 Class: OEO_00320041
+
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
@@ -12639,7 +13051,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000020>,
         OEO_00010121 some OEO_00010023
-
+    
     
 Class: OEO_00320042
 
@@ -13175,78 +13587,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         OEO_00320072,
         OEO_00020056 some OEO_00000159
 
-    
-Class: OEO_00240019
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        OEO_00050019,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
-
-Class: OEO_00240014
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-Add alternative label and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "electricity generation process"
-    
-     EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
-
-Class: OEO_00010116
-Class: OEO_00240003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-reclassify and make equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "production"
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
-
 Class: OEO_00140159
 
     Annotations: 
@@ -13268,9 +13608,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000331,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-
-Class: OEO_00020181
-
+Class:  OEO_00020181
 Class: OEO_00140081
 
     Annotations: 
@@ -13296,129 +13634,76 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000502 some OEO_00000147,
         OEO_00020180 some OEO_00020181,
         OEO_00140002 some OEO_00010079
-
-Class: OEO_00320002
+    
+Class: OEO_00240003
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-Add pkm as synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+reclassify and make equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
-        rdfs:label "passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-
-Class: OEO_00320001
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "transport performance unit"
-
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-Class: OEO_00320000
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "transport performance value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00320001
-
-Class: OEO_00260007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "CO2 emission"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en
+        rdfs:label "production"
     
     EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000006)
+        OEO_00000419
+         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
+         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
     
     SubClassOf: 
-        OEO_00000147
+        OEO_00000419,
+        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
 
-Class: OEO_00240038
+Class: OEO_00240014
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Add alternative label and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "personal living space"
+        rdfs:label "electricity generation process"
     
-    SubClassOf: 
-        OEO_00020136
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000139)
 
-Class: OEO_00140040
-
-Class: OEO_00000051
-
-Class: OEO_00240024
+Class: OEO_00240019
 
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "energy service demand"
-    
-    SubClassOf: 
-        OEO_00140040,
-        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
 
-Class: OEO_00240022
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "protected area"
+        rdfs:label "energy consumption value"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-
+        OEO_00050019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
+    
+    
 Individual: OEO_00000182
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8747,6 +8747,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00020039
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy carrier"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00020040
 
@@ -8999,6 +9021,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
     
 Class: OEO_00020085
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+Move to oeo-shared:
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable energy"
+    
+    EquivalentTo: 
+        OEO_00000150
+         and (OEO_00000530 some OEO_00030004)
+    
+    SubClassOf: 
+        OEO_00000150
+    
     DisjointWith: 
         OEO_00010295
     
@@ -9048,6 +9091,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
     
 Class: OEO_00020102
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy transformation unit"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
+    
     
 Class: OEO_00020103
 
@@ -9065,6 +9132,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
     
 Class: OEO_00020104
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "outage"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+    
     
 Class: OEO_00020105
 
@@ -9100,9 +9185,41 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
     
 Class: OEO_00020107
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "curtailment"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
+    
     
 Class: OEO_00020136
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+
+extend definition and add alternative term
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "space requirement"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
     
 Class: OEO_00020137
 
@@ -9132,6 +9249,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
     
 Class: OEO_00020140
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "area per power unit"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 Class: OEO_00020141
 
@@ -9145,6 +9275,42 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
     SubClassOf: 
         OEO_00000350,
         OEO_00040010 some OEO_00020140
+    
+    
+Class: OEO_00020142
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "square kilometer"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000047>
+    
+    
+Class: OEO_00020143
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "area value"
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
     
     
 Class: OEO_00020144
@@ -9229,6 +9395,76 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185",
     
     
 Class: OEO_00020166
+
+    
+Class: OEO_00020175
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "life time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020176
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "construction time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020177
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "decommissioning time"
+    
+    SubClassOf: 
+        OEO_00030035,
+        OEO_00020056 some OEO_00000061
+    
+    
+Class: OEO_00020178
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "operational life time"
+    
+    SubClassOf: 
+        OEO_00020175
+    
+    
+Class: OEO_00020181
 
     
 Class: OEO_00020196
@@ -9323,11 +9559,101 @@ Class: OEO_00020201
 Class: OEO_00020202
 
     
+Class: OEO_00020204
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electrical energy amount value"
+    
+    SubClassOf: 
+        OEO_00050019
+    
+    
+Class: OEO_00020205
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity import value"
+    
+    SubClassOf: 
+        OEO_00020204,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020207
+    
+    
+Class: OEO_00020206
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity export value"
+    
+    SubClassOf: 
+        OEO_00020204,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020208
+    
+    
 Class: OEO_00020207
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity import"
+    
+    SubClassOf: 
+        OEO_00020201,
+        OEO_00140002 some OEO_00020205,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
+    
     
 Class: OEO_00020208
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity export"
+    
+    SubClassOf: 
+        OEO_00020202,
+        OEO_00140002 some OEO_00020206,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
+    
     
 Class: OEO_00020210
 
@@ -9377,6 +9703,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
     
 Class: OEO_00020252
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542
+
+move to oeo-share
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
+A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
+        rdfs:label "climate system"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
     
 Class: OEO_00020254
 
@@ -9421,8 +9765,45 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
         OEO_00020056 some OEO_00020254
     
     
+Class: OEO_00020264
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "material transformation"
+    
+    EquivalentTo: 
+        OEO_00000419
+         and (OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>)
+         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
+    
+    SubClassOf: 
+        OEO_00000419
+    
+    
 Class: OEO_00020267
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy technology is a technology that describes how to combine energy transformation units, energy transformations, energy carriers and energy in a specific way.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy technology"
+    
+    SubClassOf: 
+        OEO_00000407,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00020102
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
+    
     
 Class: OEO_00020306
 
@@ -9593,15 +9974,105 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
     
 Class: OEO_00030002
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+Update definition and add disjoint:
+https://github.com/OpenEnergyPlatform/ontology/issues/872
+https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Shift part of the definition into an editor note:
+Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "fossil"
+    
+    SubClassOf: 
+        OEO_00030003,
+        OEO_00010121 some OEO_00000331
+    
     DisjointWith: 
         OEO_00030001
     
     
 Class: OEO_00030003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+Update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "geogenic"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some 
+            (OEO_00000150 or OEO_00000331)
+    
     
 Class: OEO_00030004
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
+include \"or energies\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable"
+    
+    SubClassOf: 
+        OEO_00000316,
+        OEO_00010121 some OEO_00000150
+    
     DisjointWith: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
@@ -9651,9 +10122,48 @@ Class: OEO_00030022
     
 Class: OEO_00030024
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
+
+make subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy system"
+    
+    SubClassOf: 
+        OEO_00030025
+    
     
 Class: OEO_00030025
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "supply system"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
     
 Class: OEO_00030026
 
@@ -9976,6 +10486,38 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
     
 Class: OEO_00050018
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+make energy consumption value:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "primary energy consumption"@en
+    
+    SubClassOf: 
+        OEO_00240019,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
+        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
+    
     
 Class: OEO_00050019
 
@@ -10420,6 +10962,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
             (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
     
     
+Class: OEO_00140040
+
+    
 Class: OEO_00140049
 
     Annotations: 
@@ -10781,6 +11326,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
     
 Class: OEO_00140081
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+has quantity value axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to social cost of carbon
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission value"@en
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00000147,
+        OEO_00020180 some OEO_00020181,
+        OEO_00140002 some OEO_00010079
+    
     
 Class: OEO_00140082
 
@@ -11101,6 +11670,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
     
 Class: OEO_00140159
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "hydrocarbon"@en
+    
+    SubClassOf: 
+        OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+    
     
 Class: OEO_00140160
 
@@ -11370,6 +11959,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
     
 Class: OEO_00240003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
+reclassify and make equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "production"
+    
+    EquivalentTo: 
+        OEO_00000419
+         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
+         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
+    
+    SubClassOf: 
+        OEO_00000419,
+        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
+    
     
 Class: OEO_00240009
 
@@ -11490,7 +12102,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
 Class: OEO_00240014
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation"
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+Add alternative label and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity generation process"
+    
+    EquivalentTo: 
+        OEO_00020003
+         and (OEO_00010235 some OEO_00000139)
     
     SubClassOf: 
         OEO_00020003,
@@ -11553,6 +12186,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
     
     
 Class: OEO_00240019
+
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "energy consumption value"
+    
+    SubClassOf: 
+        OEO_00050019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
 
     
 Class: OEO_00240022
@@ -11740,6 +12392,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00020136
     
+ 
     
 Class: OEO_00260001
 
@@ -13579,6 +14232,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         OEO_00320072,
         OEO_00020056 some OEO_00000159
 
+
 Class: OEO_00140159
 
     Annotations: 
@@ -13694,6 +14348,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     SubClassOf: 
         OEO_00050019,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
+
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1700,6 +1700,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         OEO_00000126
     
     
+Class: OEO_00000051
+
+    
 Class: OEO_00000054
 
     Annotations: 
@@ -3807,6 +3810,9 @@ Class: OEO_00000322
         OEO_00000331,
         OEO_00000530 some OEO_00030000
     
+    
+Class: OEO_00000323
+
     
 Class: OEO_00000324
 
@@ -6801,6 +6807,78 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
     
 Class: OEO_00010263
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "passenger transport"
+    
+    SubClassOf: 
+        OEO_00140003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000323
+             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
+    
+    
+Class: OEO_00010264
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "passenger"
+    
+    SubClassOf: 
+        OEO_00000051,
+        OEO_00010121 some OEO_00000323
+    
+    
+Class: OEO_00010265
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand for passenger-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
+    
+    
+Class: OEO_00010266
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand for ton-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
+    
     
 Class: OEO_00010267
 
@@ -7272,9 +7350,62 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
     
 Class: OEO_00010315
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+make subclass of secondary energy production and further changes:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "mineral oil refining process"
+    
+    SubClassOf: 
+        OEO_00010127,
+        OEO_00000532 some OEO_00000115,
+        OEO_00000533 some OEO_00010316,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000007,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
+    
     
 Class: OEO_00010316
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+Add 'secondary energy carrier disposition' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "mineral oil product"
+    
+    EquivalentTo: 
+        OEO_00000014
+         and (OEO_00240025 some OEO_00010315)
+    
+    SubClassOf: 
+        OEO_00000014,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+    
     
 Class: OEO_00010317
 
@@ -7501,8 +7632,46 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         OEO_00010336
     
     
+Class: OEO_00010361
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable power unit"@en
+    
+    EquivalentTo: 
+        OEO_00000334
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00010234 some OEO_00020085
+    
+    
 Class: OEO_00010362
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable power plant"@en
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
+    
+    SubClassOf: 
+        OEO_00000031
+    
     
 Class: OEO_00010379
 
@@ -7624,9 +7793,43 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
     
 Class: OEO_00010385
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy transformation function"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000034>,
+        OEO_00010121 some OEO_00000061
+    
     
 Class: OEO_00010386
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity generation function"@en
+    
+    SubClassOf: 
+        OEO_00010385
+    
     
 Class: OEO_00010387
 
@@ -7643,6 +7846,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445",
     
 Class: OEO_00010388
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable energy transformation function"@en
+    
+    SubClassOf: 
+        OEO_00010385
+    
     
 Class: OEO_00010392
 
@@ -8310,6 +8529,70 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00020003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
+
+make class a subclass of transformation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+add input and output relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+add relation to energy transformation unit:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+add axiom relating to energy carrier / input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
+
+make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+added process attributes:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "energy transformation"@en
+    
+    EquivalentTo: 
+        OEO_00000419
+         and (OEO_00010234 some OEO_00000150)
+         and (OEO_00010235 some OEO_00000150)
+    
+    SubClassOf: 
+        OEO_00000419,
+        OEO_00000500 some OEO_00000333,
+        OEO_00000500 some OEO_00140049,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+    
     
 Class: OEO_00020004
 
@@ -8341,6 +8624,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
     
 Class: OEO_00020006
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
     
 Class: OEO_00020007
 
@@ -9867,6 +10167,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
     
+Class: OEO_00140003
+
+    
 Class: OEO_00140005
 
     
@@ -10973,6 +11276,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
     
     
 Class: OEO_00240019
+
+    
+Class: OEO_00240024
 
     
 Class: OEO_00240026

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3712,6 +3712,41 @@ Class: OEO_00000311
     
 Class: OEO_00000316
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
+
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+change definition and add comment with examples:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
+* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
+* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
+        rdfs:label "origin"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some 
+            (OEO_00000150 or OEO_00000331)
+    
     
 Class: OEO_00000318
 
@@ -3806,6 +3841,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000331
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
+
+definition update and editor note:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000027>,
+        OEO_00000530 some OEO_00000316
+    
     
 Class: OEO_00000332
 
@@ -3835,9 +3899,78 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
     
 Class: OEO_00000333
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369
+
+moved to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"
+    
+    SubClassOf: 
+        OEO_00030019,
+        OEO_00000502 some OEO_00020003
+    
     
 Class: OEO_00000334
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
+
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+remove \"among other parts from definition\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1258
+pull request: https://github.com/OpenEnergyPlatform/ontology/issues/1259
+
+New function-based definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "power generating unit"
+    
+    EquivalentTo: 
+        OEO_00020102
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
+    
+    SubClassOf: 
+        OEO_00020102,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010235 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
+    
     
 Class: OEO_00000335
 
@@ -4130,6 +4263,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
     
 Class: OEO_00000395
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39
+
+add 'has bearer' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "state of matter"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some OEO_00000331
+    
     
 Class: OEO_00000396
 
@@ -4911,6 +5068,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
     
 Class: OEO_00010023
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+Add vehicle operational mode axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000604",
+        rdfs:label "vehicle"
+    
+    SubClassOf: 
+        OEO_00000061,
+        OEO_00010235 some OEO_00010114,
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
+    
     
 Class: OEO_00010024
 
@@ -5216,9 +5400,43 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
     
 Class: OEO_00010078
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
+
+move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1410
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "global warming potential"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
+    
     
 Class: OEO_00010079
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission quantity value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
+    
     
 Class: OEO_00010080
 
@@ -5828,12 +6046,68 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
     
 Class: OEO_00010114
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813
+
+change label and definition language
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "waste thermal energy"
+    
+    SubClassOf: 
+        OEO_00000207
+    
     
 Class: OEO_00010117
 
     
 Class: OEO_00010127
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
+pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+make equivalent and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1523
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1619
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "secondary energy production"@en
+    
+    EquivalentTo: 
+        OEO_00240003
+         and (OEO_00000533 some OEO_00140079)
+    
+    SubClassOf: 
+        OEO_00240003,
+        OEO_00000533 some OEO_00140079,
+        OEO_00140002 some OEO_00050019,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003
+    
     
 Class: OEO_00010137
 
@@ -6141,12 +6415,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
     
 Class: OEO_00010210
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
+
+Add alternative label:
+https://github.com/OpenEnergyPlatform/ontology/pull/1321
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
+    
     DisjointWith: 
         OEO_00010211
     
     
 Class: OEO_00010211
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
+
+add 'has participant axiom':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "non-energy use"@en
+    
+    SubClassOf: 
+        OEO_00140039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
+    
     DisjointWith: 
         OEO_00010210
     
@@ -11985,6 +12303,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00320036
     
+    
+Class: OEO_00320041
+
     
 Class: OEO_00320042
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11630,6 +11630,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000032>
     
     
+Class: OEO_00140146
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy demand"@en
+    
+    SubClassOf: 
+        OEO_00140040
+    
+    
 Class: OEO_00140159
 
     Annotations: 
@@ -12443,6 +12460,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     SubClassOf: 
         OEO_00000147
+    
+    
+Class: OEO_00260008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission value is greenhouse gas emission value that quantifies the output of a CO2 emission process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "CO2 emission value"@en,
+        rdfs:label "carbon dioxide emission value"@en
+    
+    SubClassOf: 
+        OEO_00140081
     
     
 Class: OEO_00290000
@@ -14013,6 +14047,38 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00320001
+    
+    
+Class: OEO_00320062
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity demand"
+    
+    SubClassOf: 
+        OEO_00140146
+    
+    
+Class: OEO_00320063
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "fuel demand"
+    
+    SubClassOf: 
+        OEO_00140146
     
     
 Class: OEO_00320064

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9467,21 +9467,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
             (OEO_00310008
              and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010248>))
     
-    
-Class: OEO_00020321
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission scenario is an emission scenario that describes a possible CO2 emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "CO2 emission scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00260007)
-    
-    SubClassOf: 
-        OEO_00030009
+
     
     
 Class: OEO_00020347

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8041,7 +8041,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     SubClassOf: 
         OEO_00000115
-  
+    
     
 Class: OEO_00010410
 
@@ -8980,13 +8980,13 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     SubClassOf: 
         OEO_00140101,
         OEO_00010234 only OEO_00000191
-
+    
     
 Class: OEO_00020066
 
     
 Class: OEO_00020068
-    
+
     
 Class: OEO_00020073
 
@@ -10225,7 +10225,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
     
 Class: OEO_00030035
 
-
+    
 Class: OEO_00050000
 
     Annotations: 
@@ -10954,9 +10954,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00010121 some 
             (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
     
-    
-Class: OEO_00140040
-
     
 Class: OEO_00140049
 
@@ -12180,7 +12177,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
     
 Class: OEO_00240019
 
-
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
@@ -12193,12 +12189,20 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1463
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "energy consumption value"
     
     SubClassOf: 
         OEO_00050019,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
-
+    
     
 Class: OEO_00240022
 
@@ -12407,7 +12411,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00020136
     
- 
     
 Class: OEO_00260001
 
@@ -14249,125 +14252,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
     SubClassOf: 
         OEO_00320072,
         OEO_00020056 some OEO_00000159
-
-
-Class: OEO_00140159
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "hydrocarbon"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-
-
-
-Class: OEO_00140081
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-has quantity value axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to social cost of carbon
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00140002 some OEO_00010079
-    
-Class: OEO_00240003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-reclassify and make equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "production"
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
-
-Class: OEO_00240014
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-Add alternative label and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "electricity generation process"
-    
-    EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
-
-Class: OEO_00240019
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        OEO_00050019,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
-
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -765,6 +765,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000018>
 Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000020>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
@@ -12045,6 +12048,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
     
     
+Class: OEO_00320001
+
+    
+Class: OEO_00320003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+
+Add tkm as synonym:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tkm",
+        rdfs:label "ton-kilometre"
+    
+    SubClassOf: 
+        OEO_00320001
+    
+    
 Class: OEO_00320004
 
     Annotations: 
@@ -12598,6 +12625,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
     
     
 Class: OEO_00320041
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
+        rdfs:label "vehicle operational mode"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        OEO_00010121 some OEO_00010023
 
     
 Class: OEO_00320042
@@ -12915,6 +12956,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000220
     
     
+Class: OEO_00320061
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Vehicle-kilometre is a transport performance unit for the accumulated transport distance of the used vehicles themselves where one vehicle-kilometre equals the transport distance of 1 km for one vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
+
+restructure modules:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "vkm",
+        rdfs:comment "Can be obtained from passenger-kilometre/ton-kilometre by dividing through the average number of passengers/tons per vehicle respectively.",
+        rdfs:label "vehicle-kilometre"
+    
+    SubClassOf: 
+        OEO_00320001
+    
+    
 Class: OEO_00320064
 
     Annotations: 
@@ -13115,13 +13174,155 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
     SubClassOf: 
         OEO_00320072,
         OEO_00020056 some OEO_00000159
+Class: OEO_00320002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+
+Add pkm as synonym:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
+        rdfs:label "passenger-kilometre"
     
+    SubClassOf: 
+        OEO_00320001
+
+Class: OEO_00320001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "transport performance unit"
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+Class: OEO_00320000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "transport performance value"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some OEO_00320001
+
+Class: OEO_00260007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "CO2 emission"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en
+    
+    EquivalentTo: 
+        OEO_00000147
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000006)
+    
+    SubClassOf: 
+        OEO_00000147
+
+Class: OEO_00240038
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "personal living space"
+    
+    SubClassOf: 
+        OEO_00020136
+
+Class: OEO_00140040
+
+Class: OEO_00000051
+
+Class: OEO_00240024
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand"
+    
+    SubClassOf: 
+        OEO_00140040,
+        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
+
+Class: OEO_00240022
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "protected area"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+
 Individual: OEO_00000182
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390,
+restructure modules:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "gaseous"
+    
+    Types: 
+        OEO_00000395
+    
     
 Individual: OEO_00000256
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has no definite shape but a definite volume (at a given temperature and pressure).",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "restructure modules:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "liquid"
+    
+    Types: 
+        OEO_00000395
+    
     
 Individual: OEO_00000326
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13600,7 +13600,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000331,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-Class:  OEO_00020181
+
+
 Class: OEO_00140081
 
     Annotations: 
@@ -13624,7 +13625,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00030019,
         OEO_00000502 some OEO_00000147,
-        OEO_00020180 some OEO_00020181,
         OEO_00140002 some OEO_00010079
     
 Class: OEO_00240003

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8028,8 +8028,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "Brent crude"@en
     
     SubClassOf: 
-        OEO_00000115,
-        OEO_00020070 some OEO_00020060
+        OEO_00000115
     
     
 Class: OEO_00010409
@@ -8042,9 +8041,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         rdfs:label "Western Texas Intermediate"@en
     
     SubClassOf: 
-        OEO_00000115,
-        OEO_00020070 some OEO_00020060
-    
+        OEO_00000115
+  
     
 Class: OEO_00010410
 
@@ -8961,9 +8959,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     SubClassOf: 
         OEO_00140101,
         OEO_00010234 only OEO_00000191
-    
-    
-Class: OEO_00020060
 
     
 Class: OEO_00020066

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2325,8 +2325,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     SubClassOf: 
         OEO_00000150,
         OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+        OEO_00020182 some OEO_00020208
     
     
 Class: OEO_00000143
@@ -10226,13 +10225,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
     
 Class: OEO_00030035
 
-    
-Class: OEO_00040009
 
-    
-Class: OEO_00040011
-
-    
 Class: OEO_00050000
 
     Annotations: 
@@ -12248,10 +12241,6 @@ Class: OEO_00240026
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
         rdfs:label "industrial material"
     
-    EquivalentTo: 
-        (OEO_00240025 some OEO_00050000)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-    
     SubClassOf: 
         OEO_00000331
     
@@ -12262,14 +12251,17 @@ Class: OEO_00240027
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "chemical substance"
     
     SubClassOf: 
         OEO_00000331,
         OEO_00240025 some OEO_00050000,
-        OEO_00240025 some OEO_00140033,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+        OEO_00240025 some OEO_00140033
     
     
 Class: OEO_00240028
@@ -12278,13 +12270,16 @@ Class: OEO_00240028
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "paper"
     
     SubClassOf: 
         OEO_00000331,
         OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
         OEO_00000529 value OEO_00000390
     
     
@@ -12294,13 +12289,16 @@ Class: OEO_00240029
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "cement"
     
     SubClassOf: 
         OEO_00000331,
         OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
         OEO_00000529 value OEO_00000390
     
     
@@ -12310,7 +12308,11 @@ Class: OEO_00240030
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "mineral"
     
     SubClassOf: 
@@ -12324,13 +12326,16 @@ Class: OEO_00240031
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "non-metallic mineral"
     
     SubClassOf: 
         OEO_00240030,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+        OEO_00240025 some OEO_00050000
     
     
 Class: OEO_00240032
@@ -12339,7 +12344,11 @@ Class: OEO_00240032
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "metal"
     
     SubClassOf: 
@@ -12352,13 +12361,16 @@ Class: OEO_00240034
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "steel"
     
     SubClassOf: 
         OEO_00240032,
         OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011,
         OEO_00000529 value OEO_00000390
     
     
@@ -12368,13 +12380,16 @@ Class: OEO_00240035
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "non-ferrous metal"
     
     SubClassOf: 
         OEO_00240032,
-        OEO_00240025 some OEO_00050000,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+        OEO_00240025 some OEO_00050000
     
     
 Class: OEO_00240038
@@ -13399,7 +13414,11 @@ Class: OEO_00320021
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "transport network component"@en
     
     EquivalentTo: 
@@ -13407,8 +13426,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
          and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016)
     
     SubClassOf: 
-        OEO_00000061,
-        OEO_00020180 some OEO_00040009
+        OEO_00000061
     
     
 Class: OEO_00320022
@@ -14254,6 +14272,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000331,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+
 
 
 Class: OEO_00140081

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11337,7 +11337,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00030019,
         OEO_00000502 some OEO_00000147,
-        OEO_00020180 some OEO_00020181,
         OEO_00140002 some OEO_00010079
     
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1431,139 +1431,18 @@ Class: OEO_00000006
     
 Class: OEO_00000007
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000023",
-        rdfs:label "chemical energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
     
 Class: OEO_00000011
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-renaming to component
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-redefine
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
-        rdfs:label "energy converting component"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
-    
     
 Class: OEO_00000014
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000099,
-        OEO_00000530 some OEO_00030003
-    
     
 Class: OEO_00000020
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add global warming potential axiom:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000524 some OEO_00010078,
-        OEO_00000529 value OEO_00000182
-    
     
 Class: OEO_00000031
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-more precise axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "power plant"
-    
-    EquivalentTo: 
-        OEO_00020102
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334)
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240014
-    
     
 Class: OEO_00000051
 
@@ -1586,26 +1465,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
     
 Class: OEO_00000061
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
-subclasses
-https://github.com/OpenEnergyPlatform/ontology/pull/128
-relation to space requirement
-https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>,
-        <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
     
 Class: OEO_00000064
 
-Class: OEO_00000107
-
-Class: OEO_00000323
     
 Class: OEO_00000087
 
@@ -1620,260 +1482,42 @@ Class: OEO_00000087
     
 Class: OEO_00000097
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'realized in' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140033
-    
     
 Class: OEO_00000099
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/931
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "combustion fuel"
     
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
-    
-    SubClassOf: 
-        OEO_00000173
+Class: OEO_00000107
 
-    
     
 Class: OEO_00000115
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-Add petroleum as alternative label:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000256
-    
     
 Class: OEO_00000119
 
     
 Class: OEO_00000139
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
-
-alternative term electricity:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
-
-add commodity role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
-
-add axiom to electricity im/exports:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-move class to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000020",
-        rdfs:label "electrical energy"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
     
 Class: OEO_00000143
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360
-
-updated part relation between electricity grid and power line to have simple restrictions:
-
-replace min 1 restriction by some restriction
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1479",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000253
-    
     
 Class: OEO_00000144
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
-    
-    SubClassOf: 
-        OEO_00020006
-    
     
 Class: OEO_00000147
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000500 some OEO_00000148
-    
     
 Class: OEO_00000148
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission factor"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00000502 some <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Class: OEO_00000149
 
     
 Class: OEO_00000150
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
-fix grammar error:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
-adjust definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Add bearer:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00000530 some OEO_00000316,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 Class: OEO_00000151
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
-    
     
 Class: OEO_00000173
 
@@ -2158,7 +1802,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
         OEO_00010121 some 
             (OEO_00000150 or OEO_00000331)
     
+    
+Class: OEO_00000323
 
+    DisjointWith: 
+        OEO_00000315
+    
     
 Class: OEO_00000331
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1497,175 +1497,27 @@ Class: OEO_00000151
     
 Class: OEO_00000173
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-add role fuel commodity
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-shorten definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187
-
-Add good role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117
-    
     
 Class: OEO_00000188
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
-    
     
 Class: OEO_00000198
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-
-Add 'realized in' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
-        rdfs:label "greenhouse effect disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some 
-            (OEO_00000331
-             and (OEO_00000531 value OEO_00000182)),
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
-    
     
 Class: OEO_00000199
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "greenhouse gas emission"
-    
-    EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020)
-    
-    SubClassOf: 
-        OEO_00000147
-    
     
 Class: OEO_00000200
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
 Class: OEO_00000206
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114
-    
     
 Class: OEO_00000207
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000032",
-        rdfs:label "thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00000150
-    
     
 Class: OEO_00000238
 
@@ -1682,36 +1534,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
     
 Class: OEO_00000253
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        OEO_00000255,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
     
 Class: OEO_00000255
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        OEO_00020006
-    
     
 Class: OEO_00000264
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1425,50 +1425,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
     
 Class: OEO_00000001
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
-        rdfs:label "fuel role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00010121 some OEO_00000331
-    
     
 Class: OEO_00000006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16526",
-        rdfs:label "carbon dioxide"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        OEO_00000529 value OEO_00000182
-    
     
 Class: OEO_00000007
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1445,23 +1445,6 @@ Class: OEO_00000031
 
     
 Class: OEO_00000051
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "agent"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00010121 some 
-            (OEO_00000323 or OEO_00030022)
-    
     
 Class: OEO_00000061
 
@@ -1470,15 +1453,6 @@ Class: OEO_00000064
 
     
 Class: OEO_00000087
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
-        rdfs:label "client"
-    
-    SubClassOf: 
-        OEO_00000051
-    
     
 Class: OEO_00000097
 
@@ -2140,26 +2114,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
     
     
 Class: OEO_00010083
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-update definition and improve axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market participant"@en
-    
-    SubClassOf: 
-        OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
-    
     
 Class: OEO_00010114
 
@@ -2955,29 +2909,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     
 Class: OEO_00020069
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market exchange"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    SubClassOf: 
-        OEO_00030022,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019"
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (OEO_00010082
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
-    
     
 Class: OEO_00020072
 
@@ -4302,17 +4233,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
     
     
 Class: OEO_00140009
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
-        rdfs:label "sponsor"@en
-    
-    SubClassOf: 
-        OEO_00000051
-    
     
 Class: OEO_00140012
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -84,7 +84,7 @@ AnnotationProperty: dc:description
     
 AnnotationProperty: dc:identifier
 
-
+    
 AnnotationProperty: dc:license
 
     
@@ -2207,12 +2207,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
         rdfs:label "model"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some <http://purl.obolibrary.org/obo/BFO_0000004>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000275
+        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000275
@@ -4383,16 +4378,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
 Class: OEO_00030015
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        OEO_00000274
-    
     
 Class: OEO_00030019
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1709,20 +1709,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
     
 Class: OEO_00000119
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
-        rdfs:label "data descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00000139
 
@@ -1842,20 +1828,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956",
     
 Class: OEO_00000149
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical data set is a dataset that is obtained from observations in the real world."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Move to oeo-shared and harmonise label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "empirical data set"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000403
-    
     
 Class: OEO_00000150
 
@@ -2139,15 +2111,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
     
 Class: OEO_00000264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "energy market model"
-    
     SubClassOf: 
-        OEO_00000274
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        OEO_00140164 some OEO_00020065
     
     
 Class: OEO_00000274
@@ -2487,9 +2455,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000149
     
     
 Class: OEO_00000407

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -2104,43 +2104,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
     
 Class: OEO_00000274
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
-
-add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "model"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
     
 Class: OEO_00000275
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
-        rdfs:label "model calculation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140093 some OEO_00030029,
-        OEO_00140094 some OEO_00030030,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
-    
     
 Class: OEO_00000315
 
@@ -2334,25 +2300,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00000364
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'narrative' and 'storyline' as alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
-    
     
 Class: OEO_00000367
 
@@ -2416,17 +2363,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
 Class: OEO_00000403
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic data set is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real-world dataset."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Harmonise label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "synthetic data set"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
     
 Class: OEO_00000407
 
@@ -2468,15 +2404,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
     
 Class: OEO_00000423
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "electricity transshipment model"
-    
     SubClassOf: 
-        OEO_00000274
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
+        OEO_00140164 some OEO_00000143
     
     
 Class: OEO_00010023
@@ -2853,18 +2785,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
     
 Class: OEO_00010296
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "primary energy consumption calculation method"@en
-    
     SubClassOf: 
-        OEO_00020166,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
     
     
@@ -3001,32 +2922,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
 Class: OEO_00010404
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance is an empirical data set that describes a specified set of energy transformations and a specified set of energy carriers in a spatial region for a specific time step (usually a year).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance"
-    
     SubClassOf: 
-        OEO_00000149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 OEO_00030033,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://purl.obolibrary.org/obo/BFO_0000006>
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020039
     
     
 Class: OEO_00010406
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance calculation method is a methodology to calculate an energy balance.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance calculation method"@en
-    
-    SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
-    
     
 Class: OEO_00010407
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1601,17 +1601,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/933",
         <http://purl.obolibrary.org/obo/BFO_0000030>,
         <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
     
-    
 Class: OEO_00000064
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
-        rdfs:label "author"
-    
-    SubClassOf: 
-        OEO_00000051
-    
+Class: OEO_00000107
+
+Class: OEO_00000323
     
 Class: OEO_00000087
 
@@ -1665,17 +1659,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     SubClassOf: 
         OEO_00000173
-    
-    
-Class: OEO_00000107
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
-        rdfs:label "contact person"
-    
-    SubClassOf: 
-        OEO_00000051
     
     
 Class: OEO_00000115
@@ -2208,20 +2192,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
         OEO_00010121 some 
             (OEO_00000150 or OEO_00000331)
     
-    
-Class: OEO_00000323
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
-        rdfs:label "person"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    DisjointWith: 
-        OEO_00000315
-    
     
 Class: OEO_00000331
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1335,23 +1335,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 
+    SubClassOf: 
+        OEO_00020188 some OEO_00010412
+    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-
-Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     SubClassOf: 
-        OEO_00000514 some OEO_00020121
+        OEO_00000514 some OEO_00020121,
+        OEO_00020188 some OEO_00020186
     
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
 
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000310>
+
+    SubClassOf: 
+        OEO_00020188 some OEO_00010412
+    
     
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
@@ -2547,16 +2549,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00010412
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "creative work licence"@en
-    
-    SubClassOf: 
-        OEO_00020185
-    
     
 Class: OEO_00020003
 
@@ -2693,57 +2685,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
     
 Class: OEO_00020015
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
-move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "licence"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00020016
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-
-Add SubclassOf axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00020018
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
-    
     
 Class: OEO_00020032
 
@@ -3293,61 +3240,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020185
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "copyright licence"
-    
-    SubClassOf: 
-        OEO_00020015
+        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license"
     
     
 Class: OEO_00020186
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "data licence"
-    
-    SubClassOf: 
-        OEO_00020015
-    
     
 Class: OEO_00020187
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "software licence"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        OEO_00020185
-    
     
 Class: OEO_00020201
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1211,16 +1211,6 @@ Class: <http://purl.obolibrary.org/obo/RO_0002577>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537
-renaming
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:comment "The original definition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
-    
     
 Class: <http://purl.obolibrary.org/obo/UO_0000001>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1119,25 +1119,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000040>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000027>
 
-    Annotations: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/823
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/826"
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data item is an information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "http://www.ontobee.org/ontology/IAO?iri=http://purl.obolibrary.org/obo/IAO_0000027"
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Delete axiom has (copyright) licence:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 
@@ -1350,9 +1334,6 @@ Class: OEO_00020181
     
 Class: OEO_00020185
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license"
-    
     
 Class: OEO_00020186
 
@@ -1411,13 +1392,6 @@ Class: OEO_00030009
 Class: OEO_00030015
 
     SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
         OEO_00140164 some OEO_00030024
     
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1842,62 +1842,15 @@ Class: OEO_00010211
     
 Class: OEO_00010263
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
-    
     
 Class: OEO_00010264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        OEO_00000051,
-        OEO_00010121 some OEO_00000323
-    
     
 Class: OEO_00010265
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
-    
     
 Class: OEO_00010266
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
-    
     
 Class: OEO_00010268
 
@@ -1957,134 +1910,24 @@ Class: OEO_00010296
     
 Class: OEO_00010315
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-make subclass of secondary energy production and further changes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil refining process"
-    
-    SubClassOf: 
-        OEO_00010127,
-        OEO_00000532 some OEO_00000115,
-        OEO_00000533 some OEO_00010316,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
-    
     
 Class: OEO_00010316
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add 'secondary energy carrier disposition' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil product"
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00240025 some OEO_00010315)
-    
-    SubClassOf: 
-        OEO_00000014,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
     
 Class: OEO_00010361
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power unit"@en
-    
-    EquivalentTo: 
-        OEO_00000334
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00010234 some OEO_00020085
-    
     
 Class: OEO_00010362
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power plant"@en
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
-    
-    SubClassOf: 
-        OEO_00000031
-    
     
 Class: OEO_00010385
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "energy transformation function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>,
-        OEO_00010121 some OEO_00000061
-    
     
 Class: OEO_00010386
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity generation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010388
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy transformation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010404
 
@@ -2113,82 +1956,9 @@ Class: OEO_00010412
     
 Class: OEO_00020003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-added process attributes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625"@en,
-        rdfs:label "energy transformation"@en
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00010234 some OEO_00000150)
-         and (OEO_00010235 some OEO_00000150)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000500 some OEO_00000333,
-        OEO_00000500 some OEO_00140049,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
     
 Class: OEO_00020006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
     
 Class: OEO_00020011
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -2048,9 +2048,6 @@ Class: OEO_00320061
     
 Class: OEO_00320074
 
-    SubClassOf: 
-        OEO_00020178
-    
     
 Class: OEO_00340004
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1571,8 +1571,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         rdfs:label "quantity value"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00000364
@@ -3522,153 +3521,33 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
     
 Class: OEO_00240022
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
-        rdfs:label "protected area"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
     
 Class: OEO_00240024
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
-        rdfs:label "energy service demand"
-    
-    SubClassOf: 
-        OEO_00140040,
-        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
-    
     
 Class: OEO_00240038
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "personal living space"
-    
-    SubClassOf: 
-        OEO_00020136
-    
     
 Class: OEO_00260007
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615"@en,
-        rdfs:label "CO2 emission"@en,
-        rdfs:label "carbon dioxide emission"@en
-    
-    EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000006)
-    
-    SubClassOf: 
-        OEO_00000147
-    
     
 Class: OEO_00320000
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
-        rdfs:label "transport performance value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00320001
-    
     
 Class: OEO_00320001
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289",
-        rdfs:label "transport performance unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 Class: OEO_00320002
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-Add pkm as synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
-        rdfs:label "passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320003
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-Add tkm as synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tkm",
-        rdfs:label "ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320041
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
-        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
-        rdfs:label "vehicle operational mode"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
-        OEO_00010121 some OEO_00010023
-    
     
 Class: OEO_00320061
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Vehicle-kilometre is a transport performance unit for the accumulated transport distance of the used vehicles themselves where one vehicle-kilometre equals the transport distance of 1 km for one vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "vkm",
-        rdfs:comment "Can be obtained from passenger-kilometre/ton-kilometre by dividing through the average number of passengers/tons per vehicle respectively.",
-        rdfs:label "vehicle-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320073
 
@@ -3702,28 +3581,9 @@ Class: OEO_00340005
     
 Individual: OEO_00000182
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "gaseous"
-    
-    Types: 
-        OEO_00000395
-    
     
 Individual: OEO_00000256
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has no definite shape but a definite volume (at a given temperature and pressure).",
-        rdfs:label "liquid"
-    
-    Types: 
-        OEO_00000395
-    
     
 Individual: OEO_00020161
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -2993,27 +2993,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
     
 Class: OEO_00140081
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-has quantity value axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to social cost of carbon
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00020180 some OEO_00020181,
-        OEO_00140002 some OEO_00010079
-    
     
 Class: OEO_00140124
 
@@ -3081,85 +3060,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
     
 Class: OEO_00140159
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "hydrocarbon"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
-    
     
 Class: OEO_00240003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-reclassify and make equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575",
-        rdfs:label "production"
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
-    
     
 Class: OEO_00240014
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-Add alternative label and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
-        rdfs:label "electricity generation process"
-    
-    EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
-    
     
 Class: OEO_00240019
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        OEO_00050019,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
-    
     
 Class: OEO_00240022
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1456,9 +1456,6 @@ Class: OEO_00000199
     
 Class: OEO_00000200
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
     
 Class: OEO_00000206
 
@@ -2570,18 +2567,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
     
 Class: OEO_00020248
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An explorative scenario is a scenario that contains certain constraints / statements regarding measures that are taken in the near future / today to explore where these measures will lead to in a later future. The later future is not predefined in the scenario.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "explorative scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00020252
 
@@ -2637,110 +2622,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
     
 Class: OEO_00020309
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy scenario is a scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "policy scenario"
-    
     EquivalentTo: 
         OEO_00020248
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00140149 or OEO_00140151))
     
-    SubClassOf: 
-        OEO_00020248
-    
     
 Class: OEO_00020310
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A without measures scenario (WOM) is a policy scenario that excludes all policy instruments and transformative measures which are planned, adopted or implemented.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "without measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020311
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A with existing measures scenario (WEM) is a policy scenario that includes policy instruments and transformative measures that have been adopted and implemented.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WEM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "with existing measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020312
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A with additional measures scenario (WAM) is a policy scenario that includes policy instruments and transformative measures which have been adopted and implemented to mitigate climate change or meet energy objectives, as well as policy instruments and transformative measures which are planned for that purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WAM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "with additional measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020313
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an information content entity, that indicates a benchmark, e.g. in a comparison.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Although contradicting to BFO2, we add the reference role to the generically dependent \"information content entity\", aware of the ongoing discussion.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "reference role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
     
 Class: OEO_00020314
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference scenario is a scenario that is used as a reference, e.g. in a scenario comparison. It has the reference role.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "reference scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020313)
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00020317
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission scenario is an emission scenario that describes a possible greenhouse gas emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "greenhouse gas emission scenario"
-    
     EquivalentTo: 
         OEO_00000364
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199)
     
-    SubClassOf: 
-        OEO_00030009
+    
+Class: OEO_00020321
+
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00260007)
     
     
 Class: OEO_00030002
@@ -2833,23 +2747,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
 Class: OEO_00030009
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-
-move to oeo-share
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "emission scenario"
-    
     EquivalentTo: 
         OEO_00000364
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000147)
-    
-    SubClassOf: 
-        OEO_00000364
     
     
 Class: OEO_00030015

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -2190,57 +2190,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
     
 Class: OEO_00020121
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "resolution"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/IAO_0000100>
-    
     
 Class: OEO_00020122
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-add individuals
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "temporal resolution"
-    
-    SubClassOf: 
-        OEO_00020121,
-        OEO_00010121 some OEO_00030034
-    
     DisjointWith: 
         OEO_00020123
     
     
 Class: OEO_00020123
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
-        rdfs:label "spatial resolution"
-    
-    SubClassOf: 
-        OEO_00020121
-    
     DisjointWith: 
         OEO_00020122
     
@@ -2828,52 +2786,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
 Class: OEO_00030029
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "exogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020189 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
-    
     
 Class: OEO_00030030
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "endogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020190 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
-    
     
 Class: OEO_00030031
 
@@ -2889,21 +2804,6 @@ Class: OEO_00030034
     
 Class: OEO_00030035
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-change duration to time span (def, label, alternative term)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
-        rdfs:label "time span"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
-    
     
 Class: OEO_00040002
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -19,9 +19,6 @@ Annotations:
     dc:license "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Shared axioms module)"
 
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000112>
-
-    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
@@ -40,9 +37,6 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
-
-    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -50,12 +44,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
-
-    
-AnnotationProperty: OEO_00010037
-
-    
-AnnotationProperty: OEO_00040001
 
     
 AnnotationProperty: OEO_00110012
@@ -1102,9 +1090,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: OEO_00140178
-
-    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
@@ -1114,22 +1099,10 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000003>
 Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000006>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000009>
-
-    
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000017>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000019>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000020>
@@ -1138,28 +1111,10 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000020>
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000027>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000030>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000031>
-
-    
 Class: <http://purl.obolibrary.org/obo/BFO_0000034>
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000038>
-
-    
 Class: <http://purl.obolibrary.org/obo/BFO_0000040>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000141>
-
-    
-Class: <http://purl.obolibrary.org/obo/BFO_0000148>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000027>
@@ -1197,46 +1152,13 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
         OEO_00020188 some OEO_00020186
     
     
-Class: <http://purl.obolibrary.org/obo/IAO_0000104>
-
-    
 Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 
     SubClassOf: 
         OEO_00020188 some OEO_00010412
     
     
-Class: <http://purl.obolibrary.org/obo/RO_0002577>
-
-    
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000001>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000002>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000003>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000036>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000046>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000047>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000111>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0000224>
-
-    
-Class: <http://purl.obolibrary.org/obo/UO_0010006>
 
     
 Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330023>
@@ -1245,25 +1167,7 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330023>
 Class: OEO_00000001
 
     
-Class: OEO_00000006
-
-    
-Class: OEO_00000007
-
-    
-Class: OEO_00000011
-
-    
-Class: OEO_00000014
-
-    
 Class: OEO_00000020
-
-    
-Class: OEO_00000031
-
-    
-Class: OEO_00000051
 
     
 Class: OEO_00000061
@@ -1275,19 +1179,7 @@ Class: OEO_00000064
 Class: OEO_00000087
 
     
-Class: OEO_00000097
-
-    
-Class: OEO_00000099
-
-    
 Class: OEO_00000107
-
-    
-Class: OEO_00000115
-
-    
-Class: OEO_00000119
 
     
 Class: OEO_00000139
@@ -1299,52 +1191,13 @@ Class: OEO_00000139
 Class: OEO_00000143
 
     
-Class: OEO_00000144
-
-    
 Class: OEO_00000147
-
-    
-Class: OEO_00000148
-
-    
-Class: OEO_00000149
 
     
 Class: OEO_00000150
 
     
-Class: OEO_00000151
-
-    
-Class: OEO_00000173
-
-    
-Class: OEO_00000188
-
-    
-Class: OEO_00000198
-
-    
 Class: OEO_00000199
-
-    
-Class: OEO_00000200
-
-    
-Class: OEO_00000206
-
-    
-Class: OEO_00000207
-
-    
-Class: OEO_00000238
-
-    
-Class: OEO_00000253
-
-    
-Class: OEO_00000255
 
     
 Class: OEO_00000264
@@ -1359,28 +1212,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000274
 
     
-Class: OEO_00000275
-
-    
 Class: OEO_00000315
 
     
 Class: OEO_00000316
 
     
-Class: OEO_00000323
-
-    
 Class: OEO_00000331
-
-    
-Class: OEO_00000333
-
-    
-Class: OEO_00000334
-
-    
-Class: OEO_00000340
 
     
 Class: OEO_00000350
@@ -1398,9 +1236,6 @@ Class: OEO_00000368
 Class: OEO_00000395
 
     
-Class: OEO_00000403
-
-    
 Class: OEO_00000407
 
     SubClassOf: 
@@ -1408,9 +1243,6 @@ Class: OEO_00000407
             (OEO_00000061
              and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>))
     
-    
-Class: OEO_00000419
-
     
 Class: OEO_00000423
 
@@ -1421,9 +1253,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
         OEO_00140164 some OEO_00000143
     
     
-Class: OEO_00010023
-
-    
 Class: OEO_00010078
 
     
@@ -1432,15 +1261,6 @@ Class: OEO_00010079
     SubClassOf: 
         OEO_00020056 some OEO_00020063
     
-    
-Class: OEO_00010082
-
-    
-Class: OEO_00010083
-
-    
-Class: OEO_00010114
-
     
 Class: OEO_00010115
 
@@ -1456,65 +1276,11 @@ Class: OEO_00010117
         OEO_00020180 some OEO_00040003
     
     
-Class: OEO_00010127
-
-    
-Class: OEO_00010210
-
-    
-Class: OEO_00010211
-
-    
-Class: OEO_00010263
-
-    
-Class: OEO_00010264
-
-    
-Class: OEO_00010265
-
-    
-Class: OEO_00010266
-
-    
-Class: OEO_00010268
-
-    
-Class: OEO_00010269
-
-    
-Class: OEO_00010270
-
-    
-Class: OEO_00010271
-
-    
 Class: OEO_00010296
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
     
-    
-Class: OEO_00010315
-
-    
-Class: OEO_00010316
-
-    
-Class: OEO_00010361
-
-    
-Class: OEO_00010362
-
-    
-Class: OEO_00010385
-
-    
-Class: OEO_00010386
-
-    
-Class: OEO_00010388
-
     
 Class: OEO_00010404
 
@@ -1546,31 +1312,10 @@ Class: OEO_00010409
 Class: OEO_00010412
 
     
-Class: OEO_00020003
-
-    
-Class: OEO_00020006
-
-    
 Class: OEO_00020011
 
     
-Class: OEO_00020012
-
-    
 Class: OEO_00020015
-
-    
-Class: OEO_00020016
-
-    
-Class: OEO_00020018
-
-    
-Class: OEO_00020032
-
-    
-Class: OEO_00020035
 
     
 Class: OEO_00020039
@@ -1585,20 +1330,11 @@ Class: OEO_00020063
 Class: OEO_00020065
 
     
-Class: OEO_00020066
-
-    
-Class: OEO_00020067
-
-    
 Class: OEO_00020068
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
     
-    
-Class: OEO_00020069
-
     
 Class: OEO_00020072
 
@@ -1606,64 +1342,7 @@ Class: OEO_00020072
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
     
     
-Class: OEO_00020085
-
-    
-Class: OEO_00020097
-
-    
-Class: OEO_00020098
-
-    
-Class: OEO_00020102
-
-    
-Class: OEO_00020104
-
-    
-Class: OEO_00020107
-
-    
 Class: OEO_00020121
-
-    
-Class: OEO_00020122
-
-    
-Class: OEO_00020123
-
-    
-Class: OEO_00020136
-
-    
-Class: OEO_00020140
-
-    
-Class: OEO_00020142
-
-    
-Class: OEO_00020143
-
-    
-Class: OEO_00020154
-
-    
-Class: OEO_00020155
-
-    
-Class: OEO_00020166
-
-    
-Class: OEO_00020175
-
-    
-Class: OEO_00020176
-
-    
-Class: OEO_00020177
-
-    
-Class: OEO_00020178
 
     
 Class: OEO_00020181
@@ -1678,9 +1357,6 @@ Class: OEO_00020185
 Class: OEO_00020186
 
     
-Class: OEO_00020187
-
-    
 Class: OEO_00020201
 
     SubClassOf: 
@@ -1693,31 +1369,7 @@ Class: OEO_00020202
         (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
     
     
-Class: OEO_00020204
-
-    
-Class: OEO_00020205
-
-    
-Class: OEO_00020206
-
-    
-Class: OEO_00020207
-
-    
-Class: OEO_00020208
-
-    
 Class: OEO_00020248
-
-    
-Class: OEO_00020252
-
-    
-Class: OEO_00020264
-
-    
-Class: OEO_00020267
 
     
 Class: OEO_00020309
@@ -1727,21 +1379,6 @@ Class: OEO_00020309
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00140149 or OEO_00140151))
     
-    
-Class: OEO_00020310
-
-    
-Class: OEO_00020311
-
-    
-Class: OEO_00020312
-
-    
-Class: OEO_00020313
-
-    
-Class: OEO_00020314
-
     
 Class: OEO_00020317
 
@@ -1756,15 +1393,6 @@ Class: OEO_00020321
         OEO_00000364
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00260007)
     
-    
-Class: OEO_00030002
-
-    
-Class: OEO_00030003
-
-    
-Class: OEO_00030004
-
     
 Class: OEO_00030008
 
@@ -1791,45 +1419,15 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
         OEO_00140164 some OEO_00030024
-        
+    
     
 Class: OEO_00030019
-
-    
-Class: OEO_00030022
 
     
 Class: OEO_00030024
 
     
-Class: OEO_00030025
-
-    
-Class: OEO_00030029
-
-    
-Class: OEO_00030030
-
-    
-Class: OEO_00030031
-
-    
-Class: OEO_00030032
-
-    
-Class: OEO_00030033
-
-    
-Class: OEO_00030034
-
-    
-Class: OEO_00030035
-
-    
 Class: OEO_00040003
-
-    
-Class: OEO_00040004
 
     
 Class: OEO_00040009
@@ -1844,61 +1442,7 @@ Class: OEO_00050000
 Class: OEO_00050018
 
     
-Class: OEO_00050019
-
-    
 Class: OEO_00090001
-
-    
-Class: OEO_00140003
-
-    
-Class: OEO_00140004
-
-    
-Class: OEO_00140005
-
-    
-Class: OEO_00140006
-
-    
-Class: OEO_00140007
-
-    
-Class: OEO_00140009
-
-    
-Class: OEO_00140012
-
-    
-Class: OEO_00140033
-
-    
-Class: OEO_00140039
-
-    
-Class: OEO_00140040
-
-    
-Class: OEO_00140043
-
-    
-Class: OEO_00140044
-
-    
-Class: OEO_00140049
-
-    
-Class: OEO_00140050
-
-    
-Class: OEO_00140075
-
-    
-Class: OEO_00140076
-
-    
-Class: OEO_00140079
 
     
 Class: OEO_00140081
@@ -1914,24 +1458,6 @@ Class: OEO_00140149
 
     
 Class: OEO_00140151
-
-    
-Class: OEO_00140159
-
-    
-Class: OEO_00240003
-
-    
-Class: OEO_00240014
-
-    
-Class: OEO_00240019
-
-    
-Class: OEO_00240022
-
-    
-Class: OEO_00240024
 
     
 Class: OEO_00240026
@@ -1977,22 +1503,7 @@ Class: OEO_00240035
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
     
     
-Class: OEO_00240038
-
-    
 Class: OEO_00260007
-
-    
-Class: OEO_00320000
-
-    
-Class: OEO_00320001
-
-    
-Class: OEO_00320002
-
-    
-Class: OEO_00320003
 
     
 Class: OEO_00320021
@@ -2000,40 +1511,4 @@ Class: OEO_00320021
     SubClassOf: 
         OEO_00020180 some OEO_00040009
     
-    
-Class: OEO_00320041
-
-    
-Class: OEO_00320061
-
-    
-Class: OEO_00320074
-
-    
-Class: OEO_00340004
-
-    
-Class: OEO_00340005
-
-    
-Individual: OEO_00000182
-
-    
-Individual: OEO_00000256
-
-    
-Individual: OEO_00020161
-
-    
-Individual: OEO_00020162
-
-    
-Individual: OEO_00020163
-
-    
-Individual: OEO_00020164
-
-    
-Individual: OEO_00020165
-
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1629,15 +1629,9 @@ Class: OEO_00020121
     
 Class: OEO_00020122
 
-    DisjointWith: 
-        OEO_00020123
-    
     
 Class: OEO_00020123
 
-    DisjointWith: 
-        OEO_00020122
-    
     
 Class: OEO_00020136
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -898,22 +898,6 @@ ObjectProperty: OEO_00020071
     
 ObjectProperty: OEO_00020179
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-Make subproperty of 'quantity value of' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
-        rdfs:label "economic value of"
-    
-    SubPropertyOf: 
-        OEO_00020056
-    
-    Domain: 
-        OEO_00140012
-    
     
 ObjectProperty: OEO_00020180
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1364,18 +1364,12 @@ Class: OEO_00000275
     
 Class: OEO_00000315
 
-    DisjointWith: 
-        OEO_00000323
-    
     
 Class: OEO_00000316
 
     
 Class: OEO_00000323
 
-    DisjointWith: 
-        OEO_00000315
-    
     
 Class: OEO_00000331
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1226,9 +1226,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000036>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-    
     
 Class: <http://purl.obolibrary.org/obo/UO_0000047>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1699,25 +1699,6 @@ Class: OEO_00020035
     
 Class: OEO_00020039
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
-        rdfs:label "energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 Class: OEO_00020060
     
@@ -1751,24 +1732,6 @@ Class: OEO_00020072
     
 Class: OEO_00020085
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Move to oeo-shared:
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy"
-    
-    EquivalentTo: 
-        OEO_00000150
-         and (OEO_00000530 some OEO_00030004)
-    
-    SubClassOf: 
-        OEO_00000150
-    
     
 Class: OEO_00020097
 
@@ -1778,59 +1741,12 @@ Class: OEO_00020098
     
 Class: OEO_00020102
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "energy transformation unit"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
-    
     
 Class: OEO_00020104
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "outage"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
     
 Class: OEO_00020107
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "curtailment"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
-    
     
 Class: OEO_00020121
 
@@ -1849,64 +1765,15 @@ Class: OEO_00020123
     
 Class: OEO_00020136
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-
-extend definition and add alternative term
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "space requirement"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
     
 Class: OEO_00020140
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
-        rdfs:label "area per power unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 Class: OEO_00020142
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "square kilometer"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000047>
-    
     
 Class: OEO_00020143
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "area value"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
-    
     
 Class: OEO_00020154
 
@@ -1919,58 +1786,15 @@ Class: OEO_00020166
     
 Class: OEO_00020175
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "life time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
     
 Class: OEO_00020176
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "construction time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
     
 Class: OEO_00020177
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "decommissioning time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
-    
     
 Class: OEO_00020178
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "operational life time"
-    
-    SubClassOf: 
-        OEO_00020175
-    
     
 Class: OEO_00020181
     
@@ -1995,139 +1819,30 @@ Class: OEO_00020202
     
 Class: OEO_00020204
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy amount value"
-    
-    SubClassOf: 
-        OEO_00050019
-    
     
 Class: OEO_00020205
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020207
-    
     
 Class: OEO_00020206
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020208
-    
     
 Class: OEO_00020207
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "electricity import"
-    
-    SubClassOf: 
-        OEO_00020201,
-        OEO_00140002 some OEO_00020205,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
-    
     
 Class: OEO_00020208
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "electricity export"
-    
-    SubClassOf: 
-        OEO_00020202,
-        OEO_00140002 some OEO_00020206,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
-    
     
 Class: OEO_00020248
 
     
 Class: OEO_00020252
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542
-
-move to oeo-share
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
-A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
-        rdfs:label "climate system"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
     
 Class: OEO_00020264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575"@en,
-        rdfs:label "material transformation"
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-    
-    SubClassOf: 
-        OEO_00000419
-    
     
 Class: OEO_00020267
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy technology is a technology that describes how to combine energy transformation units, energy transformations, energy carriers and energy in a specific way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
-        rdfs:label "energy technology"
-    
-    SubClassOf: 
-        OEO_00000407,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00020102
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
-    
     
 Class: OEO_00020309
 
@@ -2168,90 +1883,14 @@ Class: OEO_00020321
     
 Class: OEO_00030002
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Update definition and add disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Shift part of the definition into an editor note:
-Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        OEO_00030003,
-        OEO_00010121 some OEO_00000331
-    
     
 Class: OEO_00030003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
     
 Class: OEO_00030004
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable"
     
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000150
+Class: OEO_00030008
     
     
 Class: OEO_00030008
@@ -2282,42 +1921,9 @@ Class: OEO_00030022
     
 Class: OEO_00030024
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-make subclass of supply system:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "energy system"
-    
-    SubClassOf: 
-        OEO_00030025
-    
     
 Class: OEO_00030025
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "supply system"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
     
 Class: OEO_00030029
 
@@ -2450,35 +2056,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     
 Class: OEO_00050018
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-
-make energy consumption value:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
-        rdfs:label "primary energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00240019,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
-    
     
 Class: OEO_00050019
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1736,18 +1736,8 @@ Class: OEO_00020067
     
 Class: OEO_00020068
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066
-    
     SubClassOf: 
-        OEO_00020067
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001
     
     
 Class: OEO_00020069

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -586,67 +586,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
     
 ObjectProperty: OEO_00000514
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-rework
-issue https://github.com/OpenEnergyPlatform/ontology/issues/849
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has resolution"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020121
-    
     
 ObjectProperty: OEO_00000515
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has spatial resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020123
-    
     
 ObjectProperty: OEO_00000516
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-fix def and add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has temporal resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020122
-    
     
 ObjectProperty: OEO_00000522
 
@@ -3033,77 +2978,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
     
 Class: OEO_00030031
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "start time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
     
 Class: OEO_00030032
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "ending time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
     
 Class: OEO_00030033
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an ending time and thus a finite duration.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time step"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>,
-        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
-    
     
 Class: OEO_00030034
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000584",
-        rdfs:label "time series"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
-    
     
 Class: OEO_00030035
 
@@ -3462,37 +3345,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
     
 Class: OEO_00140043
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time stamp"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
-    
     
 Class: OEO_00140044
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time stamp alignment"@en
-    
-    SubClassOf: 
-        OEO_00000119
-    
     
 Class: OEO_00140049
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1729,16 +1729,6 @@ Class: OEO_00020065
 
     
 Class: OEO_00020066
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity role"
-    
-    SubClassOf: 
-        OEO_00040011
     
     
 Class: OEO_00020067

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1036,6 +1036,9 @@ ObjectProperty: OEO_00040010
     
     
 ObjectProperty: OEO_00140002
+
+    InverseOf: 
+        OEO_00020056
     
     
 ObjectProperty: OEO_00140008
@@ -1406,7 +1409,7 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-    
+
     
 Class: OEO_00000253
 
@@ -1430,6 +1433,9 @@ Class: OEO_00000275
 
     
 Class: OEO_00000315
+
+    DisjointWith: 
+        OEO_00000323
     
     
 Class: OEO_00000316
@@ -1483,10 +1489,10 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-    
+
     
 Class: OEO_00000368
-    
+
     
 Class: OEO_00000395
 
@@ -1527,7 +1533,7 @@ Class: OEO_00010079
     
     
 Class: OEO_00010082
-    
+
     
 Class: OEO_00010083
 
@@ -1536,7 +1542,7 @@ Class: OEO_00010114
 
     
 Class: OEO_00010115
-    
+
     
 Class: OEO_00010116
 
@@ -1570,16 +1576,16 @@ Class: OEO_00010266
 
     
 Class: OEO_00010268
-    
+
     
 Class: OEO_00010269
-    
+
     
 Class: OEO_00010270
-    
+
     
 Class: OEO_00010271
-    
+
     
 Class: OEO_00010296
 
@@ -1621,6 +1627,7 @@ Class: OEO_00010407
 
     SubClassOf: 
         OEO_00000504 some OEO_00010406
+    
     
 Class: OEO_00010412
 
@@ -1721,7 +1728,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     
 Class: OEO_00020063
-    
+
     
 Class: OEO_00020065
 
@@ -1799,7 +1806,7 @@ Class: OEO_00020072
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
-
+    
     
 Class: OEO_00020085
 
@@ -2333,6 +2340,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
         OEO_00010121 some OEO_00000150
     
     
+Class: OEO_00030008
+
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010115)
+    
+    
 Class: OEO_00030009
 
     EquivalentTo: 
@@ -2554,117 +2568,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
     
 Class: OEO_00050019
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-moved to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "energy amount value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
-    
     
 Class: OEO_00090001
 
     
 Class: OEO_00140003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-add performance axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-add has participant axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1271
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000125",
-        rdfs:label "transport"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140002 some OEO_00320000,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323 or OEO_00010116)
-    
     
 Class: OEO_00140004
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "international transport"@en
-    
-    SubClassOf: 
-        OEO_00140003
-    
     
 Class: OEO_00140005
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Add axiom for goods as participant:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
-        rdfs:label "freight transport"@en
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
-    
     
 Class: OEO_00140006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "private transport"
-    
-    SubClassOf: 
-        OEO_00010263
-    
     
 Class: OEO_00140007
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "public transport"
-    
-    SubClassOf: 
-        OEO_00010263
-    
     
 Class: OEO_00140009
 
@@ -2674,58 +2595,12 @@ Class: OEO_00140012
     
 Class: OEO_00140033
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "chemical reaction"@en
-    
-    SubClassOf: 
-        OEO_00000419,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 Class: OEO_00140039
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "consumption"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Class: OEO_00140040
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
-        rdfs:label "demand"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000017>,
-        OEO_00010121 some 
-            (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
-    
     
 Class: OEO_00140043
 
@@ -2735,104 +2610,18 @@ Class: OEO_00140044
     
 Class: OEO_00140049
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:label "energy conversion efficiency"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003,
-        OEO_00140002 some OEO_00140050
-    
     
 Class: OEO_00140050
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:label "efficiency value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
     
 Class: OEO_00140075
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "primary energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
     
 Class: OEO_00140076
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "secondary energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
     
 Class: OEO_00140079
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-fix error in definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "secondary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
-    
-    SubClassOf: 
-        OEO_00020039
-    
     
 Class: OEO_00140081
 
@@ -2972,14 +2761,7 @@ Class: OEO_00340004
     
 Class: OEO_00340005
 
-
-Class: OEO_00030008
     
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010115)
-
-
 Individual: OEO_00000182
 
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1447,6 +1447,7 @@ Class: OEO_00000031
 
     
 Class: OEO_00000051
+
     
 Class: OEO_00000061
 
@@ -1455,6 +1456,7 @@ Class: OEO_00000064
 
     
 Class: OEO_00000087
+
     
 Class: OEO_00000097
 
@@ -1572,37 +1574,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
     
 Class: OEO_00000316
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-change definition and add comment with examples:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
-* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
-* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
     
 Class: OEO_00000323
 
@@ -1612,98 +1583,12 @@ Class: OEO_00000323
     
 Class: OEO_00000331
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-definition update and editor note:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>,
-        OEO_00000530 some OEO_00000316
-    
     
 Class: OEO_00000333
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003
-    
     
 Class: OEO_00000334
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-remove \"among other parts from definition\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1258
-pull request: https://github.com/OpenEnergyPlatform/ontology/issues/1259
-
-New function-based definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
-        rdfs:label "power generating unit"
-    
-    EquivalentTo: 
-        OEO_00020102
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
-    
-    SubClassOf: 
-        OEO_00020102,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
-    
     
 Class: OEO_00000340
 
@@ -1790,26 +1675,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
     
 Class: OEO_00000395
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some OEO_00000331
-    
     
 Class: OEO_00000403
 
@@ -1863,60 +1728,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
     
 Class: OEO_00010023
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-Add vehicle operational mode axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000604",
-        rdfs:label "vehicle"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
-    
     
 Class: OEO_00010078
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
-
-move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "global warming potential"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
     
 Class: OEO_00010079
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
-        rdfs:label "emission quantity value"@en
-    
     SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
+        OEO_00020056 some OEO_00020063
     
     
 Class: OEO_00010082
@@ -1941,27 +1760,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
     
     
 Class: OEO_00010083
+
     
 Class: OEO_00010114
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813
-
-change label and definition language
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "waste thermal energy"
-    
-    SubClassOf: 
-        OEO_00000207
-    
     
 Class: OEO_00010115
 
@@ -2031,78 +1833,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
     
 Class: OEO_00010127
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
-
-make equivalent and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1523
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1619",
-        rdfs:label "secondary energy production"@en
-    
-    EquivalentTo: 
-        OEO_00240003
-         and (OEO_00000533 some OEO_00140079)
-    
-    SubClassOf: 
-        OEO_00240003,
-        OEO_00000533 some OEO_00140079,
-        OEO_00140002 some OEO_00050019,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003
-    
     
 Class: OEO_00010210
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
-
-Add alternative label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1321
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
-    
     
 Class: OEO_00010211
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "non-energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
-    
     
 Class: OEO_00010263
 
@@ -2681,6 +2417,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     
 Class: OEO_00020069
+
     
 Class: OEO_00020072
 
@@ -3958,6 +3695,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
     
     
 Class: OEO_00140009
+
     
 Class: OEO_00140012
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1727,20 +1727,6 @@ Class: OEO_00020063
     
 Class: OEO_00020065
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "energy market exchange"
-    
-    SubClassOf: 
-        OEO_00020069
-    
     
 Class: OEO_00020066
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1791,9 +1791,6 @@ Class: OEO_00030015
     
 Class: OEO_00030019
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 Class: OEO_00030022
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -768,33 +768,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
     
     InverseOf: 
         OEO_00240025
-    
-    
-ObjectProperty: OEO_00010119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-Make subproperty of 'is about':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "guides"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    Domain: 
-        OEO_00140151
-    
-    Range: 
-        OEO_00140149
-    
+       
     
 ObjectProperty: OEO_00010121
 
@@ -1366,6 +1340,8 @@ Class: OEO_00000119
     
 Class: OEO_00000139
 
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
     
 Class: OEO_00000143
 
@@ -1550,7 +1526,8 @@ Class: OEO_00010116
     
 Class: OEO_00010117
 
-    SubClassOf: 
+    SubClassOf:
+        OEO_00020180 some OEO_00040003,
         OEO_00010121 some 
             (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>)
     
@@ -1813,8 +1790,14 @@ Class: OEO_00020187
     
 Class: OEO_00020201
 
+    SubClassOf: 
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+
     
 Class: OEO_00020202
+
+    SubClassOf: 
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
 
     
 Class: OEO_00020204
@@ -1944,116 +1927,63 @@ Class: OEO_00030034
 
     
 Class: OEO_00030035
-
-    
-Class: OEO_00040002
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639
-
-https://github.com/OpenEnergyPlatform/ontology/issues/677
-https://github.com/OpenEnergyPlatform/ontology/pull/740
-
-change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market exchange role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: OEO_00040003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "monetary price"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00020179 some OEO_00010117,
-        OEO_00040010 some OEO_00040004
     
     
 Class: OEO_00040004
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
-https://github.com/OpenEnergyPlatform/ontology/pull/640
-add comment and example
-https://github.com/OpenEnergyPlatform/ontology/pull/910
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
-        rdfs:label "currency"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00040009
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-delete cost in oeo-social
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
-        rdfs:label "cost"@en
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
     
 Class: OEO_00040011
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
-https://github.com/OpenEnergyPlatform/ontology/pull/644
-moved to oeo-shared and renamed
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-made subclass of good role
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "commodity role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
-    
+
+Class: OEO_00240026
+
+    EquivalentTo: 
+        (OEO_00240025 some OEO_00050000)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
+
+
+Class: OEO_00240027
+
     SubClassOf: 
-        OEO_00010117
-    
-    
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
+Class: OEO_00050000
+
+
+Class: OEO_00240028
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
+Class: OEO_00240029
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
+Class: OEO_00240031
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
+Class: OEO_00240034
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
+Class: OEO_00240035
+
+    SubClassOf:
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+
+
 Class: OEO_00050018
 
     
@@ -2120,67 +2050,12 @@ Class: OEO_00140081
         OEO_00020180 some OEO_00020181
     
 Class: OEO_00140124
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
-
-add 'has participant axiom' and move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "service"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
     
     
 Class: OEO_00140149
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-move to oeo-shared, alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "transformative measure"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00140151
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-Redefine as 'plan specification' and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
-
-move to oeo-shared, alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "policy instrument"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
     
     
 Class: OEO_00140159
@@ -2223,36 +2098,26 @@ Class: OEO_00320041
 
     
 Class: OEO_00320061
-
-    
-Class: OEO_00320073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
-        rdfs:label "amortisation time"
-    
-    SubClassOf: 
-        OEO_00030035
     
     
 Class: OEO_00320074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
-        rdfs:label "economic life time"
     
     SubClassOf: 
         OEO_00020178
-    
+
+
+Class: OEO_00320021
+
+    SubClassOf: 
+        OEO_00020180 some OEO_00040009
     
 Class: OEO_00340004
 
     
 Class: OEO_00340005
+
+
+Class: OEO_00040009
 
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -768,7 +768,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
     
     InverseOf: 
         OEO_00240025
-       
+    
     
 ObjectProperty: OEO_00010121
 
@@ -889,6 +889,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
     InverseOf: 
         OEO_00140002
     
+    
+ObjectProperty: OEO_00020070
+
     
 ObjectProperty: OEO_00020071
 
@@ -1111,7 +1114,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     InverseOf: 
         OEO_00000533
     
-ObjectProperty: OEO_00020070
     
 ObjectProperty: owl:topObjectProperty
 
@@ -1343,6 +1345,7 @@ Class: OEO_00000139
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
     
+    
 Class: OEO_00000143
 
     
@@ -1438,29 +1441,6 @@ Class: OEO_00000340
     
 Class: OEO_00000350
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/496
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1405
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000032",
-        rdfs:label "quantity value"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-  
     
 Class: OEO_00000364
 
@@ -1526,10 +1506,10 @@ Class: OEO_00010116
     
 Class: OEO_00010117
 
-    SubClassOf:
-        OEO_00020180 some OEO_00040003,
+    SubClassOf: 
         OEO_00010121 some 
-            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>)
+            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>),
+        OEO_00020180 some OEO_00040003
     
     
 Class: OEO_00010127
@@ -1606,17 +1586,19 @@ Class: OEO_00010407
     SubClassOf: 
         OEO_00000504 some OEO_00010406
     
-
+    
 Class: OEO_00010408
 
     SubClassOf: 
         OEO_00020070 some OEO_00020060
-
-Class: OEO_00010409
     
+    
+Class: OEO_00010409
+
     SubClassOf: 
         OEO_00020070 some OEO_00020060
-
+    
+    
 Class: OEO_00010412
 
     
@@ -1678,7 +1660,7 @@ Class: OEO_00020039
 
     
 Class: OEO_00020060
-    
+
     
 Class: OEO_00020063
 
@@ -1687,10 +1669,10 @@ Class: OEO_00020065
 
     
 Class: OEO_00020066
-    
+
     
 Class: OEO_00020067
-    
+
     
 Class: OEO_00020068
 
@@ -1756,7 +1738,7 @@ Class: OEO_00020154
 
     
 Class: OEO_00020155
-  
+
     
 Class: OEO_00020166
 
@@ -1774,8 +1756,8 @@ Class: OEO_00020178
 
     
 Class: OEO_00020181
-    
 
+    
 Class: OEO_00020185
 
     Annotations: 
@@ -1792,13 +1774,13 @@ Class: OEO_00020201
 
     SubClassOf: 
         (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
-
+    
     
 Class: OEO_00020202
 
     SubClassOf: 
         (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
-
+    
     
 Class: OEO_00020204
 
@@ -1874,9 +1856,6 @@ Class: OEO_00030004
 
     
 Class: OEO_00030008
-    
-    
-Class: OEO_00030008
 
     EquivalentTo: 
         OEO_00000364
@@ -1927,63 +1906,23 @@ Class: OEO_00030034
 
     
 Class: OEO_00030035
-    
+
     
 Class: OEO_00040003
-    
+
     
 Class: OEO_00040004
 
     
+Class: OEO_00040009
+
+    
 Class: OEO_00040011
 
-
-Class: OEO_00240026
-
-    EquivalentTo: 
-        (OEO_00240025 some OEO_00050000)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-
-
-Class: OEO_00240027
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
+    
 Class: OEO_00050000
 
-
-Class: OEO_00240028
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
-Class: OEO_00240029
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
-Class: OEO_00240031
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
-Class: OEO_00240034
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
-Class: OEO_00240035
-
-    SubClassOf:
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-
-
+    
 Class: OEO_00050018
 
     
@@ -2049,14 +1988,15 @@ Class: OEO_00140081
     SubClassOf: 
         OEO_00020180 some OEO_00020181
     
-Class: OEO_00140124
     
+Class: OEO_00140124
+
     
 Class: OEO_00140149
-    
+
     
 Class: OEO_00140151
-    
+
     
 Class: OEO_00140159
 
@@ -2076,6 +2016,49 @@ Class: OEO_00240022
 Class: OEO_00240024
 
     
+Class: OEO_00240026
+
+    EquivalentTo: 
+        (OEO_00240025 some OEO_00050000)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
+    
+    
+Class: OEO_00240027
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240028
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240029
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240031
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240034
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
+Class: OEO_00240035
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
+    
+    
 Class: OEO_00240038
 
     
@@ -2094,30 +2077,28 @@ Class: OEO_00320002
 Class: OEO_00320003
 
     
-Class: OEO_00320041
-
-    
-Class: OEO_00320061
-    
-    
-Class: OEO_00320074
-    
-    SubClassOf: 
-        OEO_00020178
-
-
 Class: OEO_00320021
 
     SubClassOf: 
         OEO_00020180 some OEO_00040009
     
+    
+Class: OEO_00320041
+
+    
+Class: OEO_00320061
+
+    
+Class: OEO_00320074
+
+    SubClassOf: 
+        OEO_00020178
+    
+    
 Class: OEO_00340004
 
     
 Class: OEO_00340005
-
-
-Class: OEO_00040009
 
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1912,9 +1912,7 @@ Class: OEO_00020154
 
     
 Class: OEO_00020155
-
-    SubClassOf: 
-        OEO_00020181    
+  
     
 Class: OEO_00020166
 
@@ -1975,20 +1973,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
     
     
 Class: OEO_00020181
+    
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of emission"
-    
-    SubClassOf: 
-        OEO_00040009,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
 Class: OEO_00020185
 
     Annotations: 
@@ -2553,6 +2539,8 @@ Class: OEO_00140079
     
 Class: OEO_00140081
 
+    SubClassOf: 
+        OEO_00020180 some OEO_00020181
     
 Class: OEO_00140124
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -54,21 +54,9 @@ AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynony
     
 AnnotationProperty: OEO_00010037
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
-        rdfs:label "unique individual identifier"
-    
-    SubPropertyOf: 
-        dc:identifier
-    
     
 AnnotationProperty: OEO_00040001
 
-    Annotations: 
-        rdfs:label "belongs to module"
-    
     
 AnnotationProperty: OEO_00110012
 
@@ -1152,15 +1140,6 @@ ObjectProperty: owl:topObjectProperty
     
 DataProperty: OEO_00140178
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/840",
-        rdfs:label "has number"@en
-    
-    Domain: 
-        OEO_00000350
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -2255,37 +2255,9 @@ Class: OEO_00020018
     
 Class: OEO_00020032
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
     
 Class: OEO_00020035
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "considered region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
     
 Class: OEO_00020039
 
@@ -2421,26 +2393,6 @@ Class: OEO_00020069
     
 Class: OEO_00020072
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'is about' axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286",
-        rdfs:label "analysis scope"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
-    
     
 Class: OEO_00020085
 
@@ -2465,38 +2417,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
 Class: OEO_00020097
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario year"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
-    
     
 Class: OEO_00020098
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario horizon"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
-    
     
 Class: OEO_00020102
 
@@ -4248,27 +4171,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
     
 Class: OEO_00340004
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process of becoming smaller, less numerous, less important, or less likely.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644",
-        rdfs:label "decrease"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Class: OEO_00340005
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process of becoming larger, more numerous, more important, or more likely.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644",
-        rdfs:label "increase"@de
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Individual: OEO_00000182
 
@@ -4297,56 +4202,16 @@ Individual: OEO_00000256
     
 Individual: OEO_00020161
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
-        rdfs:label "annual"
-    
-    Types: 
-        OEO_00020122
-    
     
 Individual: OEO_00020162
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
-        rdfs:label "weekly"
-    
-    Types: 
-        OEO_00020122
-    
     
 Individual: OEO_00020163
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
-        rdfs:label "daily"
-    
-    Types: 
-        OEO_00020122
-    
     
 Individual: OEO_00020164
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
-        rdfs:label "hourly"
-    
-    Types: 
-        OEO_00020122
-    
     
 Individual: OEO_00020165
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
-        rdfs:label "monthly"
-    
-    Types: 
-        OEO_00020122
-    
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1732,26 +1732,6 @@ Class: OEO_00020066
     
     
 Class: OEO_00020067
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
-subclass of good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-change axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "commodity"
-    
-    EquivalentTo: 
-        OEO_00010116
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-    
-    SubClassOf: 
-        OEO_00010116
     
     
 Class: OEO_00020068

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1610,33 +1610,6 @@ Class: OEO_00020006
     
 Class: OEO_00020011
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to investigate something."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add covers-relation (oeo-model)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-add axiom (study report)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study"@en
-    
-    SubClassOf: 
-        OEO_00000340,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
-        OEO_00000509 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001),
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00020012
-    
     
 Class: OEO_00020012
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1262,19 +1262,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0010006>
     
 Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330023>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life cycle assessment is a methodology to calculate and analyse environmental impacts of the life cycle of a material entity or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LCA"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Lebenszyklusanalyse"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "life cycle analysis"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Ökobilanz"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1551
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
-        rdfs:label "life cycle assessment"@en
-    
-    SubClassOf: 
-        OEO_00020166
-    
     
 Class: OEO_00000001
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1137,6 +1137,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     InverseOf: 
         OEO_00000533
     
+ObjectProperty: OEO_00020070
     
 ObjectProperty: owl:topObjectProperty
 
@@ -1628,7 +1629,17 @@ Class: OEO_00010407
     SubClassOf: 
         OEO_00000504 some OEO_00010406
     
+
+Class: OEO_00010408
+
+    SubClassOf: 
+        OEO_00020070 some OEO_00020060
+
+Class: OEO_00010409
     
+    SubClassOf: 
+        OEO_00020070 some OEO_00020060
+
 Class: OEO_00010412
 
     
@@ -1709,22 +1720,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
     
     
 Class: OEO_00020060
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "fuel market exchange"
-    
-    SubClassOf: 
-        OEO_00020065,
-        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
     
     
 Class: OEO_00020063

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1238,14 +1238,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000111>
     
 Class: <http://purl.obolibrary.org/obo/UO_0000224>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "kilowatt hours",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term and has_exact_synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kWh",
-        rdfs:comment "The original term from UO had neither an alternative term nor has_exact_synonym. It was added for OEO purposes to include the Eurostat spellings."@en
-    
     
 Class: <http://purl.obolibrary.org/obo/UO_0010006>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -951,22 +951,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     
     
 ObjectProperty: OEO_00020180
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-Make subproperty of 'has quatity value' and add range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
-        rdfs:label "has economic value"
-    
-    SubPropertyOf: 
-        OEO_00140002
-    
-    Range: 
-        OEO_00140012
     
     
 ObjectProperty: OEO_00020182
@@ -1064,27 +1048,6 @@ ObjectProperty: OEO_00040010
     
     
 ObjectProperty: OEO_00140002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010231
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000350
-    
-    InverseOf: 
-        OEO_00020056
     
     
 ObjectProperty: OEO_00140008
@@ -1464,16 +1427,6 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        OEO_00030022
     
     
 Class: OEO_00000253
@@ -1498,20 +1451,6 @@ Class: OEO_00000275
 
     
 Class: OEO_00000315
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        OEO_00000323
     
     
 Class: OEO_00000316
@@ -1578,40 +1517,9 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000368
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-Add relation to organisation or person:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        OEO_00000504 some 
-            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000395
@@ -1680,24 +1588,6 @@ Class: OEO_00010079
     
     
 Class: OEO_00010082
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one good or service is exchanged for another good or service or money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1565
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
-        rdfs:label "trade"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
     
     
 Class: OEO_00010083
@@ -1707,43 +1597,10 @@ Class: OEO_00010114
 
     
 Class: OEO_00010115
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "economic system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-move to oeo-shared, add alternative lable
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "economy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00010116
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-make good a continuant:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
-        rdfs:label "good"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 Class: OEO_00010117
 
@@ -1794,53 +1651,15 @@ Class: OEO_00010266
 
     
 Class: OEO_00010268
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission price is a monetary price of emitting a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "emission price"
-    
-    SubClassOf: 
-        OEO_00040003,
-        OEO_00020179 some OEO_00140081
     
     
 Class: OEO_00010269
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 price is an emission price of emitting a certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "CO2 price"
-    
-    SubClassOf: 
-        OEO_00010268
     
     
 Class: OEO_00010270
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon tax value is a CO2 price that is set by a carbon tax.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "carbon tax value"
-    
-    SubClassOf: 
-        OEO_00010269
     
     
 Class: OEO_00010271
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission certificate price is an emission price of an CO2 emission certificate that allows the emission of certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "CO2 emission certificate price"
-    
-    SubClassOf: 
-        OEO_00020154
     
     
 Class: OEO_00010296
@@ -1881,16 +1700,8 @@ Class: OEO_00010406
     
 Class: OEO_00010407
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance sector division"@en
-    
     SubClassOf: 
-        OEO_00000368,
         OEO_00000504 some OEO_00010406
-    
     
 Class: OEO_00010412
 
@@ -2012,22 +1823,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     
 Class: OEO_00020063
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
     
     
 Class: OEO_00020065
@@ -2103,6 +1898,9 @@ Class: OEO_00020069
 
     
 Class: OEO_00020072
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
 
     
 Class: OEO_00020085
@@ -2266,24 +2064,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
     
 Class: OEO_00020154
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to emission certificate
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-make subclass of 'emission price':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "emission certificate price"
-    
-    SubClassOf: 
-        OEO_00010268,
-        OEO_00020179 some OEO_00020063
-    
     
 Class: OEO_00020155
 
@@ -2726,23 +2506,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
     
     
 Class: OEO_00030022
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
-added term in oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-deleted term in oeo-social:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
-        rdfs:label "organisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     
 Class: OEO_00030024
@@ -3478,7 +3241,14 @@ Class: OEO_00340004
     
 Class: OEO_00340005
 
+
+Class: OEO_00030008
     
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010115)
+
+
 Individual: OEO_00000182
 
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1913,21 +1913,8 @@ Class: OEO_00020154
     
 Class: OEO_00020155
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission value, add new parent class and relabel
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of carbon emission"
-    
     SubClassOf: 
-        OEO_00020181,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
+        OEO_00020181    
     
 Class: OEO_00020166
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -939,7 +939,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     
     
 ObjectProperty: OEO_00020180
-    
+
     
 ObjectProperty: OEO_00020182
 
@@ -1452,19 +1452,6 @@ Class: OEO_00000334
     
 Class: OEO_00000340
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "project"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Class: OEO_00000350
 
@@ -1490,7 +1477,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
-    
+  
     
 Class: OEO_00000364
 
@@ -1509,18 +1496,7 @@ Class: OEO_00000403
     
 Class: OEO_00000407
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A technology is a plan specification that describes how to combine artificial objects or other material entities and processes in a specific way."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334
-moved to oeo-shared, change definition, reclassify, add axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
-        rdfs:label "technology"
-    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
         <http://purl.obolibrary.org/obo/IAO_0000136> some 
             (OEO_00000061
              and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>))
@@ -1528,22 +1504,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
     
 Class: OEO_00000419
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "transformation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 Class: OEO_00000423
 
@@ -1583,29 +1543,9 @@ Class: OEO_00010116
     
 Class: OEO_00010117
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The role of an independent continuant or energy over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-add relation to monetary price
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-update definition:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
-        rdfs:label "good role"@en
-    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
         OEO_00010121 some 
-            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>),
-        OEO_00020180 some OEO_00040003
+            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>)
     
     
 Class: OEO_00010127
@@ -1723,27 +1663,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
     
 Class: OEO_00020012
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
-add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
-        rdfs:label "study report"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000088>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000506 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064),
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/RO_0002353> some OEO_00020011
-    
     
 Class: OEO_00020015
 
@@ -2064,21 +1983,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
     
 Class: OEO_00020166
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
-        rdfs:label "methodology"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
-    
     
 Class: OEO_00020175
 
@@ -2164,41 +2068,9 @@ Class: OEO_00020187
     
 Class: OEO_00020201
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "import"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
-    
     
 Class: OEO_00020202
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "export"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
-    
     
 Class: OEO_00020204
 
@@ -2473,19 +2345,12 @@ Class: OEO_00030015
     
 Class: OEO_00030019
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
-        rdfs:label "process attribute"
-    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000003>
     
     
 Class: OEO_00030022
-    
+
     
 Class: OEO_00030024
 
@@ -2707,16 +2572,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
     
 Class: OEO_00090001
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
-        rdfs:label "funder"@en
-    
-    SubClassOf: 
-        OEO_00140009
-    
     
 Class: OEO_00140003
 
@@ -2816,18 +2671,6 @@ Class: OEO_00140009
     
 Class: OEO_00140012
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "economic value"@en
-    
-    SubClassOf: 
-        OEO_00000350
-    
     
 Class: OEO_00140033
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1782,6 +1782,16 @@ Class: OEO_00030009
     
 Class: OEO_00030015
 
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+        OEO_00140164 some OEO_00030024
+        
     
 Class: OEO_00030019
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1707,20 +1707,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
     
 Class: OEO_00000119
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
-        rdfs:label "data descriptor"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00000139
 
@@ -1840,20 +1826,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956",
     
 Class: OEO_00000149
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical data set is a dataset that is obtained from observations in the real world."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Move to oeo-shared and harmonise label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "empirical data set"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000403
-    
     
 Class: OEO_00000150
 
@@ -2136,16 +2108,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
     
     
 Class: OEO_00000264
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "energy market model"
-    
-    SubClassOf: 
-        OEO_00000274
     
     
 Class: OEO_00000274
@@ -2490,9 +2452,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    DisjointWith: 
-        OEO_00000149
     
     
 Class: OEO_00000407
@@ -4336,8 +4295,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
     SubClassOf: 
         OEO_00000364
-       
-
+    
     
 Class: OEO_00030019
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2117,48 +2117,9 @@ Class: OEO_00000264
     
     
 Class: OEO_00000274
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/208
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/287
-
-add axiom to model calculation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "model"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some <http://purl.obolibrary.org/obo/BFO_0000004>,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00000275
     
     
 Class: OEO_00000275
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113"@en,
-        rdfs:label "model calculation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140093 some OEO_00030029,
-        OEO_00140094 some OEO_00030030,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000274
     
     
 Class: OEO_00000315
@@ -2368,25 +2329,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     
 Class: OEO_00000364
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-add is about-relation
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'narrative' and 'storyline' as alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1232
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1296",
-        rdfs:label "scenario"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020072
     
     
 Class: OEO_00000367
@@ -2450,17 +2392,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00000403
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic data set is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real-world dataset."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Harmonise label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "synthetic data set"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 Class: OEO_00000407
@@ -2502,16 +2433,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
     
     
 Class: OEO_00000423
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "electricity transshipment model"
-    
-    SubClassOf: 
-        OEO_00000274
     
     
 Class: OEO_00010023
@@ -2887,20 +2808,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
     
     
 Class: OEO_00010296
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption calculation method is a methodology to calculate primary energy consumption.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "primary energy consumption calculation method"@en
-    
-    SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
     
     
 Class: OEO_00010315
@@ -3035,32 +2942,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
     
 Class: OEO_00010404
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance is an empirical data set that describes a specified set of energy transformations and a specified set of energy carriers in a spatial region for a specific time step (usually a year).",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance"
-    
-    SubClassOf: 
-        OEO_00000149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 OEO_00030033,
-        <http://purl.obolibrary.org/obo/IAO_0000136> exactly 1 <http://purl.obolibrary.org/obo/BFO_0000006>
     
     
 Class: OEO_00010406
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance calculation method is a methodology to calculate an energy balance.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance calculation method"@en
-    
-    SubClassOf: 
-        OEO_00020166,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010296,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010404
     
     
 Class: OEO_00010407

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -4378,20 +4378,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
     SubClassOf: 
         OEO_00000364
-    
-    
-Class: OEO_00030015
+       
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
-        rdfs:label "energy system model"@en
-    
-    SubClassOf: 
-        OEO_00000274
-    
     
 Class: OEO_00030019
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1424,51 +1424,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
     
 Class: OEO_00000001
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
 
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
-        rdfs:label "fuel role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00010121 some OEO_00000331
-    
-    
 Class: OEO_00000006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16526",
-        rdfs:label "carbon dioxide"
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198,
-        OEO_00000529 value OEO_00000182
-    
-    
 Class: OEO_00000007
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1605,6 +1605,9 @@ Class: OEO_00000064
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "author"
     
     SubClassOf: 
@@ -1670,6 +1673,9 @@ Class: OEO_00000107
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "contact person"
     
     SubClassOf: 
@@ -2211,6 +2217,9 @@ Class: OEO_00000323
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "person"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1337,14 +1337,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000088>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-
-Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     SubClassOf: 
         OEO_00000514 some OEO_00020121
     
@@ -1751,10 +1743,10 @@ Class: OEO_00000264
 
     
 Class: OEO_00000274
-    
+
     
 Class: OEO_00000275
-    
+
     
 Class: OEO_00000315
 
@@ -1963,7 +1955,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     
 Class: OEO_00000364
-    
+
     
 Class: OEO_00000367
 
@@ -2026,7 +2018,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00000403
-    
+
     
 Class: OEO_00000407
 
@@ -2067,7 +2059,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
     
     
 Class: OEO_00000423
-    
+
     
 Class: OEO_00010023
 
@@ -2422,7 +2414,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
     
     
 Class: OEO_00010296
-    
+
     
 Class: OEO_00010315
 
@@ -2556,10 +2548,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
     
 Class: OEO_00010404
-    
+
     
 Class: OEO_00010406
-    
+
     
 Class: OEO_00010407
 
@@ -2576,16 +2568,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00010412
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "creative work licence"@en
-    
-    SubClassOf: 
-        OEO_00020185
-    
     
 Class: OEO_00020003
 
@@ -2728,8 +2710,13 @@ Class: OEO_00020015
         <http://purl.obolibrary.org/obo/IAO_0000118> "license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
+
 move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "licence"
     
     SubClassOf: 
@@ -2738,40 +2725,10 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     
 Class: OEO_00020016
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
 
-Add SubclassOf axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020018
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
     
     
 Class: OEO_00020032
@@ -3322,61 +3279,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
     
 Class: OEO_00020185
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "copyright licence"
     
-    SubClassOf: 
-        OEO_00020015
     
     
 Class: OEO_00020186
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "data licence"
-    
-    SubClassOf: 
-        OEO_00020015
-    
     
 Class: OEO_00020187
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "software licence"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        OEO_00020185
     
     
 Class: OEO_00020201

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1480,15 +1480,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00000087
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
-        rdfs:label "client"
-    
-    SubClassOf: 
-        OEO_00000051
-    
     
 Class: OEO_00000097
 
@@ -1497,18 +1488,16 @@ Class: OEO_00000099
 
     
 Class: OEO_00000107
-
-    Annotations: 
+    Annotations:
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
+        rdfs:label "contact person",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "contact person"
-    
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+
     SubClassOf: 
         OEO_00000051
-    
     
 Class: OEO_00000115
 
@@ -2160,26 +2149,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
     
     
 Class: OEO_00010083
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-update definition and improve axiom:
-https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market participant"@en
-    
-    SubClassOf: 
-        OEO_00000051,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
-    
     
 Class: OEO_00010114
 
@@ -2969,28 +2938,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     
 Class: OEO_00020069
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market exchange"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-    
-    SubClassOf: 
-        OEO_00030022,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
-https://github.com/OpenEnergyPlatform/ontology/pull/1019"
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (OEO_00010082
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
     
     
 Class: OEO_00020072

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1424,144 +1424,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
     
 Class: OEO_00000001
 
-
+    
 Class: OEO_00000006
 
+    
 Class: OEO_00000007
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000023",
-        rdfs:label "chemical energy"
-    
-    SubClassOf: 
-        OEO_00000150
-    
     
 Class: OEO_00000011
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-renaming to component
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-redefine
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
-        rdfs:label "energy converting component"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
-    
     
 Class: OEO_00000014
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000099
-         and (OEO_00000530 some OEO_00030002)
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Add `SubClass Of` axiom for `fossil combustion fuel`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
-        OEO_00000099,
-        OEO_00000530 some OEO_00030003
-    
     
 Class: OEO_00000020
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add global warming potential axiom:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "greenhouse gas"
-    
-    EquivalentTo: 
-        OEO_00000331
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000198)
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000524 some OEO_00010078,
-        OEO_00000529 value OEO_00000182
-    
     
 Class: OEO_00000031
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/588
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/594
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-more precise axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "power plant"
-    
-    EquivalentTo: 
-        OEO_00020102
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334)
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000334,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240014
-    
     
 Class: OEO_00000051
 
@@ -1584,21 +1464,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
     
 Class: OEO_00000061
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
-subclasses
-https://github.com/OpenEnergyPlatform/ontology/pull/128
-relation to space requirement
-https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "artificial object"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000030>,
-        <http://purl.obolibrary.org/obo/RO_0002328> some OEO_00020136
-    
     
 Class: OEO_00000064
 
@@ -1627,46 +1492,9 @@ Class: OEO_00000087
     
 Class: OEO_00000097
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'realized in' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "combustible energy carrier disposition"
-    
-    SubClassOf: 
-        OEO_00000151,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140033
-    
     
 Class: OEO_00000099
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/931
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "combustion fuel"
-    
-    EquivalentTo: 
-        OEO_00000173
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097)
-    
-    SubClassOf: 
-        OEO_00000173
-    
     
 Class: OEO_00000107
 
@@ -1684,216 +1512,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000115
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024
-
-Add petroleum as alternative label:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
-        rdfs:label "crude oil"
-    
-    SubClassOf: 
-        OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
-        OEO_00000529 value OEO_00000256
-    
     
 Class: OEO_00000119
 
     
 Class: OEO_00000139
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "definition of electrical energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
-
-alternative term electricity:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/381
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/621
-
-add commodity role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
-
-add axiom to electricity im/exports:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-move class to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000020",
-        rdfs:label "electrical energy"
-    
-    SubClassOf: 
-        OEO_00000150,
-        OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011
-    
     
 Class: OEO_00000143
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360
-
-updated part relation between electricity grid and power line to have simple restrictions:
-
-replace min 1 restriction by some restriction
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1479",
-        rdfs:label "electricity grid"
-    
-    SubClassOf: 
-        OEO_00000200,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000144,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000253
-    
     
 Class: OEO_00000144
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity grid component"
-    
-    EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
-    
-    SubClassOf: 
-        OEO_00020006
-    
     
 Class: OEO_00000147
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000500 some OEO_00000148
-    
     
 Class: OEO_00000148
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:label "emission factor"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00000502 some <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 Class: OEO_00000149
 
     
 Class: OEO_00000150
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
-fix grammar error:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
-adjust definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Add bearer:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00000530 some OEO_00000316,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 Class: OEO_00000151
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-
-add has bearer axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
-        rdfs:label "energy carrier disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
-    
     
 Class: OEO_00000173
 
@@ -2114,7 +1759,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
     
     
 Class: OEO_00000264
-    
+
     
 Class: OEO_00000274
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1523,175 +1523,27 @@ Class: OEO_00000151
     
 Class: OEO_00000173
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-add role fuel commodity
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-shorten definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1184
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1187
-
-Add good role:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "fuel"
-    
-    EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117
-    
     
 Class: OEO_00000188
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        rdfs:label "generator"
-    
-    SubClassOf: 
-        OEO_00000011,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
-    
     
 Class: OEO_00000198
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-
-Add 'realized in' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
-        rdfs:label "greenhouse effect disposition"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some 
-            (OEO_00000331
-             and (OEO_00000531 value OEO_00000182)),
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
-    
     
 Class: OEO_00000199
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1012
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1100
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "greenhouse gas emission"
-    
-    EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000020)
-    
-    SubClassOf: 
-        OEO_00000147
-    
     
 Class: OEO_00000200
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/114
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137",
-        rdfs:label "supply grid"
-    
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>
     
     
 Class: OEO_00000206
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        rdfs:label "hardware"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114
-    
     
 Class: OEO_00000207
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000032",
-        rdfs:label "thermal energy"@en
-    
-    SubClassOf: 
-        OEO_00000150
-    
     
 Class: OEO_00000238
 
@@ -1708,36 +1560,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
     
 Class: OEO_00000253
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "power line"@en
-    
-    SubClassOf: 
-        OEO_00000255,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
-    
     
 Class: OEO_00000255
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
-        rdfs:label "grid component link"
-    
-    SubClassOf: 
-        OEO_00020006
-    
     
 Class: OEO_00000264
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1488,16 +1488,6 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        OEO_00030022
     
     
 Class: OEO_00000253
@@ -1517,21 +1507,7 @@ Class: OEO_00000275
     
 Class: OEO_00000315
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        OEO_00000323
-    
-    
+
 Class: OEO_00000316
 
     
@@ -1547,9 +1523,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
-    
-    DisjointWith: 
-        OEO_00000315
     
     
 Class: OEO_00000331
@@ -1608,40 +1581,9 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000368
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-Add relation to organisation or person:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        OEO_00000504 some 
-            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000395
@@ -1701,24 +1643,6 @@ Class: OEO_00010079
 
     
 Class: OEO_00010082
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one good or service is exchanged for another good or service or money.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1565
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
-        rdfs:label "trade"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
     
     
 Class: OEO_00010083
@@ -1729,21 +1653,7 @@ Class: OEO_00010114
     
 Class: OEO_00010115
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "economic system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-move to oeo-shared, add alternative lable
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "economy"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
-    
-    
+
 Class: OEO_00010116
 
     Annotations: 
@@ -1815,53 +1725,15 @@ Class: OEO_00010266
 
     
 Class: OEO_00010268
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission price is a monetary price of emitting a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "emission price"
-    
-    SubClassOf: 
-        OEO_00040003,
-        OEO_00020179 some OEO_00140081
     
     
 Class: OEO_00010269
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 price is an emission price of emitting a certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "CO2 price"
-    
-    SubClassOf: 
-        OEO_00010268
     
     
 Class: OEO_00010270
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon tax value is a CO2 price that is set by a carbon tax.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "carbon tax value"
-    
-    SubClassOf: 
-        OEO_00010269
     
     
 Class: OEO_00010271
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission certificate price is an emission price of an CO2 emission certificate that allows the emission of certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "CO2 emission certificate price"
-    
-    SubClassOf: 
-        OEO_00020154
     
     
 Class: OEO_00010296
@@ -1895,16 +1767,6 @@ Class: OEO_00010406
 
     
 Class: OEO_00010407
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance sector division"@en
-    
-    SubClassOf: 
-        OEO_00000368,
-        OEO_00000504 some OEO_00010406
     
     
 Class: OEO_00010412
@@ -2045,22 +1907,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     
 Class: OEO_00020063
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
     
     
 Class: OEO_00020065
@@ -2292,24 +2138,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
     
     
 Class: OEO_00020154
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to emission certificate
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-make subclass of 'emission price':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
-        rdfs:label "emission certificate price"
-    
-    SubClassOf: 
-        OEO_00010268,
-        OEO_00020179 some OEO_00020063
     
     
 Class: OEO_00020155

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1472,6 +1472,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00000087
+
     
 Class: OEO_00000097
 
@@ -1480,16 +1481,18 @@ Class: OEO_00000099
 
     
 Class: OEO_00000107
-    Annotations:
+
+    Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
-        rdfs:label "contact person",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "contact person"
+    
     SubClassOf: 
         OEO_00000051
+    
     
 Class: OEO_00000115
 
@@ -1592,37 +1595,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
     
 Class: OEO_00000316
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-change definition and add comment with examples:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/974
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/976
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
-* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
-* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
-        rdfs:label "origin"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
-    
     
 Class: OEO_00000323
 
@@ -1643,98 +1615,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000331
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
-
-definition update and editor note:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/738
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/759
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1218
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>,
-        OEO_00000530 some OEO_00000316
-    
     
 Class: OEO_00000333
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/79
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/369
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003
-    
     
 Class: OEO_00000334
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "block",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/372
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/646
-
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-remove \"among other parts from definition\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1258
-pull request: https://github.com/OpenEnergyPlatform/ontology/issues/1259
-
-New function-based definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
-        rdfs:label "power generating unit"
-    
-    EquivalentTo: 
-        OEO_00020102
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010386)
-    
-    SubClassOf: 
-        OEO_00020102,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
-    
     
 Class: OEO_00000340
 
@@ -1821,26 +1707,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
     
 Class: OEO_00000395
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "In physics, a state of matter is one of the distinct forms in which matter can exist. Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "state of matter"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some OEO_00000331
-    
     
 Class: OEO_00000403
 
@@ -1888,61 +1754,12 @@ Class: OEO_00000423
     
 Class: OEO_00010023
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-Add vehicle operational mode axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000604",
-        rdfs:label "vehicle"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
-    
     
 Class: OEO_00010078
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
-
-move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "global warming potential"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
     
 Class: OEO_00010079
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697",
-        rdfs:label "emission quantity value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
-    
     
 Class: OEO_00010082
 
@@ -1966,27 +1783,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613",
     
     
 Class: OEO_00010083
+
     
 Class: OEO_00010114
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813
-
-change label and definition language
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "waste thermal energy"
-    
-    SubClassOf: 
-        OEO_00000207
-    
     
 Class: OEO_00010115
 
@@ -2056,78 +1856,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
     
 Class: OEO_00010127
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/860
-pull: https://github.com/OpenEnergyPlatform/ontology/pull/865
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
-
-make equivalent and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1523
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1619",
-        rdfs:label "secondary energy production"@en
-    
-    EquivalentTo: 
-        OEO_00240003
-         and (OEO_00000533 some OEO_00140079)
-    
-    SubClassOf: 
-        OEO_00240003,
-        OEO_00000533 some OEO_00140079,
-        OEO_00140002 some OEO_00050019,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003
-    
     
 Class: OEO_00010210
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
-
-Add alternative label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1321
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
-    
     
 Class: OEO_00010211
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "non-energy use"@en
-    
-    SubClassOf: 
-        OEO_00140039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039
-    
     
 Class: OEO_00010263
 
@@ -2550,11 +2284,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00020016
 
-
-    
     
 Class: OEO_00020018
-    
+
     
 Class: OEO_00020032
 
@@ -2720,7 +2452,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
     
     
 Class: OEO_00020069
-    
+
     
 Class: OEO_00020072
 
@@ -3105,14 +2837,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020185
 
     
-    
-    
 Class: OEO_00020186
 
     
 Class: OEO_00020187
 
-    
     
 Class: OEO_00020201
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -932,11 +932,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
 
 Make subproperty of 'has quatity value' and add range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
         rdfs:label "has economic value"
     
     SubPropertyOf: 
@@ -1273,10 +1269,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537
 renaming
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
         rdfs:comment "The original definition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
     
     SubClassOf: 
@@ -1313,10 +1306,7 @@ Class: <http://purl.obolibrary.org/obo/UO_0000224>
         <http://purl.obolibrary.org/obo/IAO_0000118> "kilowatt hours",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term and has_exact_synonym:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kWh",
         rdfs:comment "The original term from UO had neither an alternative term nor has_exact_synonym. It was added for OEO purposes to include the Eurostat spellings."@en
     
@@ -1333,10 +1323,7 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330023>
         <http://purl.obolibrary.org/obo/IAO_0000118> "life cycle analysis"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ökobilanz"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1551
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
         rdfs:label "life cycle assessment"@en
     
     SubClassOf: 
@@ -1373,9 +1360,6 @@ Class: OEO_00000064
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "author"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1919,26 +1919,6 @@ Class: OEO_00020066
 
     
 Class: OEO_00020067
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
-add alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
-subclass of good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
-change axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
-        rdfs:label "commodity"
-    
-    EquivalentTo: 
-        OEO_00010116
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
-    
-    SubClassOf: 
-        OEO_00010116
     
     
 Class: OEO_00020068

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -584,67 +584,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
     
     
 ObjectProperty: OEO_00000514
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a data set and the resolution it depicts."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-rework
-issue https://github.com/OpenEnergyPlatform/ontology/issues/849
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has resolution"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020121
     
     
 ObjectProperty: OEO_00000515
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data set and the spatial resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has spatial resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020123
-    
     
 ObjectProperty: OEO_00000516
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between data set and the temporal resolution it uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/622
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/626
-def and axioms
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/912
-fix def and add domain and range
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/972",
-        rdfs:label "has temporal resolution"
-    
-    SubPropertyOf: 
-        OEO_00000514
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>
-    
-    Range: 
-        OEO_00020122
     
     
 ObjectProperty: OEO_00000522
@@ -3058,78 +3004,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
     
     
 Class: OEO_00030031
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "start time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
 Class: OEO_00030032
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538",
-        rdfs:label "ending time"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
 Class: OEO_00030033
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an ending time and thus a finite duration.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time step"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000038>,
-        ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032)) or ((<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140043)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140044))
     
     
 Class: OEO_00030034
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/IAO_0000584",
-        rdfs:label "time series"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000100>,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030031,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030032,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00030035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00030033 or <http://purl.obolibrary.org/obo/BFO_0000148>)
-    
     
 Class: OEO_00030035
 
@@ -3497,37 +3381,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
     
     
 Class: OEO_00140043
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time stamp"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
     
     
 Class: OEO_00140044
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "time stamp alignment"@en
-    
-    SubClassOf: 
-        OEO_00000119
     
     
 Class: OEO_00140049

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1337,9 +1337,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000088>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    SubClassOf: 
-        OEO_00000514 some OEO_00020121
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
 
@@ -2290,37 +2287,9 @@ Class: OEO_00020018
     
 Class: OEO_00020032
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "study region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
     
 Class: OEO_00020035
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
-The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
-In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
-        rdfs:label "considered region"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
-    
     
 Class: OEO_00020039
 
@@ -2456,26 +2425,6 @@ Class: OEO_00020069
     
 Class: OEO_00020072
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
-
-Add 'is about' axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1059
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1286",
-        rdfs:label "analysis scope"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020098
-    
     
 Class: OEO_00020085
 
@@ -2500,38 +2449,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
 Class: OEO_00020097
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario year"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020098,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>)
-             and (OEO_00140178 value 1))
-    
     
 Class: OEO_00020098
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
-        rdfs:label "scenario horizon"
-    
-    SubClassOf: 
-        OEO_00030033,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020097,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (OEO_00030035
-             and (OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000036>))
-    
     
 Class: OEO_00020102
 
@@ -4290,7 +4210,11 @@ Class: OEO_00340004
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process of becoming smaller, less numerous, less important, or less likely.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "decrease"@en
     
     SubClassOf: 
@@ -4302,8 +4226,12 @@ Class: OEO_00340005
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process of becoming larger, more numerous, more important, or more likely.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644",
-        rdfs:label "increase"@de
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1644
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "increase"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -4335,57 +4263,18 @@ Individual: OEO_00000256
     
     
 Individual: OEO_00020161
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
-        rdfs:label "annual"
-    
-    Types: 
-        OEO_00020122
     
     
 Individual: OEO_00020162
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
-        rdfs:label "weekly"
-    
-    Types: 
-        OEO_00020122
     
     
 Individual: OEO_00020163
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
-        rdfs:label "daily"
-    
-    Types: 
-        OEO_00020122
     
     
 Individual: OEO_00020164
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
-        rdfs:label "hourly"
-    
-    Types: 
-        OEO_00020122
     
     
 Individual: OEO_00020165
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
-        rdfs:label "monthly"
-    
-    Types: 
-        OEO_00020122
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2830,21 +2830,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
     
     
 Class: OEO_00050019
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-moved to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "energy amount value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000111>
     
     
 Class: OEO_00090001
@@ -2864,96 +2849,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00140003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-add performance axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-add has participant axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1271
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000125",
-        rdfs:label "transport"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140002 some OEO_00320000,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323 or OEO_00010116)
     
     
 Class: OEO_00140004
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517",
-        rdfs:label "international transport"@en
-    
-    SubClassOf: 
-        OEO_00140003
     
     
 Class: OEO_00140005
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Add axiom for goods as participant:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
-        rdfs:label "freight transport"@en
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
-    
     
 Class: OEO_00140006
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "private transport"
-    
-    SubClassOf: 
-        OEO_00010263
     
     
 Class: OEO_00140007
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
-
-Make subclass of 'passenger transport'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "public transport"
-    
-    SubClassOf: 
-        OEO_00010263
     
     
 Class: OEO_00140009
@@ -2991,59 +2897,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00140033
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "chemical reaction"@en
     
-    SubClassOf: 
-        OEO_00000419,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+Class: OEO_00140039    
     
-    
-Class: OEO_00140039
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569",
-        rdfs:label "consumption"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140040
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
-        rdfs:label "demand"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000017>,
-        OEO_00010121 some 
-            (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
-    
+Class: OEO_00140040    
     
 Class: OEO_00140043
 
@@ -3052,105 +2909,15 @@ Class: OEO_00140044
 
     
 Class: OEO_00140049
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:label "energy conversion efficiency"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00020003,
-        OEO_00140002 some OEO_00140050
     
     
 Class: OEO_00140050
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
-
-moved to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625",
-        rdfs:label "efficiency value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0010006>
-    
     
 Class: OEO_00140075
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "primary energy carrier disposition"@en
     
-    SubClassOf: 
-        OEO_00000151
-    
-    
-Class: OEO_00140076
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "secondary energy carrier disposition"@en
-    
-    SubClassOf: 
-        OEO_00000151
-    
+Class: OEO_00140076    
     
 Class: OEO_00140079
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
-fix error in definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/669
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/678
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "secondary energy carrier"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076)
-    
-    SubClassOf: 
-        OEO_00020039
-    
     
 Class: OEO_00140081
     
@@ -3220,11 +2987,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
     
     
 Class: OEO_00140159
-    
-    
+     
 Class: OEO_00240003
     
-Class: OEO_00240014    
+    
+Class: OEO_00240014
+    
     
 Class: OEO_00240019
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1909,25 +1909,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
         <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
-Class: OEO_00020060
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "fuel market exchange"
-    
-    SubClassOf: 
-        OEO_00020065,
-        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
-    
-    
 Class: OEO_00020063
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3538,154 +3538,33 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
     
     
 Class: OEO_00240022
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078"@en,
-        rdfs:label "protected area"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
-    
     
 Class: OEO_00240024
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080",
-        rdfs:label "energy service demand"
-    
-    SubClassOf: 
-        OEO_00140040,
-        OEO_00010121 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000051)
-    
     
 Class: OEO_00240038
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "personal living space"
-    
-    SubClassOf: 
-        OEO_00020136
-    
     
 Class: OEO_00260007
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615"@en,
-        rdfs:label "CO2 emission"@en,
-        rdfs:label "carbon dioxide emission"@en
-    
-    EquivalentTo: 
-        OEO_00000147
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000006)
-    
-    SubClassOf: 
-        OEO_00000147
-    
     
 Class: OEO_00320000
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289"@en,
-        rdfs:label "transport performance value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00040010 some OEO_00320001
-    
     
 Class: OEO_00320001
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289",
-        rdfs:label "transport performance unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 Class: OEO_00320002
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-Add pkm as synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
-        rdfs:label "passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320003
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
-
-Add tkm as synonym:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tkm",
-        rdfs:label "ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320041
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314",
-        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
-        rdfs:label "vehicle operational mode"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
-        OEO_00010121 some OEO_00010023
-    
     
 Class: OEO_00320061
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Vehicle-kilometre is a transport performance unit for the accumulated transport distance of the used vehicles themselves where one vehicle-kilometre equals the transport distance of 1 km for one vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388",
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "vkm",
-        rdfs:comment "Can be obtained from passenger-kilometre/ton-kilometre by dividing through the average number of passengers/tons per vehicle respectively.",
-        rdfs:label "vehicle-kilometre"
-    
-    SubClassOf: 
-        OEO_00320001
-    
     
 Class: OEO_00320073
 
@@ -3745,28 +3624,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Individual: OEO_00000182
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "gaseous"
-    
-    Types: 
-        OEO_00000395
-    
     
 Individual: OEO_00000256
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has no definite shape but a definite volume (at a given temperature and pressure).",
-        rdfs:label "liquid"
-    
-    Types: 
-        OEO_00000395
-    
     
 Individual: OEO_00020161
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1888,25 +1888,6 @@ Class: OEO_00020035
 
     
 Class: OEO_00020039
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173",
-        rdfs:label "energy carrier"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-         and (<http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00020063
@@ -1931,24 +1912,6 @@ Class: OEO_00020072
 
     
 Class: OEO_00020085
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Move to oeo-shared:
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy"
-    
-    EquivalentTo: 
-        OEO_00000150
-         and (OEO_00000530 some OEO_00030004)
-    
-    SubClassOf: 
-        OEO_00000150
     
     
 Class: OEO_00020097
@@ -1958,59 +1921,12 @@ Class: OEO_00020098
 
     
 Class: OEO_00020102
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "energy transformation unit"
-    
-    SubClassOf: 
-        OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
     
     
 Class: OEO_00020104
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "outage"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
-    
+      
 Class: OEO_00020107
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
-        rdfs:label "curtailment"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
     
     
 Class: OEO_00020121
@@ -2023,64 +1939,15 @@ Class: OEO_00020123
 
     
 Class: OEO_00020136
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-
-extend definition and add alternative term
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084",
-        rdfs:label "space requirement"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000009>
     
     
 Class: OEO_00020140
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930",
-        rdfs:label "area per power unit"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 Class: OEO_00020142
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "square kilometer"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000047>
     
     
 Class: OEO_00020143
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
-        rdfs:label "area value"
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
     
     
 Class: OEO_00020154
@@ -2108,58 +1975,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     
 Class: OEO_00020175
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "life time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
     
     
 Class: OEO_00020176
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "construction time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
     
     
 Class: OEO_00020177
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "decommissioning time"
-    
-    SubClassOf: 
-        OEO_00030035,
-        OEO_00020056 some OEO_00000061
     
     
 Class: OEO_00020178
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
-        rdfs:label "operational life time"
-    
-    SubClassOf: 
-        OEO_00020175
     
     
 Class: OEO_00020185
@@ -2216,139 +2040,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00020204
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electrical energy amount value"
-    
-    SubClassOf: 
-        OEO_00050019
     
     
 Class: OEO_00020205
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity import value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020207
-    
     
 Class: OEO_00020206
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
-        rdfs:label "electricity export value"
-    
-    SubClassOf: 
-        OEO_00020204,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020208
     
     
 Class: OEO_00020207
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "electricity import"
-    
-    SubClassOf: 
-        OEO_00020201,
-        OEO_00140002 some OEO_00020205,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
     
     
-Class: OEO_00020208
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add class
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
-
-add 'has participant axiom':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "electricity export"
-    
-    SubClassOf: 
-        OEO_00020202,
-        OEO_00140002 some OEO_00020206,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
-    
+Class: OEO_00020208    
     
 Class: OEO_00020248
 
     
 Class: OEO_00020252
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542
-
-move to oeo-share
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
-A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
-        rdfs:label "climate system"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00020264
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575"@en,
-        rdfs:label "material transformation"
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-    
-    SubClassOf: 
-        OEO_00000419
     
     
 Class: OEO_00020267
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy technology is a technology that describes how to combine energy transformation units, energy transformations, energy carriers and energy in a specific way.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
-        rdfs:label "energy technology"
-    
-    SubClassOf: 
-        OEO_00000407,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00020102
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003))
     
     
 Class: OEO_00020309
@@ -2372,93 +2085,13 @@ Class: OEO_00020314
 Class: OEO_00020317
 
     
-Class: OEO_00030002
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-
-Update definition and add disjoint:
-https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Shift part of the definition into an editor note:
-Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1180
-Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1181
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "fossil"
-    
-    SubClassOf: 
-        OEO_00030003,
-        OEO_00010121 some OEO_00000331
-    
+Class: OEO_00030002    
     
 Class: OEO_00030003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
-
-Update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "geogenic"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some 
-            (OEO_00000150 or OEO_00000331)
     
     
 Class: OEO_00030004
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/398
-include \"or energies\"
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Move to oeo-shared:
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable"
-    
-    SubClassOf: 
-        OEO_00000316,
-        OEO_00010121 some OEO_00000150
-    
     
 Class: OEO_00030009
 
@@ -2503,42 +2136,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00030024
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-make subclass of supply system:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1071
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1123
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "energy system"
-    
-    SubClassOf: 
-        OEO_00030025
     
     
 Class: OEO_00030025
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "supply system"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00030029
@@ -2689,35 +2289,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
     
     
 Class: OEO_00050018
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-
-make energy consumption value:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
-        rdfs:label "primary energy consumption"@en
-    
-    SubClassOf: 
-        OEO_00240019,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
     
     
 Class: OEO_00050019

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -584,14 +584,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
     
     
 ObjectProperty: OEO_00000514
-    
+
     
 ObjectProperty: OEO_00000515
 
     
 ObjectProperty: OEO_00000516
 
-    
     
 ObjectProperty: OEO_00000522
 
@@ -2224,60 +2223,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
     
 Class: OEO_00020121
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "resolution"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/IAO_0000100>
-    
     
 Class: OEO_00020122
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-add individuals
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
-
-add 'has bearer' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
-        rdfs:label "temporal resolution"
-    
-    SubClassOf: 
-        OEO_00020121,
-        OEO_00010121 some OEO_00030034
-    
-    DisjointWith: 
-        OEO_00020123
-    
     
 Class: OEO_00020123
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912",
-        rdfs:label "spatial resolution"
-    
-    SubClassOf: 
-        OEO_00020121
-    
-    DisjointWith: 
-        OEO_00020122
-    
     
 Class: OEO_00020136
 
@@ -2836,61 +2787,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
     
 Class: OEO_00030029
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "exogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020189 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
-    
     
 Class: OEO_00030030
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
-
-make equivalent class
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113
-
-add relation to quantity value:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
-        rdfs:label "endogenous data"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>
-         and (OEO_00020190 some OEO_00000275)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000027>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000350
     
     
 Class: OEO_00030031
-    
+
     
 Class: OEO_00030032
-    
+
     
 Class: OEO_00030033
-    
+
     
 Class: OEO_00030034
 
@@ -2904,7 +2812,10 @@ Class: OEO_00030035
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
 change duration to time span (def, label, alternative term)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1017
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "time span"
     
     SubClassOf: 
@@ -3261,10 +3172,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
     
     
 Class: OEO_00140043
-    
+
     
 Class: OEO_00140044
-    
+
     
 Class: OEO_00140049
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2162,21 +2162,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026",
         OEO_00020175
     
     
-Class: OEO_00020181
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of emission"
-    
-    SubClassOf: 
-        OEO_00040009,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
 Class: OEO_00020185
 
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1862,62 +1862,15 @@ Class: OEO_00010211
     
 Class: OEO_00010263
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
-    
     
 Class: OEO_00010264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        OEO_00000051,
-        OEO_00010121 some OEO_00000323
-    
     
 Class: OEO_00010265
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
-    
     
 Class: OEO_00010266
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
-    
     
 Class: OEO_00010268
 
@@ -1974,134 +1927,24 @@ Class: OEO_00010296
     
 Class: OEO_00010315
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-make subclass of secondary energy production and further changes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil refining process"
-    
-    SubClassOf: 
-        OEO_00010127,
-        OEO_00000532 some OEO_00000115,
-        OEO_00000533 some OEO_00010316,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
-    
     
 Class: OEO_00010316
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add 'secondary energy carrier disposition' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil product"
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00240025 some OEO_00010315)
-    
-    SubClassOf: 
-        OEO_00000014,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
     
 Class: OEO_00010361
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power unit"@en
-    
-    EquivalentTo: 
-        OEO_00000334
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00010234 some OEO_00020085
-    
     
 Class: OEO_00010362
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power plant"@en
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
-    
-    SubClassOf: 
-        OEO_00000031
-    
     
 Class: OEO_00010385
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "energy transformation function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>,
-        OEO_00010121 some OEO_00000061
-    
     
 Class: OEO_00010386
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity generation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010388
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy transformation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010404
 
@@ -2127,82 +1970,9 @@ Class: OEO_00010412
     
 Class: OEO_00020003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-added process attributes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625"@en,
-        rdfs:label "energy transformation"@en
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00010234 some OEO_00000150)
-         and (OEO_00010235 some OEO_00000150)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000500 some OEO_00000333,
-        OEO_00000500 some OEO_00140049,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
     
 Class: OEO_00020006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
     
 Class: OEO_00020011
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -958,7 +958,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
 
 Make subproperty of 'has quatity value' and add range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has economic value"
     
     SubPropertyOf: 
@@ -1543,7 +1547,10 @@ Class: OEO_00000340
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
 move to oeo-shared
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "project"
     
     SubClassOf: 
@@ -1565,7 +1572,11 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1405
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606
+
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -1601,14 +1612,14 @@ Class: OEO_00000407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334
 moved to oeo-shared, change definition, reclassify, add axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "technology"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00000061
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>))
+        <http://purl.obolibrary.org/obo/IAO_0000104>
     
     
 Class: OEO_00000419
@@ -1621,7 +1632,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
 
 input and output axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "transformation"
     
     SubClassOf: 
@@ -1665,7 +1679,10 @@ move to oeo-shared
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
 
 make good a continuant:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "good"@en
     
     EquivalentTo: 
@@ -1693,13 +1710,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
 add 'has bearer' axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "good role"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00010121 some 
-            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>),
         OEO_00020180 some OEO_00040003
     
     
@@ -1816,7 +1834,11 @@ Class: OEO_00020012
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
 add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "study report"@en
     
     SubClassOf: 
@@ -2168,7 +2190,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
 
 move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "methodology"
     
     SubClassOf: 
@@ -2266,7 +2291,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 
 add 'has participant axiom':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "import"
     
     SubClassOf: 
@@ -2285,7 +2313,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 
 add 'has participant axiom':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "export"
     
     SubClassOf: 
@@ -2547,7 +2578,10 @@ Class: OEO_00030019
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "process attribute"
     
     SubClassOf: 
@@ -2566,7 +2600,10 @@ added term in oeo-shared:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
 deleted term in oeo-social:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "organisation"
     
     SubClassOf: 
@@ -2816,7 +2853,10 @@ Class: OEO_00090001
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "funder"@en
     
     SubClassOf: 
@@ -2922,7 +2962,10 @@ Class: OEO_00140009
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "sponsor"@en
     
     SubClassOf: 
@@ -2937,7 +2980,10 @@ Class: OEO_00140012
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559
 move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "economic value"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -781,32 +781,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
         OEO_00240025
     
     
-ObjectProperty: OEO_00010119
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-Make subproperty of 'is about':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
-
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "guides"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    Domain: 
-        OEO_00140151
-    
-    Range: 
-        OEO_00140149
-    
-    
 ObjectProperty: OEO_00010121
 
     Annotations: 
@@ -1717,8 +1691,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "good role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>,
-        OEO_00020180 some OEO_00040003
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Class: OEO_00010127
@@ -2013,8 +1986,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "import"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00020202
@@ -2035,8 +2007,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "export"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00020204
@@ -2178,115 +2149,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000350,
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
-    
-    
-Class: OEO_00040002
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
-https://github.com/OpenEnergyPlatform/ontology/pull/639
-
-https://github.com/OpenEnergyPlatform/ontology/issues/677
-https://github.com/OpenEnergyPlatform/ontology/pull/740
-
-change label to market exchange role
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "market exchange role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
+        
     
 Class: OEO_00040003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to good
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "monetary price"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00020179 some OEO_00010117,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00040004
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
-https://github.com/OpenEnergyPlatform/ontology/pull/640
-add comment and example
-https://github.com/OpenEnergyPlatform/ontology/pull/910
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956",
-        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
-        rdfs:label "currency"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
-    
-Class: OEO_00040009
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
-move to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-delete cost in oeo-social
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977",
-        rdfs:label "cost"@en
-    
-    SubClassOf: 
-        OEO_00140012,
-        OEO_00040010 some OEO_00040004
-    
-    
-Class: OEO_00040011
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
-https://github.com/OpenEnergyPlatform/ontology/pull/644
-moved to oeo-shared and renamed
-https://github.com/OpenEnergyPlatform/ontology/pull/748
-made subclass of good role
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843",
-        rdfs:label "commodity role"@en,
-        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
-    
-    SubClassOf: 
-        OEO_00010117
-    
+      
     
 Class: OEO_00050018
     
@@ -2382,72 +2248,8 @@ Class: OEO_00140076
 Class: OEO_00140079
     
 Class: OEO_00140081
-    
-    
-Class: OEO_00140124
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
 
-add 'has participant axiom' and move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        rdfs:label "service"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
-    
-    
-Class: OEO_00140149
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-move to oeo-shared, alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "transformative measure"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    
-Class: OEO_00140151
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
-
-Redefine as 'plan specification' and add axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
-
-move to oeo-shared, alternative label
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "policy instrument"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000104>,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
-        OEO_00010119 some OEO_00140149,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
-    
-    
 Class: OEO_00140159
      
 Class: OEO_00240003
@@ -2487,30 +2289,6 @@ Class: OEO_00320041
     
 Class: OEO_00320061
 
-    
-Class: OEO_00320073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
-        rdfs:label "amortisation time"
-    
-    SubClassOf: 
-        OEO_00030035
-    
-    
-Class: OEO_00320074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436",
-        rdfs:label "economic life time"
-    
-    SubClassOf: 
-        OEO_00020178
-    
     
 Class: OEO_00340004
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2086,24 +2086,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020154
     
     
-Class: OEO_00020155
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission value, add new parent class and relabel
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "social cost of carbon emission"
-    
-    SubClassOf: 
-        OEO_00020181,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
 Class: OEO_00020166
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1913,20 +1913,6 @@ Class: OEO_00020063
     
     
 Class: OEO_00020065
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
-        rdfs:label "energy market exchange"
-    
-    SubClassOf: 
-        OEO_00020069
     
     
 Class: OEO_00020066

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1343,25 +1343,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00020166
     
     
-Class: OEO_00000001
-
-    
-Class: OEO_00000006
-
-    
-Class: OEO_00000007
-
-    
-Class: OEO_00000011
-
-    
-Class: OEO_00000014
-
-    
 Class: OEO_00000020
-
-    
-Class: OEO_00000031
 
     
 Class: OEO_00000051
@@ -1403,12 +1385,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000087
 
     
-Class: OEO_00000097
-
-    
-Class: OEO_00000099
-
-    
 Class: OEO_00000107
 
     Annotations: 
@@ -1423,55 +1399,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000051
     
     
-Class: OEO_00000115
-
-    
-Class: OEO_00000139
-
-    
-Class: OEO_00000143
-
-    
-Class: OEO_00000144
-
-    
-Class: OEO_00000147
-
-    
-Class: OEO_00000148
-
-    
 Class: OEO_00000150
-
-    
-Class: OEO_00000151
-
-    
-Class: OEO_00000173
-
-    
-Class: OEO_00000188
-
-    
-Class: OEO_00000198
-
-    
-Class: OEO_00000199
-
-    
-Class: OEO_00000200
-
-    
-Class: OEO_00000206
-
-    
-Class: OEO_00000207
-
-    
-Class: OEO_00000253
-
-    
-Class: OEO_00000255
 
     
 Class: OEO_00000274
@@ -1498,12 +1426,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00000331
-
-    
-Class: OEO_00000333
-
-    
-Class: OEO_00000334
 
     
 Class: OEO_00000340
@@ -1603,16 +1525,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
-Class: OEO_00010023
-
-    
 Class: OEO_00010078
 
     
 Class: OEO_00010079
-
-    
-Class: OEO_00010114
 
     
 Class: OEO_00010116
@@ -1667,52 +1583,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: OEO_00010127
-
-    
-Class: OEO_00010210
-
-    
-Class: OEO_00010211
-
-    
-Class: OEO_00010263
-
-    
-Class: OEO_00010264
-
-    
-Class: OEO_00010265
-
-    
-Class: OEO_00010266
-
-    
 Class: OEO_00010315
-
-    
-Class: OEO_00010316
-
-    
-Class: OEO_00010361
-
-    
-Class: OEO_00010362
-
-    
-Class: OEO_00010385
-
-    
-Class: OEO_00010386
-
-    
-Class: OEO_00010388
-
-    
-Class: OEO_00020003
-
-    
-Class: OEO_00020006
 
     
 Class: OEO_00020011
@@ -1797,30 +1668,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020039
 
     
-Class: OEO_00020085
-
-    
-Class: OEO_00020102
-
-    
-Class: OEO_00020104
-
-    
-Class: OEO_00020107
-
-    
-Class: OEO_00020136
-
-    
-Class: OEO_00020140
-
-    
-Class: OEO_00020142
-
-    
-Class: OEO_00020143
-
-    
 Class: OEO_00020166
 
     Annotations: 
@@ -1841,15 +1688,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         <http://purl.obolibrary.org/obo/IAO_0000104>,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
     
-    
-Class: OEO_00020175
-
-    
-Class: OEO_00020176
-
-    
-Class: OEO_00020177
-
     
 Class: OEO_00020178
 
@@ -1896,39 +1734,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: OEO_00020204
-
-    
-Class: OEO_00020205
-
-    
-Class: OEO_00020206
-
-    
-Class: OEO_00020207
-
-    
-Class: OEO_00020208
-
-    
-Class: OEO_00020252
-
-    
-Class: OEO_00020264
-
-    
-Class: OEO_00020267
-
-    
-Class: OEO_00030002
-
-    
-Class: OEO_00030003
-
-    
-Class: OEO_00030004
-
-    
 Class: OEO_00030019
 
     Annotations: 
@@ -1968,12 +1773,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     
-Class: OEO_00030024
-
-    
-Class: OEO_00030025
-
-    
 Class: OEO_00030035
 
     Annotations: 
@@ -1995,12 +1794,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
     
     
-Class: OEO_00050018
-
-    
-Class: OEO_00050019
-
-    
 Class: OEO_00090001
 
     Annotations: 
@@ -2017,19 +1810,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00140009
     
     
-Class: OEO_00140003
-
-    
 Class: OEO_00140004
-
-    
-Class: OEO_00140005
-
-    
-Class: OEO_00140006
-
-    
-Class: OEO_00140007
 
     
 Class: OEO_00140009
@@ -2066,73 +1847,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000350
     
     
-Class: OEO_00140033
-
-    
-Class: OEO_00140039
-
-    
-Class: OEO_00140040
-
-    
-Class: OEO_00140049
-
-    
-Class: OEO_00140050
-
-    
-Class: OEO_00140075
-
-    
-Class: OEO_00140076
-
-    
-Class: OEO_00140079
-
-    
 Class: OEO_00140081
-
-    
-Class: OEO_00140159
-
-    
-Class: OEO_00240003
-
-    
-Class: OEO_00240014
-
-    
-Class: OEO_00240019
-
-    
-Class: OEO_00240022
-
-    
-Class: OEO_00240024
-
-    
-Class: OEO_00240038
-
-    
-Class: OEO_00260007
-
-    
-Class: OEO_00320000
-
-    
-Class: OEO_00320001
-
-    
-Class: OEO_00320002
-
-    
-Class: OEO_00320003
-
-    
-Class: OEO_00320041
-
-    
-Class: OEO_00320061
 
     
 Class: OEO_00340004

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1327,7 +1327,10 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330023>
         <http://purl.obolibrary.org/obo/IAO_0000118> "life cycle analysis"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ökobilanz"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1551
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "life cycle assessment"@en
     
     SubClassOf: 
@@ -1466,7 +1469,7 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-    
+
     
 Class: OEO_00000253
 
@@ -1485,7 +1488,7 @@ Class: OEO_00000275
     
 Class: OEO_00000315
 
-
+    
 Class: OEO_00000316
 
     
@@ -1566,10 +1569,10 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-    
+
     
 Class: OEO_00000368
-    
+
     
 Class: OEO_00000395
 
@@ -1631,7 +1634,7 @@ Class: OEO_00010079
 
     
 Class: OEO_00010082
-    
+
     
 Class: OEO_00010083
 
@@ -1641,7 +1644,7 @@ Class: OEO_00010114
     
 Class: OEO_00010115
 
-
+    
 Class: OEO_00010116
 
     Annotations: 
@@ -1716,16 +1719,16 @@ Class: OEO_00010266
 
     
 Class: OEO_00010268
-    
+
     
 Class: OEO_00010269
-    
+
     
 Class: OEO_00010270
-    
+
     
 Class: OEO_00010271
-    
+
     
 Class: OEO_00010296
 
@@ -1758,7 +1761,7 @@ Class: OEO_00010406
 
     
 Class: OEO_00010407
-    
+
     
 Class: OEO_00010412
 
@@ -1861,22 +1864,22 @@ Class: OEO_00020035
 
     
 Class: OEO_00020039
-    
+
     
 Class: OEO_00020063
-    
+
     
 Class: OEO_00020065
-    
+
     
 Class: OEO_00020066
 
     
 Class: OEO_00020067
-    
+
     
 Class: OEO_00020068
-    
+
     
 Class: OEO_00020069
 
@@ -1885,7 +1888,7 @@ Class: OEO_00020072
 
     
 Class: OEO_00020085
-    
+
     
 Class: OEO_00020097
 
@@ -1894,13 +1897,13 @@ Class: OEO_00020098
 
     
 Class: OEO_00020102
-    
+
     
 Class: OEO_00020104
 
-      
-Class: OEO_00020107
     
+Class: OEO_00020107
+
     
 Class: OEO_00020121
 
@@ -1912,19 +1915,19 @@ Class: OEO_00020123
 
     
 Class: OEO_00020136
-    
+
     
 Class: OEO_00020140
-    
+
     
 Class: OEO_00020142
-    
+
     
 Class: OEO_00020143
-    
+
     
 Class: OEO_00020154
-    
+
     
 Class: OEO_00020166
 
@@ -1948,16 +1951,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     
 Class: OEO_00020175
-    
+
     
 Class: OEO_00020176
-    
+
     
 Class: OEO_00020177
-    
+
     
 Class: OEO_00020178
-    
+
     
 Class: OEO_00020185
 
@@ -2011,29 +2014,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00020204
-    
+
     
 Class: OEO_00020205
+
     
 Class: OEO_00020206
-    
+
     
 Class: OEO_00020207
+
     
-    
-Class: OEO_00020208    
+Class: OEO_00020208
+
     
 Class: OEO_00020248
 
     
 Class: OEO_00020252
-    
+
     
 Class: OEO_00020264
-    
+
     
 Class: OEO_00020267
-    
+
     
 Class: OEO_00020309
 
@@ -2056,10 +2061,11 @@ Class: OEO_00020314
 Class: OEO_00020317
 
     
-Class: OEO_00030002    
+Class: OEO_00030002
+
     
 Class: OEO_00030003
-    
+
     
 Class: OEO_00030004
 
@@ -2107,16 +2113,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00030024
-    
+
     
 Class: OEO_00030025
-    
+
     
 Class: OEO_00030029
 
     
 Class: OEO_00030030
-    
+
     
 Class: OEO_00030031
 
@@ -2149,16 +2155,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000350,
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
-        
+    
     
 Class: OEO_00040003
-      
+
     
 Class: OEO_00050018
-    
+
     
 Class: OEO_00050019
-    
+
     
 Class: OEO_00090001
 
@@ -2177,18 +2183,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00140003
-    
+
     
 Class: OEO_00140004
-    
+
     
 Class: OEO_00140005
+
     
 Class: OEO_00140006
-    
+
     
 Class: OEO_00140007
-    
+
     
 Class: OEO_00140009
 
@@ -2225,10 +2232,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00140033
+
     
-Class: OEO_00140039    
+Class: OEO_00140039
+
     
-Class: OEO_00140040    
+Class: OEO_00140040
+
     
 Class: OEO_00140043
 
@@ -2237,31 +2247,37 @@ Class: OEO_00140044
 
     
 Class: OEO_00140049
-    
+
     
 Class: OEO_00140050
+
     
 Class: OEO_00140075
+
     
-Class: OEO_00140076    
+Class: OEO_00140076
+
     
 Class: OEO_00140079
+
     
 Class: OEO_00140081
 
-
-Class: OEO_00140159
-     
-Class: OEO_00240003
     
+Class: OEO_00140159
+
+    
+Class: OEO_00240003
+
     
 Class: OEO_00240014
-    
+
     
 Class: OEO_00240019
-    
+
     
 Class: OEO_00240022
+
     
 Class: OEO_00240024
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1426,9 +1426,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000115
 
     
-Class: OEO_00000119
-
-    
 Class: OEO_00000139
 
     
@@ -1442,9 +1439,6 @@ Class: OEO_00000147
 
     
 Class: OEO_00000148
-
-    
-Class: OEO_00000149
 
     
 Class: OEO_00000150
@@ -1474,22 +1468,13 @@ Class: OEO_00000206
 Class: OEO_00000207
 
     
-Class: OEO_00000238
-
-    
 Class: OEO_00000253
 
     
 Class: OEO_00000255
 
     
-Class: OEO_00000264
-
-    
 Class: OEO_00000274
-
-    
-Class: OEO_00000275
 
     
 Class: OEO_00000315
@@ -1571,19 +1556,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000000>
     
     
-Class: OEO_00000364
-
-    
 Class: OEO_00000367
 
     
-Class: OEO_00000368
-
-    
 Class: OEO_00000395
-
-    
-Class: OEO_00000403
 
     
 Class: OEO_00000407
@@ -1627,9 +1603,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
-Class: OEO_00000423
-
-    
 Class: OEO_00010023
 
     
@@ -1639,16 +1612,7 @@ Class: OEO_00010078
 Class: OEO_00010079
 
     
-Class: OEO_00010082
-
-    
-Class: OEO_00010083
-
-    
 Class: OEO_00010114
-
-    
-Class: OEO_00010115
 
     
 Class: OEO_00010116
@@ -1724,21 +1688,6 @@ Class: OEO_00010265
 Class: OEO_00010266
 
     
-Class: OEO_00010268
-
-    
-Class: OEO_00010269
-
-    
-Class: OEO_00010270
-
-    
-Class: OEO_00010271
-
-    
-Class: OEO_00010296
-
-    
 Class: OEO_00010315
 
     
@@ -1758,18 +1707,6 @@ Class: OEO_00010386
 
     
 Class: OEO_00010388
-
-    
-Class: OEO_00010404
-
-    
-Class: OEO_00010406
-
-    
-Class: OEO_00010407
-
-    
-Class: OEO_00010412
 
     
 Class: OEO_00020003
@@ -1857,49 +1794,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
-Class: OEO_00020016
-
-    
-Class: OEO_00020018
-
-    
-Class: OEO_00020032
-
-    
-Class: OEO_00020035
-
-    
 Class: OEO_00020039
 
     
-Class: OEO_00020063
-
-    
-Class: OEO_00020065
-
-    
-Class: OEO_00020066
-
-    
-Class: OEO_00020067
-
-    
-Class: OEO_00020068
-
-    
-Class: OEO_00020069
-
-    
-Class: OEO_00020072
-
-    
 Class: OEO_00020085
-
-    
-Class: OEO_00020097
-
-    
-Class: OEO_00020098
 
     
 Class: OEO_00020102
@@ -1909,15 +1807,6 @@ Class: OEO_00020104
 
     
 Class: OEO_00020107
-
-    
-Class: OEO_00020121
-
-    
-Class: OEO_00020122
-
-    
-Class: OEO_00020123
 
     
 Class: OEO_00020136
@@ -1930,9 +1819,6 @@ Class: OEO_00020142
 
     
 Class: OEO_00020143
-
-    
-Class: OEO_00020154
 
     
 Class: OEO_00020166
@@ -1966,15 +1852,6 @@ Class: OEO_00020177
 
     
 Class: OEO_00020178
-
-    
-Class: OEO_00020185
-
-    
-Class: OEO_00020186
-
-    
-Class: OEO_00020187
 
     
 Class: OEO_00020201
@@ -2034,9 +1911,6 @@ Class: OEO_00020207
 Class: OEO_00020208
 
     
-Class: OEO_00020248
-
-    
 Class: OEO_00020252
 
     
@@ -2046,27 +1920,6 @@ Class: OEO_00020264
 Class: OEO_00020267
 
     
-Class: OEO_00020309
-
-    
-Class: OEO_00020310
-
-    
-Class: OEO_00020311
-
-    
-Class: OEO_00020312
-
-    
-Class: OEO_00020313
-
-    
-Class: OEO_00020314
-
-    
-Class: OEO_00020317
-
-    
 Class: OEO_00030002
 
     
@@ -2074,9 +1927,6 @@ Class: OEO_00030003
 
     
 Class: OEO_00030004
-
-    
-Class: OEO_00030009
 
     
 Class: OEO_00030019
@@ -2124,24 +1974,6 @@ Class: OEO_00030024
 Class: OEO_00030025
 
     
-Class: OEO_00030029
-
-    
-Class: OEO_00030030
-
-    
-Class: OEO_00030031
-
-    
-Class: OEO_00030032
-
-    
-Class: OEO_00030033
-
-    
-Class: OEO_00030034
-
-    
 Class: OEO_00030035
 
     Annotations: 
@@ -2162,9 +1994,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000038>,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000003>
     
-    
-Class: OEO_00040003
-
     
 Class: OEO_00050018
 
@@ -2244,12 +2073,6 @@ Class: OEO_00140039
 
     
 Class: OEO_00140040
-
-    
-Class: OEO_00140043
-
-    
-Class: OEO_00140044
 
     
 Class: OEO_00140049

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1313,7 +1313,10 @@ Class: <http://purl.obolibrary.org/obo/UO_0000224>
         <http://purl.obolibrary.org/obo/IAO_0000118> "kilowatt hours",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term and has_exact_synonym:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/924
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kWh",
         rdfs:comment "The original term from UO had neither an alternative term nor has_exact_synonym. It was added for OEO purposes to include the Eurostat spellings."@en
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1528,9 +1528,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010078
 
     
-Class: OEO_00010079
-
-    
 Class: OEO_00010116
 
     Annotations: 
@@ -1582,9 +1579,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
-    
-Class: OEO_00010315
-
     
 Class: OEO_00020011
 
@@ -1688,9 +1682,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         <http://purl.obolibrary.org/obo/IAO_0000104>,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020011
     
-    
-Class: OEO_00020178
-
     
 Class: OEO_00020201
 
@@ -1810,9 +1801,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00140009
     
     
-Class: OEO_00140004
-
-    
 Class: OEO_00140009
 
     Annotations: 
@@ -1846,9 +1834,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00000350
     
-    
-Class: OEO_00140081
-
     
 Class: OEO_00340004
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1273,7 +1273,10 @@ Class: <http://purl.obolibrary.org/obo/UO_0000000>
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/533
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/537
 renaming
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:comment "The original definition from UO is \"A unit of measurement is a standardized quantity of a physical quality.\". It was adjusted for OEO purposes such that currencies can also be defined as units."
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1917,16 +1917,6 @@ Class: OEO_00020065
     
 Class: OEO_00020066
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity role"
-    
-    SubClassOf: 
-        OEO_00040011
-    
     
 Class: OEO_00020067
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1421,10 +1421,7 @@ Class: OEO_00000340
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
 move to oeo-shared
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/862
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
-rework module structure
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
         rdfs:label "project"
     
     SubClassOf: 
@@ -1446,11 +1443,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/518
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1405
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606
-
-rework module structure
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1606",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -1602,11 +1595,7 @@ Class: OEO_00020012
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
 add etitor note
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1025"@en,
         rdfs:label "study report"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3107,27 +3107,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
     
     
 Class: OEO_00140081
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-has quantity value axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
-moved to oeo-shared
-https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to social cost of carbon
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        OEO_00030019,
-        OEO_00000502 some OEO_00000147,
-        OEO_00020180 some OEO_00020181,
-        OEO_00140002 some OEO_00010079
     
     
 Class: OEO_00140124
@@ -3195,85 +3174,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
     
     
 Class: OEO_00140159
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "hydrocarbon"@en
-    
-    SubClassOf: 
-        OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
     
     
 Class: OEO_00240003
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
-reclassify and make equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575",
-        rdfs:label "production"
     
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
-         and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
-    
-    
-Class: OEO_00240014
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-Add alternative label and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
-        rdfs:label "electricity generation process"
-    
-    EquivalentTo: 
-        OEO_00020003
-         and (OEO_00010235 some OEO_00000139)
-    
+Class: OEO_00240014    
     
 Class: OEO_00240019
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1463"@en,
-        rdfs:label "energy consumption value"
-    
-    SubClassOf: 
-        OEO_00050019,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
     
     
 Class: OEO_00240022

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1922,19 +1922,6 @@ Class: OEO_00020067
     
     
 Class: OEO_00020068
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
-        rdfs:label "fuel commodity"
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066
-    
-    SubClassOf: 
-        OEO_00020067
     
     
 Class: OEO_00020069

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1481,9 +1481,6 @@ Class: OEO_00000199
     
 Class: OEO_00000200
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
-    
     
 Class: OEO_00000206
 
@@ -2600,18 +2597,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
     
 Class: OEO_00020248
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An explorative scenario is a scenario that contains certain constraints / statements regarding measures that are taken in the near future / today to explore where these measures will lead to in a later future. The later future is not predefined in the scenario.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1110
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1459
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "explorative scenario"
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00020252
 
@@ -2667,111 +2652,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591",
     
 Class: OEO_00020309
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy scenario is a scenario in which certain policy instruments or transformative measures and their impacts are assessed.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
-        rdfs:label "policy scenario"
-    
-    EquivalentTo: 
-        OEO_00020248
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00140149 or OEO_00140151))
-    
-    SubClassOf: 
-        OEO_00020248
-    
     
 Class: OEO_00020310
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A without measures scenario (WOM) is a policy scenario that excludes all policy instruments and transformative measures which are planned, adopted or implemented.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WOM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "without measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020311
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A with existing measures scenario (WEM) is a policy scenario that includes policy instruments and transformative measures that have been adopted and implemented.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WEM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "baseline scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "with existing measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020312
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A with additional measures scenario (WAM) is a policy scenario that includes policy instruments and transformative measures which have been adopted and implemented to mitigate climate change or meet energy objectives, as well as policy instruments and transformative measures which are planned for that purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "WAM scenario",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R1999&from=EN#d1e968-1-1 Article 2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "with additional measures scenario"
-    
-    SubClassOf: 
-        OEO_00020309
-    
     
 Class: OEO_00020313
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an information content entity, that indicates a benchmark, e.g. in a comparison.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Although contradicting to BFO2, we add the reference role to the generically dependent \"information content entity\", aware of the ongoing discussion.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "reference role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
     
 Class: OEO_00020314
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A reference scenario is a scenario that is used as a reference, e.g. in a scenario comparison. It has the reference role.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
-        rdfs:label "reference scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020313)
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00020317
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission scenario is an emission scenario that describes a possible greenhouse gas emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "greenhouse gas emission scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199)
-    
-    SubClassOf: 
-        OEO_00030009
-    
     
 Class: OEO_00030002
 
@@ -2863,24 +2761,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
 Class: OEO_00030009
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
-
-move to oeo-share
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615",
-        rdfs:label "emission scenario"
-    
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000147)
-    
-    SubClassOf: 
-        OEO_00000364
-    
     
 Class: OEO_00030019
 
@@ -3889,18 +3769,17 @@ Individual: OEO_00000256
     
     
 Individual: OEO_00020161
-    
+
     
 Individual: OEO_00020162
-    
+
     
 Individual: OEO_00020163
-    
+
     
 Individual: OEO_00020164
-    
+
     
 Individual: OEO_00020165
 
-    
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -513,12 +513,6 @@ Class: OEO_00000238
     
 Class: OEO_00000264
 
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
-        OEO_00140164 some OEO_00020065
-    
     
 Class: OEO_00000315
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -404,6 +404,16 @@ Class: OEO_00000064
     
 Class: OEO_00000087
 
+    Annotations:
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
+        rdfs:label "client",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+
+    SubClassOf:
+        OEO_00000051
     
 Class: OEO_00000105
 
@@ -417,7 +427,6 @@ Class: OEO_00000105
     
     
 Class: OEO_00000107
-
     
 Class: OEO_00000128
 
@@ -676,6 +685,29 @@ Class: OEO_00010082
 
     
 Class: OEO_00010083
+
+    Annotations:
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+update definition and improve axiom:
+https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "market participant"@en
+
+    SubClassOf:
+        OEO_00000051,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
 
     
 Class: OEO_00010115
@@ -966,6 +998,34 @@ Class: OEO_00020068
     
 Class: OEO_00020069
 
+    Annotations:
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652s",
+        rdfs:label "market exchange"
+
+    EquivalentTo:
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
+
+    SubClassOf:
+        OEO_00030022,
+
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
+https://github.com/OpenEnergyPlatform/ontology/pull/1019
+rework module structure
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+        <http://purl.obolibrary.org/obo/RO_0000056> some
+            (OEO_00010082
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
     
 Class: OEO_00020075
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -404,16 +404,17 @@ Class: OEO_00000064
     
 Class: OEO_00000087
 
-    Annotations:
+    Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
-        rdfs:label "client",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-
-    SubClassOf:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "client"
+    
+    SubClassOf: 
         OEO_00000051
+    
     
 Class: OEO_00000105
 
@@ -427,6 +428,7 @@ Class: OEO_00000105
     
     
 Class: OEO_00000107
+
     
 Class: OEO_00000128
 
@@ -677,16 +679,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1558",
     
 Class: OEO_00010079
 
-    SubClassOf: 
-        OEO_00020056 some OEO_00020063
-    
     
 Class: OEO_00010082
 
     
 Class: OEO_00010083
 
-    Annotations:
+    Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
@@ -704,11 +703,11 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "market participant"@en
-
-    SubClassOf:
+    
+    SubClassOf: 
         OEO_00000051,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010082
-
+    
     
 Class: OEO_00010115
 
@@ -998,7 +997,7 @@ Class: OEO_00020068
     
 Class: OEO_00020069
 
-    Annotations:
+    Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
@@ -1011,21 +1010,22 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652s",
         rdfs:label "market exchange"
-
-    EquivalentTo:
+    
+    EquivalentTo: 
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
-
-    SubClassOf:
+    
+    SubClassOf: 
         OEO_00030022,
-
+        
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/617
 https://github.com/OpenEnergyPlatform/ontology/pull/1019
 rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-        <http://purl.obolibrary.org/obo/RO_0000056> some
+        <http://purl.obolibrary.org/obo/RO_0000056> some 
             (OEO_00010082
              and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010083))
+    
     
 Class: OEO_00020075
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2409,16 +2409,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
     
 Class: OEO_00140146
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
-        rdfs:label "energy demand"@en
-    
-    SubClassOf: 
-        OEO_00140040
-    
     
 Class: OEO_00140149
 
@@ -2648,40 +2638,12 @@ Class: OEO_00260007
     
 Class: OEO_00260008
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission value is greenhouse gas emission value that quantifies the output of a CO2 emission process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/"@en,
-        rdfs:label "CO2 emission value"@en,
-        rdfs:label "carbon dioxide emission value"@en
-    
-    SubClassOf: 
-        OEO_00140081
-    
     
 Class: OEO_00320062
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389",
-        rdfs:label "electricity demand"
-    
-    SubClassOf: 
-        OEO_00140146
-    
     
 Class: OEO_00320063
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389",
-        rdfs:label "fuel demand"
-    
-    SubClassOf: 
-        OEO_00140146
-    
     
 Class: OEO_00320073
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1206,7 +1206,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00020068
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel commodity is a commodity that is a fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
+        rdfs:label "fuel commodity"
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066
+    
     SubClassOf: 
+        OEO_00020067,
         OEO_00020070 some OEO_00020060
     
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -412,9 +412,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1482",
         OEO_00020145
     
     
-Class: OEO_00000006
-
-    
 Class: OEO_00000045
 
     Annotations: 
@@ -496,9 +493,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
         OEO_00000158
     
     
-Class: OEO_00000147
-
-    
 Class: OEO_00000158
 
     Annotations: 
@@ -570,9 +564,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00030022
     
-    
-Class: OEO_00000264
-
     
 Class: OEO_00000315
 
@@ -2167,9 +2158,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
         OEO_00140012
     
     
-Class: OEO_00140040
-
-    
 Class: OEO_00140081
 
     
@@ -2407,9 +2395,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         OEO_00040005
     
     
-Class: OEO_00140146
-
-    
 Class: OEO_00140149
 
     Annotations: 
@@ -2632,18 +2617,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
     SubClassOf: 
         OEO_00040003
     
-    
-Class: OEO_00260007
-
-    
-Class: OEO_00260008
-
-    
-Class: OEO_00320062
-
-    
-Class: OEO_00320063
-
     
 Class: OEO_00320073
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -139,6 +139,10 @@ ObjectProperty: OEO_00010121
     
 ObjectProperty: OEO_00010128
 
+
+ObjectProperty: OEO_00020179
+
+
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
@@ -273,7 +277,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
     
 ObjectProperty: OEO_00140164
 
-    
+
+ObjectProperty: OEO_00020180
+
+
+ObjectProperty:  OEO_00140002
+
+
 ObjectProperty: owl:topObjectProperty
 
     
@@ -521,12 +531,41 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
     
 Class: OEO_00000238
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "institution"
+    
+    SubClassOf: 
+        OEO_00030022
     
 Class: OEO_00000264
 
     
 Class: OEO_00000315
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "organisation role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    DisjointWith: 
+        OEO_00000323
+        
     
 Class: OEO_00000323
 
@@ -561,10 +600,48 @@ Class: OEO_00000350
     
 Class: OEO_00000367
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "sector"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
+    
     
 Class: OEO_00000368
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+Add relation to organisation or person:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "sector division"
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00000504 some 
+            (OEO_00000323 or OEO_00030022)
+    
+
 Class: OEO_00000379
 
     Annotations: 
@@ -682,7 +759,30 @@ Class: OEO_00010079
     
 Class: OEO_00010082
 
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one good or service is exchanged for another good or service or money.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1565
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1613
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "trade"@en
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
+
+
 Class: OEO_00010083
 
     Annotations: 
@@ -711,7 +811,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010115
 
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "economic system",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+move to oeo-shared, add alternative lable
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
+        rdfs:label "economy"@en
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0002577>
+    
+
 Class: OEO_00010116
 
     
@@ -950,6 +1065,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462",
     
 Class: OEO_00010407
 
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy balance sector division"@en
+    
+    SubClassOf: 
+        OEO_00000368
+        
     
 Class: OEO_00020015
 
@@ -958,6 +1086,25 @@ Class: OEO_00020060
 
     
 Class: OEO_00020063
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+moved to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission quantity value and emission certificate price
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission certificate"
+    
+    SubClassOf: 
+        OEO_00020015,
+        OEO_00020180 some OEO_00020154,
+        OEO_00140002 some OEO_00010079
 
     
 Class: OEO_00020064
@@ -2156,7 +2303,96 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623",
         OEO_00140012,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
     
+
+Class: OEO_00010268
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission price is a monetary price of emitting a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission price"
     
+    SubClassOf: 
+        OEO_00040003,
+        OEO_00020179 some OEO_00140081
+
+
+Class: OEO_00010269
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 price is an emission price of emitting a certain CO2 emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "CO2 price"
+    
+    SubClassOf: 
+        OEO_00010268
+
+
+Class: OEO_00020154
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to emission certificate
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+make subclass of 'emission price':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission certificate price"
+    
+    SubClassOf: 
+        OEO_00010268,
+        OEO_00020179 some OEO_00020063
+
+
+Class: OEO_00010270
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon tax value is a CO2 price that is set by a carbon tax.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "carbon tax value"
+    
+    SubClassOf: 
+        OEO_00010269
+
+
+Class: OEO_00010271
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission certificate price is an emission price of an CO2 emission certificate that allows the emission of certain CO2 emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "CO2 emission certificate price"
+    
+    SubClassOf: 
+        OEO_00020154
+
+
 Individual: OEO_00000160
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2454,6 +2454,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "social cost of carbon emission"
     
     SubClassOf: 
+        OEO_00020181,
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+
+
+
+Class: OEO_00020181
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "social cost of emission"
+    
+    SubClassOf: 
+        OEO_00040009,
         OEO_00020179 some OEO_00140081,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1180,11 +1180,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020067
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "product"
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity is a good that bears the commodity role.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "product",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/302
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
+add alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
+subclass of good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+change axiom
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "commodity"
+    
+    EquivalentTo: 
+        OEO_00010116
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
     
     SubClassOf: 
+        OEO_00010116,
         OEO_00020070 some OEO_00020069
-    
+
     
 Class: OEO_00020068
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1143,6 +1143,23 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
     
 Class: OEO_00020065
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy market exchange"
+    
+    SubClassOf: 
+        OEO_00020069
     
 Class: OEO_00020066
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -133,6 +133,33 @@ ObjectProperty: OEO_00000522
     
 ObjectProperty: OEO_00010119
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a policy instrument and a transformative measure where a policy instrument guides a transformative measure.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+Make subproperty of 'is about':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
+
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "guides"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        OEO_00140151
+    
+    Range: 
+        OEO_00140149
+
     
 ObjectProperty: OEO_00010121
 
@@ -1747,13 +1774,80 @@ Class: OEO_00030035
     
 Class: OEO_00040002
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A role of an organisation, association, or group of persons, whether incorporated or unincorporated, which constitutes, maintains, or provides a facility for bringing together purchasers and sellers of financial instruments, commodities, or other products, services, or goods, and includes the market place and facilities maintained by the exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "market",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-fct-mkt:Exchange",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/341
+https://github.com/OpenEnergyPlatform/ontology/pull/639
+
+https://github.com/OpenEnergyPlatform/ontology/issues/677
+https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+change label to market exchange role
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "market exchange role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/Exchange"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
 Class: OEO_00040003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to good
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "monetary price"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
     
+    SubClassOf: 
+        OEO_00140012,
+        OEO_00020179 some OEO_00010117,
+        OEO_00040010 some OEO_00040004
+
+
 Class: OEO_00040004
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "The currency used in France in 2020 was Euro.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A unit which is a measure of the medium of an exchange value, defined by reference to the geographical location of the monetary authorities responsible for it.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:Currency",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/331
+https://github.com/OpenEnergyPlatform/ontology/pull/640
+add comment and example
+https://github.com/OpenEnergyPlatform/ontology/pull/910
+moved to oeo-shared
+https://github.com/OpenEnergyPlatform/ontology/pull/956
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "Currency is the unit of monetary value as defined by each country.",
+        rdfs:label "currency"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/Currency"
     
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+
 Class: OEO_00040005
 
     Annotations: 
@@ -1822,8 +1916,47 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
     
 Class: OEO_00040009
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/643
+move to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+delete cost in oeo-social
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "cost"@en
+    
+    SubClassOf: 
+        OEO_00140012,
+        OEO_00040010 some OEO_00040004
+
     
 Class: OEO_00040011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commodity role is a good role that inheres in something that is used in commerce and is exchangeable with other commodities of the same type.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-pas-pas:Commodity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/339
+https://github.com/OpenEnergyPlatform/ontology/pull/644
+moved to oeo-shared and renamed
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+made subclass of good role
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "commodity role"@en,
+        rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Commodity"
+    
+    SubClassOf: 
+        OEO_00010117
 
     
 Class: OEO_00090001
@@ -2017,6 +2150,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
     
 Class: OEO_00140124
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service is a process that is an intangible activity performed by some agent for the benefit of another agent.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Service (adapted)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778
+
+add 'has participant axiom' and move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "service"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
+
     
 Class: OEO_00140125
 
@@ -2138,6 +2290,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796",
     
 Class: OEO_00140149
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transformative measure is a process that is an activity that has a direct impact on a specific variable in question.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+move to oeo-shared, alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "transformative measure"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     
 Class: OEO_00140150
 
@@ -2164,6 +2334,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614",
     
     
 Class: OEO_00140151
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
+
+Redefine as 'plan specification' and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1507
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1563
+
+move to oeo-shared, alternative label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1614
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "policy instrument"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
+        OEO_00010119 some OEO_00140149,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
 
     
 Class: OEO_00140171
@@ -2508,6 +2705,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00020154
+
+
+Class: OEO_00320073
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "amortisation time"
+    
+    SubClassOf: 
+        OEO_00030035
+
+
+Class: OEO_00320074
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "economic life time"
+    
+    SubClassOf: 
+        OEO_00030035
 
 
 Individual: OEO_00000160

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1084,6 +1084,26 @@ Class: OEO_00020015
     
 Class: OEO_00020060
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "fuel market exchange"
+    
+    SubClassOf: 
+        OEO_00020065,
+        OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
+
     
 Class: OEO_00020063
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1163,6 +1163,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00020066
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
+https://github.com/OpenEnergyPlatform/ontology/pull/748
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "fuel commodity role"
+    
+    SubClassOf: 
+        OEO_00040011
+    
     
 Class: OEO_00020067
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2439,6 +2439,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00020179 some OEO_00020063
 
 
+Class: OEO_00020155
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission value, add new parent class and relabel
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "social cost of carbon emission"
+    
+    SubClassOf: 
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+
+
 Class: OEO_00010270
 
     Annotations: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -159,26 +159,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     Range: 
         OEO_00140149
-
+    
     
 ObjectProperty: OEO_00010121
 
     
 ObjectProperty: OEO_00010128
 
-
-ObjectProperty: OEO_00020179
-
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
-        rdfs:label "governs"@en
-    
-    Domain: 
-        OEO_00140150 or OEO_00140151
-    
     
 ObjectProperty: OEO_00010231
 
@@ -263,7 +250,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
         OEO_00020070
     
     
+ObjectProperty: OEO_00020179
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
+        rdfs:label "governs"@en
+    
+    Domain: 
+        OEO_00140150 or OEO_00140151
+    
+    
+ObjectProperty: OEO_00020180
+
+    
 ObjectProperty: OEO_00040010
+
+    
+ObjectProperty: OEO_00140002
 
     
 ObjectProperty: OEO_00140008
@@ -304,13 +309,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
     
 ObjectProperty: OEO_00140164
 
-
-ObjectProperty: OEO_00020180
-
-
-ObjectProperty:  OEO_00140002
-
-
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -571,6 +570,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00030022
     
+    
 Class: OEO_00000264
 
     
@@ -592,10 +592,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     DisjointWith: 
         OEO_00000323
-        
+    
     
 Class: OEO_00000323
 
+    DisjointWith: 
+        OEO_00000315
+    
     
 Class: OEO_00000329
 
@@ -668,7 +671,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00000504 some 
             (OEO_00000323 or OEO_00030022)
     
-
+    
 Class: OEO_00000379
 
     Annotations: 
@@ -786,7 +789,6 @@ Class: OEO_00010079
     
 Class: OEO_00010082
 
-
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one good or service is exchanged for another good or service or money.",
@@ -808,8 +810,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116
-
-
+    
+    
 Class: OEO_00010083
 
     Annotations: 
@@ -838,7 +840,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010115
 
-
     Annotations: 
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
@@ -853,7 +854,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0002577>
     
-
+    
 Class: OEO_00010116
 
     
@@ -949,6 +950,70 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
+    
+    
+Class: OEO_00010268
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission price is a monetary price of emitting a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission price"
+    
+    SubClassOf: 
+        OEO_00040003,
+        OEO_00020179 some OEO_00140081
+    
+    
+Class: OEO_00010269
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 price is an emission price of emitting a certain CO2 emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "CO2 price"
+    
+    SubClassOf: 
+        OEO_00010268
+    
+    
+Class: OEO_00010270
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon tax value is a CO2 price that is set by a carbon tax.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "carbon tax value"
+    
+    SubClassOf: 
+        OEO_00010269
+    
+    
+Class: OEO_00010271
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission certificate price is an emission price of an CO2 emission certificate that allows the emission of certain CO2 emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "CO2 emission certificate price"
+    
+    SubClassOf: 
+        OEO_00020154
     
     
 Class: OEO_00010304
@@ -1092,7 +1157,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462",
     
 Class: OEO_00010407
 
-
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
@@ -1104,7 +1168,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00000368
-        
+    
     
 Class: OEO_00020015
 
@@ -1130,7 +1194,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00020065,
         OEO_00020071 some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020066)
-
+    
     
 Class: OEO_00020063
 
@@ -1152,7 +1216,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00020015,
         OEO_00020180 some OEO_00020154,
         OEO_00140002 some OEO_00010079
-
+    
     
 Class: OEO_00020064
 
@@ -1187,6 +1251,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00020069
+    
     
 Class: OEO_00020066
 
@@ -1229,7 +1294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00010116,
         OEO_00020070 some OEO_00020069
-
+    
     
 Class: OEO_00020068
 
@@ -1571,6 +1636,51 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
         OEO_00020145
     
     
+Class: OEO_00020154
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add relation to emission certificate
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+
+make subclass of 'emission price':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission certificate price"
+    
+    SubClassOf: 
+        OEO_00010268,
+        OEO_00020179 some OEO_00020063
+    
+    
+Class: OEO_00020155
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission value, add new parent class and relabel
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "social cost of carbon emission"
+    
+    SubClassOf: 
+        OEO_00020181,
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
+    
 Class: OEO_00020156
 
     Annotations: 
@@ -1720,6 +1830,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
         OEO_00040009
     
     
+Class: OEO_00020178
+
+    
+Class: OEO_00020181
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "social cost of emission"
+    
+    SubClassOf: 
+        OEO_00040009,
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
+    
 Class: OEO_00030016
 
     Annotations: 
@@ -1801,6 +1932,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
+    
 Class: OEO_00040003
 
     Annotations: 
@@ -1823,8 +1955,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00140012,
         OEO_00020179 some OEO_00010117,
         OEO_00040010 some OEO_00040004
-
-
+    
+    
 Class: OEO_00040004
 
     Annotations: 
@@ -1847,7 +1979,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>
     
-
+    
 Class: OEO_00040005
 
     Annotations: 
@@ -1935,7 +2067,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         OEO_00140012,
         OEO_00040010 some OEO_00040004
-
+    
     
 Class: OEO_00040011
 
@@ -1957,7 +2089,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00010117
-
+    
     
 Class: OEO_00090001
 
@@ -2168,7 +2300,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000051
-
+    
     
 Class: OEO_00140125
 
@@ -2361,7 +2493,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
         OEO_00010119 some OEO_00140149,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030022
-
+    
     
 Class: OEO_00140171
 
@@ -2551,6 +2683,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389",
         OEO_00140146
     
     
+Class: OEO_00320073
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "amortisation time"
+    
+    SubClassOf: 
+        OEO_00030035
+    
+    
+Class: OEO_00320074
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "economic life time"
+    
+    SubClassOf: 
+        OEO_00020178
+    
+    
 Class: OEO_00350000
 
     Annotations: 
@@ -2578,166 +2741,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623",
         OEO_00140012,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000187>
     
-
-Class: OEO_00010268
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission price is a monetary price of emitting a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "emission price"
     
-    SubClassOf: 
-        OEO_00040003,
-        OEO_00020179 some OEO_00140081
-
-
-Class: OEO_00010269
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 price is an emission price of emitting a certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "CO2 price"
-    
-    SubClassOf: 
-        OEO_00010268
-
-
-Class: OEO_00020154
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add relation to emission certificate
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-make subclass of 'emission price':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "emission certificate price"
-    
-    SubClassOf: 
-        OEO_00010268,
-        OEO_00020179 some OEO_00020063
-
-
-Class: OEO_00020155
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission value, add new parent class and relabel
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "social cost of carbon emission"
-    
-    SubClassOf: 
-        OEO_00020181,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-
-
-
-Class: OEO_00020181
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "social cost of emission"
-    
-    SubClassOf: 
-        OEO_00040009,
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-
-
-Class: OEO_00010270
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon tax value is a CO2 price that is set by a carbon tax.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "carbon tax value"
-    
-    SubClassOf: 
-        OEO_00010269
-
-
-Class: OEO_00010271
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission certificate price is an emission price of an CO2 emission certificate that allows the emission of certain CO2 emission value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "CO2 emission certificate price"
-    
-    SubClassOf: 
-        OEO_00020154
-
-
-Class: OEO_00320073
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amortisation time is the time span in which the investment costs are refinanced from the annual profits and depreciation of the investment.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "amortisation time"
-    
-    SubClassOf: 
-        OEO_00030035
-
-
-Class: OEO_00320074
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "economic life time"
-    
-    SubClassOf: 
-        OEO_00030035
-
-
 Individual: OEO_00000160
 
     Annotations: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -65,6 +65,8 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
+
+    
 AnnotationProperty: dc:contributor
 
     
@@ -78,5 +80,7 @@ AnnotationProperty: dct:title
 
     
 Datatype: rdf:PlainLiteral
+
+    
 
     


### PR DESCRIPTION
## Summary of the discussion

From #1592

## Type of change (CHANGELOG.md)

### Added
- Added a new class [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Removed
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done

### Special to dos for this PR
After moving all classes we should clean the files by checking oeo-shared and oeo-shared-axioms for remnants of classes (unnecessary class declarations) and delete them.
- [x] oeo-shared
- [x] oeo-shared-axioms
- [x] oeo-physical
- [x] oeo-social
- [x] oeo-model

Also there are classes (e.g. `person`) which in the end stay untouched in oeo-shared. For those we do not need an updated term tracker item. Deleting for them the _addition_ to the term tracker would reduce the overall change that we eventually bring to the dev branch.
- [x] Check term tracker items of remaining oeo-shared classes for unnecessary term tracker additions.

In the end, oeo-shared-axioms should contain no annotations (except term tracker items that might be fine in some cases). Especially there should be no definitions in oeo-shared-axioms.
- [x] Checked: No definitions in oeo-shared-axioms.
- [x] Checked: No other unnecessary annotations in oeo-shared-axioms.
