### PR TITLE
Move classes to oeo-physical #1592, part 5

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,7 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1694570853742" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1694681790065" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6844,6 +6844,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00010121 some OEO_00000323
     
     
+Class: OEO_00010265
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand for passenger-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
+    
+    
 Class: OEO_00010267
 
     Annotations: 
@@ -11018,6 +11036,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
     
     
 Class: OEO_00240019
+
+    
+Class: OEO_00240024
 
     
 Class: OEO_00240026

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8529,6 +8529,70 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
 Class: OEO_00020003
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
+
+make class a subclass of transformation:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
+
+add input and output relations:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
+
+add relation to energy transformation unit:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+change 'has physical input / output' axioms to 'has energy input / output':
+https://github.com/OpenEnergyPlatform/ontology/issues/994
+https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+add axiom relating to energy carrier / input and output axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
+
+update definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
+
+make equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+added process attributes:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "energy transformation"@en
+    
+    EquivalentTo: 
+        OEO_00000419
+         and (OEO_00010234 some OEO_00000150)
+         and (OEO_00010235 some OEO_00000150)
+    
+    SubClassOf: 
+        OEO_00000419,
+        OEO_00000500 some OEO_00000333,
+        OEO_00000500 some OEO_00140049,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+    
     
 Class: OEO_00020004
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7813,6 +7813,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010386
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1360
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electricity generation function"@en
+    
+    SubClassOf: 
+        OEO_00010385
+    
     
 Class: OEO_00010387
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7632,6 +7632,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         OEO_00010336
     
     
+Class: OEO_00010361
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable power unit"@en
+    
+    EquivalentTo: 
+        OEO_00000334
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
+    
+    SubClassOf: 
+        OEO_00000334,
+        OEO_00010234 some OEO_00020085
+    
+    
 Class: OEO_00010362
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7846,6 +7846,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445",
     
 Class: OEO_00010388
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable energy transformation function"@en
+    
+    SubClassOf: 
+        OEO_00010385
+    
     
 Class: OEO_00010392
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8624,6 +8624,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
     
 Class: OEO_00020006
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
     
 Class: OEO_00020007
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3808,6 +3808,9 @@ Class: OEO_00000322
         OEO_00000530 some OEO_00030000
     
     
+Class: OEO_00000323
+
+    
 Class: OEO_00000324
 
     Annotations: 
@@ -6800,6 +6803,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
     
     
 Class: OEO_00010263
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "passenger transport"
+    
+    SubClassOf: 
+        OEO_00140003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
+        <http://purl.obolibrary.org/obo/RO_0000057> some 
+            (OEO_00000323
+             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
+    
+    
+Class: OEO_00010264
 
     
 Class: OEO_00010267
@@ -9866,6 +9890,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         OEO_00000350,
         <http://purl.obolibrary.org/obo/BFO_0000051> some <http://purl.obolibrary.org/obo/UO_0000001>
     
+    
+Class: OEO_00140003
+
     
 Class: OEO_00140005
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7655,6 +7655,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010362
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "renewable power plant"@en
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
+    
+    SubClassOf: 
+        OEO_00000031
+    
     
 Class: OEO_00010379
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7380,6 +7380,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010316
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+Add 'secondary energy carrier disposition' axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "mineral oil product"
+    
+    EquivalentTo: 
+        OEO_00000014
+         and (OEO_00240025 some OEO_00010315)
+    
+    SubClassOf: 
+        OEO_00000014,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+    
     
 Class: OEO_00010317
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1700,6 +1700,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         OEO_00000126
     
     
+Class: OEO_00000051
+
+    
 Class: OEO_00000054
 
     Annotations: 
@@ -6825,6 +6828,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00010264
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "passenger"
+    
+    SubClassOf: 
+        OEO_00000051,
+        OEO_00010121 some OEO_00000323
+    
     
 Class: OEO_00010267
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6862,6 +6862,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
     
     
+Class: OEO_00010266
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy service demand for ton-kilometre"
+    
+    SubClassOf: 
+        OEO_00240024,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
+    
+    
 Class: OEO_00010267
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7350,6 +7350,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
     
 Class: OEO_00010315
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+make subclass of secondary energy production and further changes:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "mineral oil refining process"
+    
+    SubClassOf: 
+        OEO_00010127,
+        OEO_00000532 some OEO_00000115,
+        OEO_00000533 some OEO_00010316,
+        OEO_00010234 some OEO_00000007,
+        OEO_00010235 some OEO_00000007,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
+    
     
 Class: OEO_00010316
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7793,6 +7793,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
     
 Class: OEO_00010385
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
+
+Move to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy transformation function"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000034>,
+        OEO_00010121 some OEO_00000061
+    
     
 Class: OEO_00010386
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1919,19 +1919,6 @@ Class: OEO_00010361
     
 Class: OEO_00010362
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power plant"@en
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
-    
-    SubClassOf: 
-        OEO_00000031
-    
     
 Class: OEO_00010385
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1928,18 +1928,6 @@ Class: OEO_00010386
     
 Class: OEO_00010388
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy transformation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010404
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1845,17 +1845,6 @@ Class: OEO_00010263
     
 Class: OEO_00010264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        OEO_00000051,
-        OEO_00010121 some OEO_00000323
-    
     
 Class: OEO_00010265
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1922,19 +1922,6 @@ Class: OEO_00010362
     
 Class: OEO_00010385
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "energy transformation function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>,
-        OEO_00010121 some OEO_00000061
-    
     
 Class: OEO_00010386
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1851,17 +1851,6 @@ Class: OEO_00010265
     
 Class: OEO_00010266
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
-    
     
 Class: OEO_00010268
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1925,19 +1925,6 @@ Class: OEO_00010385
     
 Class: OEO_00010386
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity generation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010388
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1848,17 +1848,6 @@ Class: OEO_00010264
     
 Class: OEO_00010265
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
-    
     
 Class: OEO_00010266
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1842,20 +1842,6 @@ Class: OEO_00010211
     
 Class: OEO_00010263
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
-    
     
 Class: OEO_00010264
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1956,66 +1956,6 @@ Class: OEO_00010412
     
 Class: OEO_00020003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-added process attributes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625"@en,
-        rdfs:label "energy transformation"@en
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00010234 some OEO_00000150)
-         and (OEO_00010235 some OEO_00000150)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000500 some OEO_00000333,
-        OEO_00000500 some OEO_00140049,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
     
 Class: OEO_00020006
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1916,20 +1916,6 @@ Class: OEO_00010316
     
 Class: OEO_00010361
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power unit"@en
-    
-    EquivalentTo: 
-        OEO_00000334
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00010234 some OEO_00020085
-    
     
 Class: OEO_00010362
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1913,28 +1913,6 @@ Class: OEO_00010315
     
 Class: OEO_00010316
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add 'secondary energy carrier disposition' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil product"
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00240025 some OEO_00010315)
-    
-    SubClassOf: 
-        OEO_00000014,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
     
 Class: OEO_00010361
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1910,29 +1910,6 @@ Class: OEO_00010296
     
 Class: OEO_00010315
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-make subclass of secondary energy production and further changes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil refining process"
-    
-    SubClassOf: 
-        OEO_00010127,
-        OEO_00000532 some OEO_00000115,
-        OEO_00000533 some OEO_00010316,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
-    
     
 Class: OEO_00010316
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1959,19 +1959,6 @@ Class: OEO_00020003
     
 Class: OEO_00020006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
     
 Class: OEO_00020011
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1973,66 +1973,6 @@ Class: OEO_00010412
     
 Class: OEO_00020003
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
-
-make class a subclass of transformation:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
-
-add input and output relations:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/680
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/690
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-add relation to energy transformation unit:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-change 'has physical input / output' axioms to 'has energy input / output':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-add axiom relating to energy carrier / input and output axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1167
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1178
-
-update definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1175
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1182
-
-make equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-added process attributes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1543
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625"@en,
-        rdfs:label "energy transformation"@en
-    
-    EquivalentTo: 
-        OEO_00000419
-         and (OEO_00010234 some OEO_00000150)
-         and (OEO_00010235 some OEO_00000150)
-    
-    SubClassOf: 
-        OEO_00000419,
-        OEO_00000500 some OEO_00000333,
-        OEO_00000500 some OEO_00140049,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
-    
     
 Class: OEO_00020006
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1865,20 +1865,6 @@ Class: OEO_00010211
     
 Class: OEO_00010263
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger transport"
-    
-    SubClassOf: 
-        OEO_00140003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010023,
-        <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010264))
-    
     
 Class: OEO_00010264
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1948,18 +1948,6 @@ Class: OEO_00010386
     
 Class: OEO_00010388
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable energy transformation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010404
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1942,19 +1942,6 @@ Class: OEO_00010362
     
 Class: OEO_00010385
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "energy transformation function"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>,
-        OEO_00010121 some OEO_00000061
-    
     
 Class: OEO_00010386
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1930,29 +1930,6 @@ Class: OEO_00010296
     
 Class: OEO_00010315
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-make subclass of secondary energy production and further changes:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil refining process"
-    
-    SubClassOf: 
-        OEO_00010127,
-        OEO_00000532 some OEO_00000115,
-        OEO_00000533 some OEO_00010316,
-        OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
-    
     
 Class: OEO_00010316
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1936,20 +1936,6 @@ Class: OEO_00010316
     
 Class: OEO_00010361
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power unit"@en
-    
-    EquivalentTo: 
-        OEO_00000334
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388)
-    
-    SubClassOf: 
-        OEO_00000334,
-        OEO_00010234 some OEO_00020085
-    
     
 Class: OEO_00010362
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1945,19 +1945,6 @@ Class: OEO_00010385
     
 Class: OEO_00010386
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
-
-Move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        rdfs:label "electricity generation function"@en
-    
-    SubClassOf: 
-        OEO_00010385
-    
     
 Class: OEO_00010388
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1874,17 +1874,6 @@ Class: OEO_00010265
     
 Class: OEO_00010266
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for ton-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00140005
-    
     
 Class: OEO_00010268
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1939,19 +1939,6 @@ Class: OEO_00010361
     
 Class: OEO_00010362
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "renewable power plant"@en
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010361)
-    
-    SubClassOf: 
-        OEO_00000031
-    
     
 Class: OEO_00010385
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1933,28 +1933,6 @@ Class: OEO_00010315
     
 Class: OEO_00010316
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-Add 'secondary energy carrier disposition' axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531",
-        rdfs:label "mineral oil product"
-    
-    EquivalentTo: 
-        OEO_00000014
-         and (OEO_00240025 some OEO_00010315)
-    
-    SubClassOf: 
-        OEO_00000014,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
-    
     
 Class: OEO_00010361
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1868,17 +1868,6 @@ Class: OEO_00010263
     
 Class: OEO_00010264
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "passenger"
-    
-    SubClassOf: 
-        OEO_00000051,
-        OEO_00010121 some OEO_00000323
-    
     
 Class: OEO_00010265
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1871,17 +1871,6 @@ Class: OEO_00010264
     
 Class: OEO_00010265
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234",
-        rdfs:label "energy service demand for passenger-kilometre"
-    
-    SubClassOf: 
-        OEO_00240024,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00010263
-    
     
 Class: OEO_00010266
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1976,19 +1976,6 @@ Class: OEO_00020003
     
 Class: OEO_00020006
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
     
 Class: OEO_00020011
 


### PR DESCRIPTION
## Summary of the discussion

Move 13 classes from oeo-shared to oeo-physical.

This concludes my part of moving classes.

## Type of change (CHANGELOG.md)

- `passenger transport`
- `passenger`
- `energy service demand for passenger-kilometre`
- `energy service demand for ton-kilometre`
- `mineral oil refining process`
- `mineral oil product`
- `renewable power unit`
- `renewable power plant`
- `energy transformation function`
- `electricity generation function`
- `renewable energy transformation function`
- `energy transformation`
- `grid component`

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
