### PR TITLE
Feature 1592 move model classes II

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,7 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1685967799431" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -368,15 +368,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/IAO_0000088 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
     
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -64,6 +64,12 @@ Currently, it covers the `ro-extracted.owl`-file which is a subset of the Relati
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
+
+    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
+    
+
+
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00140002 -->
 
     <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00140002"/>
@@ -231,9 +237,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0003301"/>
     
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
-
-    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -252,9 +255,27 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
+    
+
+
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020143 -->
 
     <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020143"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
+    
+
+
+    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
+
+    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
     
 
 
@@ -326,22 +347,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>
     </owl:Class>
     
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-    
 
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
+    <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
-    
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -353,6 +362,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000088 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
         <rdfs:subClassOf>
@@ -365,18 +378,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000100 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000100">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000310 -->
+
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -388,6 +408,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
     </owl:Class>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -410,5 +433,5 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</obo:IAO_
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi -->
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -398,15 +398,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/IAO_0000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure and move axiom to oeo-shared-axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652</obo:IAO_0000233>
     </owl:Class>
     
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1888,6 +1888,26 @@ Class: OEO_00020166
     
 Class: OEO_00020185
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
+issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "copyright licence"
+    
+    SubClassOf: 
+        OEO_00020015
+    
     
 Class: OEO_00020186
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1913,6 +1913,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00020187
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "software licence"
+    
+    SubClassOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
+        OEO_00020185
+    
     
 Class: OEO_00020227
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1647,6 +1647,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
     
 Class: OEO_00020018
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+alternative term
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "methodical focus"@en
+    
+    SubClassOf: 
+        OEO_00020016,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
+    
     
 Class: OEO_00020019
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1588,6 +1588,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
         OEO_00030030
     
     
+Class: OEO_00020015
+
+    
 Class: OEO_00020016
 
     
@@ -1871,6 +1874,25 @@ Class: OEO_00020166
     
 Class: OEO_00020186
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Harmonise use of British English:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "data licence"
+    
+    SubClassOf: 
+        OEO_00020015
+    
     
 Class: OEO_00020187
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1548,6 +1548,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1544",
     
 Class: OEO_00010412
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "creative work licence"@en
+    
+    SubClassOf: 
+        OEO_00020185
+    
     
 Class: OEO_00010422
 
@@ -1870,6 +1884,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
     
     
 Class: OEO_00020166
+
+    
+Class: OEO_00020185
 
     
 Class: OEO_00020186

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1607,6 +1607,28 @@ Class: OEO_00020015
     
 Class: OEO_00020016
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
+
+Add SubclassOf axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "model descriptor"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 Class: OEO_00020017
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1335,6 +1335,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 
+    SubClassOf: 
+        OEO_00020188 some OEO_00010412
+    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3016,16 +3016,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00010412
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "creative work licence"@en
-    
-    SubClassOf: 
-        OEO_00020185
-    
     
 Class: OEO_00020003
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1346,6 +1346,12 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
 
     
+Class: <http://purl.obolibrary.org/obo/IAO_0000310>
+
+    SubClassOf: 
+        OEO_00020188 some OEO_00010412
+    
+    
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3762,20 +3762,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
 Class: OEO_00020185
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "copyright licence"
-    
-    SubClassOf: 
-        OEO_00020015
+        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license"
     
     
 Class: OEO_00020186

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3158,20 +3158,6 @@ Class: OEO_00020016
     
 Class: OEO_00020018
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
-    
     
 Class: OEO_00020032
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3783,25 +3783,6 @@ Class: OEO_00020186
     
 Class: OEO_00020187
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "software licence"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        OEO_00020185
-    
     
 Class: OEO_00020201
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3160,19 +3160,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
     
 Class: OEO_00020015
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
-move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
-        rdfs:label "licence"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00020016
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1338,16 +1338,9 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000088>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-
-Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     SubClassOf: 
-        OEO_00000514 some OEO_00020121
+        OEO_00000514 some OEO_00020121,
+        OEO_00020188 some OEO_00020186
     
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000104>
@@ -3788,21 +3781,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
     
 Class: OEO_00020186
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "data licence"
-    
-    SubClassOf: 
-        OEO_00020015
-    
     
 Class: OEO_00020187
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -3155,24 +3155,6 @@ Class: OEO_00020015
     
 Class: OEO_00020016
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-
-Add SubclassOf axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 Class: OEO_00020018
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3148,20 +3148,6 @@ Class: OEO_00020016
     
     
 Class: OEO_00020018
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
-alternative term
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011",
-        rdfs:label "methodical focus"@en
-    
-    SubClassOf: 
-        OEO_00020016,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000275
     
     
 Class: OEO_00020032

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2987,16 +2987,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 Class: OEO_00010412
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A creative work licence is a copyright license that determines ownership and permissions for literary work and multimedia work that combines various media types such as text, audio, images, animations, video and interactive content and its collections.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "creative work license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "creative work licence"@en
-    
-    SubClassOf: 
-        OEO_00020185
-    
     
 Class: OEO_00020003
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3144,23 +3144,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00020016
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
 
-Add SubclassOf axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1386
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1387",
-        rdfs:label "model descriptor"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 Class: OEO_00020018

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3750,21 +3750,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034",
     
 Class: OEO_00020185
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "copyright licence"
     
-    SubClassOf: 
-        OEO_00020015
     
     
 Class: OEO_00020186

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2150,13 +2150,13 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360"@en,
     
     
 Class: OEO_00000264
-    
+
     
 Class: OEO_00000274
-    
+
     
 Class: OEO_00000275
-    
+
     
 Class: OEO_00000315
 
@@ -2362,7 +2362,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     
 Class: OEO_00000364
-    
+
     
 Class: OEO_00000367
 
@@ -2425,7 +2425,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     
 Class: OEO_00000403
-    
+
     
 Class: OEO_00000407
 
@@ -2466,7 +2466,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178",
     
     
 Class: OEO_00000423
-    
+
     
 Class: OEO_00010023
 
@@ -2841,7 +2841,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253",
     
     
 Class: OEO_00010296
-    
+
     
 Class: OEO_00010315
 
@@ -2975,10 +2975,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
     
     
 Class: OEO_00010404
-    
+
     
 Class: OEO_00010406
-    
+
     
 Class: OEO_00010407
 
@@ -3147,8 +3147,13 @@ Class: OEO_00020015
         <http://purl.obolibrary.org/obo/IAO_0000118> "license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/561
+
 move to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "licence"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1337,14 +1337,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000088>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000100>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
-
-Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     SubClassOf: 
         OEO_00000514 some OEO_00020121
     
@@ -3787,21 +3779,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
     
 Class: OEO_00020186
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "data licence"
-    
-    SubClassOf: 
-        OEO_00020015
-    
     
 Class: OEO_00020187
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3772,24 +3772,6 @@ Class: OEO_00020186
     
 Class: OEO_00020187
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Harmonise use of British English:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "software licence"
-    
-    SubClassOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "fix wrong classification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1153
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1163"
-        OEO_00020185
     
     
 Class: OEO_00020201


### PR DESCRIPTION
## Summary of the discussion

`data licence`
`creative work licence`
`software licence`
`copyright licence`
`model descriptor`
`methodical focus`

Axioms from `document`, `report` and `data set` had to be moved to oeo-shared-axioms. They live in oeo-import-edits, where a term tracker item was added.

## Type of change (CHANGELOG.md)

### Added
- Added a new class [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Removed
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
