### PR TITLE
Clean annotation and object properties

### DIFF
--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -54,15 +54,6 @@ AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynony
     
 AnnotationProperty: OEO_00010037
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A unique individual identifier is an identifier that is unique for one individual of a class. Unique individual identifiers follow usually a structure defined e.g. by a sector division.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
-        rdfs:label "unique individual identifier"
-    
-    SubPropertyOf: 
-        dc:identifier
-    
     
 AnnotationProperty: OEO_00040001
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1189,15 +1189,6 @@ ObjectProperty: owl:topObjectProperty
     
 DataProperty: OEO_00140178
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Has number is a data property that links a quantity value to a number that defines the quantity value.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/840",
-        rdfs:label "has number"@en
-    
-    Domain: 
-        OEO_00000350
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -66,9 +66,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
     
 AnnotationProperty: OEO_00040001
 
-    Annotations: 
-        rdfs:label "belongs to module"
-    
     
 AnnotationProperty: OEO_00110012
 


### PR DESCRIPTION
## Summary of the discussion

We have this not in the [list](https://docs.google.com/spreadsheets/d/18Cr2rnsFlZvZuDOEiBFEkjVd5SEvD1gt6qg0VnPpd3Q/edit#gid=0), but we also have to clean annotation and object properties as we duplicated these to oeo-shared-axioms.

## Type of change (CHANGELOG.md)

* `has number`
* `belongs to module`
* `unique individual identifier`

I intentionally did not change the term tracker item for these, because in the end these annotations and object properties will be unchanged in dev.

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
