### PR TITLE
Issue 1592: Move additional classes to social

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1846,7 +1846,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020018,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020032,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020035,

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1616,25 +1616,6 @@ Class: OEO_00000367
     
     
 Class: OEO_00000368
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-Add relation to organisation or person:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        OEO_00000504 some 
-            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000395
@@ -1904,16 +1885,8 @@ Class: OEO_00010406
     
 Class: OEO_00010407
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance sector division"@en
-    
     SubClassOf: 
-        OEO_00000368,
         OEO_00000504 some OEO_00010406
-    
     
 Class: OEO_00010412
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1546,20 +1546,6 @@ Class: OEO_00000275
 
     
 Class: OEO_00000315
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        OEO_00000323
     
     
 Class: OEO_00000316

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1613,18 +1613,6 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000368
@@ -2138,6 +2126,9 @@ Class: OEO_00020069
 
     
 Class: OEO_00020072
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000367
 
     
 Class: OEO_00020085

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -951,22 +951,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     
     
 ObjectProperty: OEO_00020180
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
-Make subproperty of 'has quatity value' and add range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
-        rdfs:label "has economic value"
-    
-    SubPropertyOf: 
-        OEO_00140002
-    
-    Range: 
-        OEO_00140012
     
     
 ObjectProperty: OEO_00020182
@@ -1064,27 +1048,6 @@ ObjectProperty: OEO_00040010
     
     
 ObjectProperty: OEO_00140002
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and a quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
-        rdfs:label "has quantity value"@en
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00010231
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        OEO_00000350
-    
-    InverseOf: 
-        OEO_00020056
     
     
 ObjectProperty: OEO_00140008
@@ -1864,22 +1827,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     
 Class: OEO_00020063
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
     
     
 Class: OEO_00020065

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1522,16 +1522,6 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        OEO_00030022
     
     
 Class: OEO_00000253
@@ -2924,23 +2914,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386",
     
     
 Class: OEO_00030022
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/421
-added term in oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-deleted term in oeo-social:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992",
-        rdfs:label "organisation"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
     
     
 Class: OEO_00030024

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1639,18 +1639,6 @@ Class: OEO_00000364
 
     
 Class: OEO_00000367
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764",
-        rdfs:label "sector"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>
     
     
 Class: OEO_00000368

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1642,25 +1642,6 @@ Class: OEO_00000367
     
     
 Class: OEO_00000368
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-Add relation to organisation or person:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506",
-        rdfs:label "sector division"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000031>,
-        OEO_00000504 some 
-            (OEO_00000323 or OEO_00030022)
     
     
 Class: OEO_00000395
@@ -1914,16 +1895,6 @@ Class: OEO_00010406
 
     
 Class: OEO_00010407
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "energy balance sector division"@en
-    
-    SubClassOf: 
-        OEO_00000368,
-        OEO_00000504 some OEO_00010406
     
     
 Class: OEO_00010412

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1911,22 +1911,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
     
     
 Class: OEO_00020063
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
-moved to oeo-shared
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
-add axiom to emission quantity value and emission certificate price
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034",
-        rdfs:label "emission certificate"
-    
-    SubClassOf: 
-        OEO_00020015,
-        OEO_00020180 some OEO_00020154,
-        OEO_00140002 some OEO_00010079
     
     
 Class: OEO_00020065

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1565,21 +1565,7 @@ Class: OEO_00000275
     
 Class: OEO_00000315
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
-        rdfs:label "organisation role"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    DisjointWith: 
-        OEO_00000323
-    
-    
+
 Class: OEO_00000316
 
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1546,16 +1546,6 @@ Class: OEO_00000207
 
     
 Class: OEO_00000238
-
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "institution"
-    
-    SubClassOf: 
-        OEO_00030022
     
     
 Class: OEO_00000253

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1582,9 +1582,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
     
-    DisjointWith: 
-        OEO_00000315
-    
     
 Class: OEO_00000331
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -544,7 +544,10 @@ Class: OEO_00000315
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "organisation role"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -525,7 +525,10 @@ Class: OEO_00000238
         OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "institution"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -521,6 +521,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484",
     
 Class: OEO_00000238
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "institution"
+    
+    SubClassOf: 
+        OEO_00030022
     
 Class: OEO_00000264
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -536,6 +536,20 @@ Class: OEO_00000264
     
 Class: OEO_00000315
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
+        rdfs:label "organisation role"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    DisjointWith: 
+        OEO_00000323
+        
     
 Class: OEO_00000323
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -604,6 +604,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000368
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+Add relation to organisation or person:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1506
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "sector division"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>,
+        OEO_00000504 some 
+            (OEO_00000323 or OEO_00030022)
     
 Class: OEO_00000379
 
@@ -990,6 +1012,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462",
     
 Class: OEO_00010407
 
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy balance sector division is a sector division that is defined by an energy balance calculation method.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "energy balance sector division"@en
+    
+    SubClassOf: 
+        OEO_00000368
+        
     
 Class: OEO_00020015
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -277,7 +277,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/562",
     
 ObjectProperty: OEO_00140164
 
-    
+
+ObjectProperty: OEO_00020180
+
+
+ObjectProperty:  OEO_00140002
+
+
 ObjectProperty: owl:topObjectProperty
 
     
@@ -1080,6 +1086,25 @@ Class: OEO_00020060
 
     
 Class: OEO_00020063
+
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
+moved to oeo-shared
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/956
+add axiom to emission quantity value and emission certificate price
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1034
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "emission certificate"
+    
+    SubClassOf: 
+        OEO_00020015,
+        OEO_00020180 some OEO_00020154,
+        OEO_00140002 some OEO_00010079
 
     
 Class: OEO_00020064

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -587,6 +587,20 @@ Class: OEO_00000350
     
 Class: OEO_00000367
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "sector"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000031>
     
 Class: OEO_00000368
 


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

There is a problem here, some of the classes in model had dependencies of the moved here, my proposal is to add those conflicting axioms to shared-axioms, the affected classes are `analysis scope` OEO_00020072 and `energy balance sector division` OEO_00010407 . The alternative is to keep sector and sector division
in shared.

### Updated

- Moved `energy balance`, `energy balance sector division`, `sector`, `organisation role` and `institution `to social
- 
## Workflow checklist
