### PR TITLE
move object properties from shared to original modules #1703

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,7 +11,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-module.owl" uri="../imports/uo-module.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1695915635079" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1695915635079" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1695982531139" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1695982531139" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -113,6 +113,12 @@ ObjectProperty: OEO_00000503
 ObjectProperty: OEO_00000504
 
     
+ObjectProperty: OEO_00000510
+
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
 ObjectProperty: OEO_00000511
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -451,6 +451,12 @@ ObjectProperty: OEO_00040010
 ObjectProperty: OEO_00140002
 
     
+ObjectProperty: OEO_00140008
+
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
 ObjectProperty: OEO_00140093
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -502,6 +502,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
         OEO_00000206
     
     
+ObjectProperty: OEO_00140164
+
+    Domain: 
+        OEO_00000274
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -113,6 +113,15 @@ ObjectProperty: OEO_00000503
 ObjectProperty: OEO_00000504
 
     
+ObjectProperty: OEO_00000506
+
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
+    
+    
 ObjectProperty: OEO_00000507
 
     Domain: 
@@ -672,6 +681,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
         <http://purl.obolibrary.org/obo/IAO_0000030>,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000364
     
+    
+Class: OEO_00000064
+
     
 Class: OEO_00000078
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -113,6 +113,12 @@ ObjectProperty: OEO_00000503
 ObjectProperty: OEO_00000504
 
     
+ObjectProperty: OEO_00000507
+
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
 ObjectProperty: OEO_00000508
 
     Domain: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -113,6 +113,12 @@ ObjectProperty: OEO_00000503
 ObjectProperty: OEO_00000504
 
     
+ObjectProperty: OEO_00000508
+
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    
 ObjectProperty: OEO_00000510
 
     Domain: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -204,6 +204,30 @@ ObjectProperty: OEO_00000522
     
 ObjectProperty: OEO_00000523
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "covers energy carrier"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Domain: 
+        OEO_00020011
+    
+    Range: 
+        OEO_00020039
+    
     
 ObjectProperty: OEO_00000524
 
@@ -8795,6 +8819,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
     
+    
+Class: OEO_00020011
+
     
 Class: OEO_00020037
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -359,6 +359,20 @@ ObjectProperty: OEO_00020180
     
 ObjectProperty: OEO_00020182
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "is energy participant of"
+    
     
 ObjectProperty: OEO_00020183
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -93,6 +93,15 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has energy participant"@en
     
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    InverseOf: 
+        OEO_00020182
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -372,6 +381,9 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "is energy participant of"
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     
     
 ObjectProperty: OEO_00020183

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -79,6 +79,20 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has energy participant"@en
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -184,6 +184,35 @@ ObjectProperty: OEO_00000523
     
 ObjectProperty: OEO_00000524
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
+
+move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1410
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has global warming potential"
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00140002
+    
+    Domain: 
+        OEO_00000020
+    
+    Range: 
+        OEO_00010078
+    
     
 ObjectProperty: OEO_00000525
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -302,6 +302,20 @@ ObjectProperty: OEO_00010231
     
 ObjectProperty: OEO_00010234
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has energy input"@en
+    
     
 ObjectProperty: OEO_00010235
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -324,6 +324,30 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
     
 ObjectProperty: OEO_00000529
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has normal state of matter"
+    
+    SubPropertyOf: 
+        OEO_00000531
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
     
 ObjectProperty: OEO_00000530
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -339,6 +339,12 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has energy input"@en
     
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Range: 
+        OEO_00000150
+    
     
 ObjectProperty: OEO_00010235
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -397,6 +397,12 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "is energy participant of"
     
+    Domain: 
+        OEO_00000150
+    
+    Range: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     InverseOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2655,45 +2655,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000150
 
-    Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
-fix grammar error:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
-move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
-adjust definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
-
-Axiomatise relations between origin, energy and portion of matter:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
-
-Add bearer:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"
-    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00000530 some OEO_00000316,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
+        OEO_00000530 some OEO_00000316
     
     
 Class: OEO_00000151

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -303,6 +303,26 @@ ObjectProperty: OEO_00000529
     
 ObjectProperty: OEO_00000530
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has origin"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000150 or OEO_00000331
+    
+    Range: 
+        OEO_00000316
+    
     
 ObjectProperty: OEO_00000531
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -362,6 +362,15 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has energy output"@en
     
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
     
 ObjectProperty: OEO_00020056
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -462,9 +462,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00020056
 
     
-ObjectProperty: OEO_00020070
-
-    
 ObjectProperty: OEO_00020180
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -319,6 +319,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 ObjectProperty: OEO_00010235
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has energy output"@en
+    
     
 ObjectProperty: OEO_00020056
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -374,6 +374,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 ObjectProperty: OEO_00000531
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "has state of matter"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
     
 ObjectProperty: OEO_00000532
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -477,21 +477,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain an
     
 ObjectProperty: OEO_00000508
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contact person"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
-    
     
 ObjectProperty: OEO_00000509
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -434,22 +434,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 ObjectProperty: OEO_00000505
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers sector"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00000367
-    
     
 ObjectProperty: OEO_00000506
 
@@ -931,24 +915,8 @@ ObjectProperty: OEO_00140164
     
 ObjectProperty: OEO_00240025
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is physical output of p iff: c output of p, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "physical output of"
-    
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 ObjectProperty: owl:topObjectProperty

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -693,29 +693,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
     
 ObjectProperty: OEO_00000532
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical input c iff: p has input c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
-
-restrict range to 'material entity':
-https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has physical input"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: OEO_00000533
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -87,27 +87,93 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has energy participant"@en
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
+    InverseOf: 
+        OEO_00020182
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603"
+    
+    Characteristics: 
+        Transitive
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
+Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603
+
+fix duplicate implementation of `Inverse Of`
+issue https://github.com/OpenEnergyPlatform/ontology/issues/979
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086"
+    
+    Characteristics: 
+        Transitive
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
+    InverseOf: 
+        OEO_00010231
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "has characteristic"
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
+    InverseOf: 
+        OEO_00010121
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
@@ -126,8 +192,11 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In contrast to the original RO class, the domain was extended to independent continuant or energy. This is due to the special role that energy plays for the OEO and the difficulty of classifying it properly."
+    Domain: 
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
@@ -147,6 +216,12 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001025>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002222>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000003>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002223>
 
@@ -162,6 +237,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002230>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
@@ -177,6 +255,20 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
 
@@ -203,42 +295,264 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 
+    Annotations: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "As produces relates to an material entity, but energy is a quality in the OEO, produces cannot be used to describe the energy output of a process. Use 'has energy output' instead."
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
+        rdfs:comment "This relation has been imported from UO.",
+        rdfs:label "is unit of"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 ObjectProperty: OEO_00000500
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domain and range; move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
+        rdfs:label "has process attribute"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00030019
+    
+    InverseOf: 
+        OEO_00000502
+    
     
 ObjectProperty: OEO_00000501
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 is required by c2 as input to work.",
+        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+add def and domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
+        rdfs:label "is used by"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    InverseOf: 
+        OEO_00000503
+    
     
 ObjectProperty: OEO_00000502
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
+        rdfs:label "process attribute of"
+    
+    Domain: 
+        OEO_00030019
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        OEO_00000500
+    
     
 ObjectProperty: OEO_00000503
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 requires c2 as input to work.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
+https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
+https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
+https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)
+change def
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
+        rdfs:label "uses"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
+    InverseOf: 
+        OEO_00000501
+    
     
 ObjectProperty: OEO_00000504
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
+
+domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
+
+adapt domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085
+
+Move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
+        rdfs:label "is defined by"
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
     
 ObjectProperty: OEO_00000505
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers sector"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Domain: 
+        OEO_00020011
+    
+    Range: 
+        OEO_00000367
+    
     
 ObjectProperty: OEO_00000506
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has author' some ('has role' some author) is necessary, because 'has author' has the range 'has role some author' (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an independent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has author"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
+    
     
 ObjectProperty: OEO_00000507
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has client"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
+    
     
 ObjectProperty: OEO_00000508
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contact person"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
+    
     
 ObjectProperty: OEO_00000509
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
+        rdfs:label "has funding source"
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Range: 
+        
+            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001
+    
     
 ObjectProperty: OEO_00000510
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+
+improve definition:
+https://github.com/OpenEnergyPlatform/ontology/issues/1038
+https://github.com/OpenEnergyPlatform/ontology/pull/1042
+
+Relabel to `has organisation`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
+        rdfs:label "has organisation"
+    
+    SubPropertyOf: 
+        OEO_00140008
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
     
 ObjectProperty: OEO_00000514
 
@@ -251,21 +565,131 @@ ObjectProperty: OEO_00000516
     
 ObjectProperty: OEO_00000522
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
+        rdfs:label "covers"
+    
     
 ObjectProperty: OEO_00000523
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
+issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
+        rdfs:label "covers energy carrier"
+    
+    SubPropertyOf: 
+        OEO_00000522
+    
+    Domain: 
+        OEO_00020011
+    
+    Range: 
+        OEO_00020039
+    
     
 ObjectProperty: OEO_00000524
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
+
+move to oeo-shared:
+https://github.com/OpenEnergyPlatform/ontology/pull/1410",
+        rdfs:label "has global warming potential"
+    
+    SubPropertyOf: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
+        OEO_00140002
+    
+    Domain: 
+        OEO_00000020
+    
+    Range: 
+        OEO_00010078
+    
     
 ObjectProperty: OEO_00000529
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has normal state of matter"
+    
+    SubPropertyOf: 
+        OEO_00000531
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
     
 ObjectProperty: OEO_00000530
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has origin"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
+        OEO_00000150 or OEO_00000331
+    
+    Range: 
+        OEO_00000316
+    
     
 ObjectProperty: OEO_00000531
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
+        rdfs:label "has state of matter"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00000331
+    
+    Range: 
+        OEO_00000395
+    
     
 ObjectProperty: OEO_00000532
 
@@ -283,6 +707,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
         rdfs:label "has physical input"
     
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
@@ -292,27 +719,158 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
 ObjectProperty: OEO_00000533
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+
+restrict range to 'material entity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1041
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has physical output"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
+        <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    InverseOf: 
+        OEO_00240025
+    
     
 ObjectProperty: OEO_00010121
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant (the dependent) and an independent continuant or energy (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
+pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
+
+add domains and ranges:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
+
+extend range to energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
+
+correct definition with respect to energy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484",
+        rdfs:label "has bearer"@en
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000020>
+    
+    Range: 
+        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/RO_0000053>
+    
     
 ObjectProperty: OEO_00010231
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
+",
+        rdfs:label "has information content entity"@en
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    InverseOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
     
 ObjectProperty: OEO_00010234
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has energy input"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
     Domain: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00010235
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "has energy output"@en
+    
+    SubPropertyOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
+    
     
 ObjectProperty: OEO_00010312
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a sector and the processes or material entities it covers.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
+        rdfs:label "is sector of"@en
+    
+    Domain: 
+        OEO_00000367
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 ObjectProperty: OEO_00020056
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
+        rdfs:label "quantity value of"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    InverseOf: 
+        OEO_00140002
+    
     
 ObjectProperty: OEO_00020070
 
@@ -328,9 +886,48 @@ ObjectProperty: OEO_00020180
     
 ObjectProperty: OEO_00020182
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
+        rdfs:label "is energy participant of"
+    
+    Domain: 
+        OEO_00000150
+    
+    Range: 
+        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
     
 ObjectProperty: OEO_00020188
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "has license",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Relabel, redefine and add domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
+        rdfs:label "has licence"
+    
+    SubPropertyOf: 
+        OEO_00010231
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00020015
+    
     
 ObjectProperty: OEO_00020189
 
@@ -370,30 +967,94 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
 ObjectProperty: OEO_00040010
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
+        rdfs:label "has unit"@en
+    
+    Domain: 
+        OEO_00000350
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 ObjectProperty: OEO_00140002
 
+    InverseOf: 
+        OEO_00020056
+    
     
 ObjectProperty: OEO_00140008
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+        rdfs:label "has contributor"@en
+    
+    Domain: 
+        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
+    
     
 ObjectProperty: OEO_00140093
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information input"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002233>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
     
 ObjectProperty: OEO_00140094
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
+moved to oeo-shared
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
+        rdfs:label "has information output"@en
     
-ObjectProperty: OEO_00140096
-
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002234>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
     Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
-        OEO_00000206
+        <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
 ObjectProperty: OEO_00140164
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+        rdfs:label "models"@en
+    
+    Domain: 
+        OEO_00000274
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000004>
+    
     
 ObjectProperty: OEO_00240025
 
@@ -415,6 +1076,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    InverseOf: 
+        OEO_00000533
     
     
 ObjectProperty: owl:topObjectProperty
@@ -484,15 +1148,6 @@ Class: OEO_00000001
 Class: OEO_00000020
 
     
-Class: OEO_00000045
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240003
-    
-
-Class: OEO_00000031
-
-    
 Class: OEO_00000061
 
     
@@ -521,9 +1176,6 @@ Class: OEO_00000150
 
     
 Class: OEO_00000199
-
-    
-Class: OEO_00000206
 
     
 Class: OEO_00000264
@@ -602,41 +1254,11 @@ Class: OEO_00010117
         OEO_00020180 some OEO_00040003
     
     
-Class: OEO_00010268
-
-    SubClassOf: 
-        OEO_00020179 some OEO_00140081
-
-
-Class: OEO_00010255
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
-    
-    
 Class: OEO_00010296
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
     
-    
-Class: OEO_00010315
-
-    
-Class: OEO_00010319
-
-    SubClassOf: 
-        OEO_00010312 some OEO_00010315
-    
-    
-Class: OEO_00010320
-
-    SubClassOf: 
-        OEO_00010312 some OEO_00140004
-    
-    
-Class: OEO_00010362
-
     
 Class: OEO_00010404
 
@@ -689,9 +1311,6 @@ Class: OEO_00020060
     
 Class: OEO_00020063
 
-    SubClassOf: 
-        OEO_00140002 some OEO_00010079
-    
     
 Class: OEO_00020065
 
@@ -711,19 +1330,8 @@ Class: OEO_00020072
 Class: OEO_00020121
 
     
-Class: OEO_00020155
-
-    SubClassOf: 
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
-    
 Class: OEO_00020181
 
-    SubClassOf: 
-        OEO_00020179 some OEO_00140081,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
     
 Class: OEO_00020185
 
@@ -744,9 +1352,6 @@ Class: OEO_00020202
     
     
 Class: OEO_00020248
-
-    
-Class: OEO_00020252
 
     
 Class: OEO_00020309
@@ -778,13 +1383,6 @@ Class: OEO_00020345
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010444)
     
     
-Class: OEO_00030007
-
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020252)
-    
-    
 Class: OEO_00030008
 
     EquivalentTo: 
@@ -797,13 +1395,6 @@ Class: OEO_00030009
     EquivalentTo: 
         OEO_00000364
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000147)
-    
-    
-Class: OEO_00030010
-
-    EquivalentTo: 
-        OEO_00000364
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030024)
     
     
 Class: OEO_00030015
@@ -836,9 +1427,6 @@ Class: OEO_00050018
 Class: OEO_00090001
 
     
-Class: OEO_00140004
-
-    
 Class: OEO_00140039
 
     
@@ -851,20 +1439,6 @@ Class: OEO_00140081
 Class: OEO_00140124
 
     
-Class: OEO_00140138
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00240014
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000031))
-    
-    
-Class: OEO_00140139
-
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010362
-    
-    
 Class: OEO_00140149
 
     
@@ -872,9 +1446,6 @@ Class: OEO_00140151
 
     
 Class: OEO_00240003
-
-    
-Class: OEO_00240014
 
     
 Class: OEO_00240026

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -125,21 +125,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "has characteristic"
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    InverseOf: 
-        OEO_00010121
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
@@ -174,16 +159,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In contrast to the original RO class, the domain was extended to independent continuant or energy. This is due to the special role that energy plays for the OEO and the difficulty of classifying it properly.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "extend domain / definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
-    
-    Domain: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In contrast to the original RO class, the domain was extended to independent continuant or energy. This is due to the special role that energy plays for the OEO and the difficulty of classifying it properly."
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
@@ -421,22 +397,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
     
 ObjectProperty: OEO_00000505
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the sector it covers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers sector"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00000367
-    
     
 ObjectProperty: OEO_00000506
 
@@ -449,20 +409,8 @@ ObjectProperty: OEO_00000508
     
 ObjectProperty: OEO_00000509
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
-        rdfs:label "has funding source"
-    
     SubPropertyOf: 
         owl:topObjectProperty
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001
     
     
 ObjectProperty: OEO_00000510
@@ -479,16 +427,6 @@ ObjectProperty: OEO_00000516
     
 ObjectProperty: OEO_00000522
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
-        rdfs:label "covers"
-    
     
 ObjectProperty: OEO_00000523
 
@@ -568,33 +506,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
     
 ObjectProperty: OEO_00010121
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant (the dependent) and an independent continuant or energy (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-extend range to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-correct definition with respect to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484",
-        rdfs:label "has bearer"@en
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    Range: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
-    
     
 ObjectProperty: OEO_00010231
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -459,21 +459,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain an
     
 ObjectProperty: OEO_00000507
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has client"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
-    
     
 ObjectProperty: OEO_00000508
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -126,9 +126,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In contrast to the original RO class, the domain was extended to independent continuant or energy. This is due to the special role that energy plays for the OEO and the difficulty of classifying it properly."
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
 
@@ -418,14 +415,14 @@ Class: OEO_00000001
 Class: OEO_00000020
 
     
+Class: OEO_00000031
+
+    
 Class: OEO_00000045
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240003
     
-
-Class: OEO_00000031
-
     
 Class: OEO_00000061
 
@@ -536,16 +533,16 @@ Class: OEO_00010117
         OEO_00020180 some OEO_00040003
     
     
-Class: OEO_00010268
-
-    SubClassOf: 
-        OEO_00020179 some OEO_00140081
-
-
 Class: OEO_00010255
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
+    
+    
+Class: OEO_00010268
+
+    SubClassOf: 
+        OEO_00020179 some OEO_00140081
     
     
 Class: OEO_00010296

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -768,25 +768,6 @@ ObjectProperty: OEO_00010234
     
 ObjectProperty: OEO_00010235
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
     
 ObjectProperty: OEO_00010312
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -87,93 +87,27 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy participant"@en
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    InverseOf: 
-        OEO_00020182
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603"
-    
-    Characteristics: 
-        Transitive
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603
-
-fix duplicate implementation of `Inverse Of`
-issue https://github.com/OpenEnergyPlatform/ontology/issues/979
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086"
-    
-    Characteristics: 
-        Transitive
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
-    InverseOf: 
-        OEO_00010231
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000118> "has characteristic"
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    InverseOf: 
-        OEO_00010121
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
@@ -192,11 +126,8 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 
-    Domain: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In contrast to the original RO class, the domain was extended to independent continuant or energy. This is due to the special role that energy plays for the OEO and the difficulty of classifying it properly."
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
@@ -216,12 +147,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001025>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002222>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002223>
 
@@ -237,9 +162,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002230>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
@@ -255,20 +177,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
 
@@ -295,248 +203,42 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 
-    Annotations: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "As produces relates to an material entity, but energy is a quality in the OEO, produces cannot be used to describe the energy output of a process. Use 'has energy output' instead."
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
-        rdfs:comment "This relation has been imported from UO.",
-        rdfs:label "is unit of"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 ObjectProperty: OEO_00000500
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domain and range; move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "has process attribute"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00030019
-    
-    InverseOf: 
-        OEO_00000502
-    
     
 ObjectProperty: OEO_00000501
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 is required by c2 as input to work.",
-        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-add def and domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
-        rdfs:label "is used by"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    InverseOf: 
-        OEO_00000503
-    
     
 ObjectProperty: OEO_00000502
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "process attribute of"
-    
-    Domain: 
-        OEO_00030019
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        OEO_00000500
-    
     
 ObjectProperty: OEO_00000503
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 requires c2 as input to work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
-https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
-https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
-https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
-        rdfs:label "uses"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    InverseOf: 
-        OEO_00000501
-    
     
 ObjectProperty: OEO_00000504
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
-
-domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-
-adapt domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "is defined by"
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00000505
 
     
 ObjectProperty: OEO_00000506
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has author' some ('has role' some author) is necessary, because 'has author' has the range 'has role some author' (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an independent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has author"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
-    
     
 ObjectProperty: OEO_00000507
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has client"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
-    
     
 ObjectProperty: OEO_00000508
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contact person"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
-    
     
 ObjectProperty: OEO_00000509
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an entity and its source of funding."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556",
-        rdfs:label "has funding source"
-    
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
-    Range: 
-        
-            Annotations: rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00090001
-    
     
 ObjectProperty: OEO_00000510
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
-
-improve definition:
-https://github.com/OpenEnergyPlatform/ontology/issues/1038
-https://github.com/OpenEnergyPlatform/ontology/pull/1042
-
-Relabel to `has organisation`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
-        rdfs:label "has organisation"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
-    
     
 ObjectProperty: OEO_00000514
 
@@ -555,95 +257,15 @@ ObjectProperty: OEO_00000523
     
 ObjectProperty: OEO_00000524
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
-
-move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "has global warming potential"
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00140002
-    
-    Domain: 
-        OEO_00000020
-    
-    Range: 
-        OEO_00010078
-    
     
 ObjectProperty: OEO_00000529
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has normal state of matter"
-    
-    SubPropertyOf: 
-        OEO_00000531
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000530
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has origin"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
-        OEO_00000150 or OEO_00000331
-    
-    Range: 
-        OEO_00000316
-    
     
 ObjectProperty: OEO_00000531
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has state of matter"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000532
 
@@ -653,123 +275,24 @@ ObjectProperty: OEO_00000533
     
 ObjectProperty: OEO_00010121
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a specifically dependent continuant (the dependent) and an independent continuant or energy (the bearer), in which the dependent is specifically reliant on the bearer for its existence",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
-pull request: issue: https://github.com/OpenEnergyPlatform/ontology/pull/853
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-extend range to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
-
-correct definition with respect to energy:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484",
-        rdfs:label "has bearer"@en
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>
-    
-    Range: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
-    
     
 ObjectProperty: OEO_00010231
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-",
-        rdfs:label "has information content entity"@en
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
     
 ObjectProperty: OEO_00010234
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy input"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
     Domain: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
     
     
 ObjectProperty: OEO_00010235
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy output"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
     
 ObjectProperty: OEO_00010312
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a sector and the processes or material entities it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
-        rdfs:label "is sector of"@en
-    
-    Domain: 
-        OEO_00000367
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: OEO_00020056
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
-        rdfs:label "quantity value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    InverseOf: 
-        OEO_00140002
-    
     
 ObjectProperty: OEO_00020070
 
@@ -785,48 +308,9 @@ ObjectProperty: OEO_00020180
     
 ObjectProperty: OEO_00020182
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "is energy participant of"
-    
-    Domain: 
-        OEO_00000150
-    
-    Range: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
     
 ObjectProperty: OEO_00020188
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "has license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Relabel, redefine and add domain and range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "has licence"
-    
-    SubPropertyOf: 
-        OEO_00010231
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        OEO_00020015
-    
     
 ObjectProperty: OEO_00020189
 
@@ -836,78 +320,26 @@ ObjectProperty: OEO_00020190
     
 ObjectProperty: OEO_00040010
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 ObjectProperty: OEO_00140002
 
-    InverseOf: 
-        OEO_00020056
-    
     
 ObjectProperty: OEO_00140008
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contributor"@en
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00140093
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information input"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 ObjectProperty: OEO_00140094
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information output"@en
     
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
+ObjectProperty: OEO_00140096
+
     Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/749
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/751"
+        OEO_00000206
     
     
 ObjectProperty: OEO_00140164
@@ -986,6 +418,15 @@ Class: OEO_00000001
 Class: OEO_00000020
 
     
+Class: OEO_00000045
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240003
+    
+
+Class: OEO_00000031
+
+    
 Class: OEO_00000061
 
     
@@ -1014,6 +455,9 @@ Class: OEO_00000150
 
     
 Class: OEO_00000199
+
+    
+Class: OEO_00000206
 
     
 Class: OEO_00000264
@@ -1092,11 +536,41 @@ Class: OEO_00010117
         OEO_00020180 some OEO_00040003
     
     
+Class: OEO_00010268
+
+    SubClassOf: 
+        OEO_00020179 some OEO_00140081
+
+
+Class: OEO_00010255
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000199
+    
+    
 Class: OEO_00010296
 
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00050018
     
+    
+Class: OEO_00010315
+
+    
+Class: OEO_00010319
+
+    SubClassOf: 
+        OEO_00010312 some OEO_00010315
+    
+    
+Class: OEO_00010320
+
+    SubClassOf: 
+        OEO_00010312 some OEO_00140004
+    
+    
+Class: OEO_00010362
+
     
 Class: OEO_00010404
 
@@ -1149,6 +623,9 @@ Class: OEO_00020060
     
 Class: OEO_00020063
 
+    SubClassOf: 
+        OEO_00140002 some OEO_00010079
+    
     
 Class: OEO_00020065
 
@@ -1168,8 +645,19 @@ Class: OEO_00020072
 Class: OEO_00020121
 
     
+Class: OEO_00020155
+
+    SubClassOf: 
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
+    
 Class: OEO_00020181
 
+    SubClassOf: 
+        OEO_00020179 some OEO_00140081,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
+    
     
 Class: OEO_00020185
 
@@ -1190,6 +678,9 @@ Class: OEO_00020202
     
     
 Class: OEO_00020248
+
+    
+Class: OEO_00020252
 
     
 Class: OEO_00020309
@@ -1221,6 +712,13 @@ Class: OEO_00020345
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010444)
     
     
+Class: OEO_00030007
+
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00020252)
+    
+    
 Class: OEO_00030008
 
     EquivalentTo: 
@@ -1233,6 +731,13 @@ Class: OEO_00030009
     EquivalentTo: 
         OEO_00000364
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000147)
+    
+    
+Class: OEO_00030010
+
+    EquivalentTo: 
+        OEO_00000364
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030024)
     
     
 Class: OEO_00030015
@@ -1265,6 +770,9 @@ Class: OEO_00050018
 Class: OEO_00090001
 
     
+Class: OEO_00140004
+
+    
 Class: OEO_00140039
 
     
@@ -1277,6 +785,20 @@ Class: OEO_00140081
 Class: OEO_00140124
 
     
+Class: OEO_00140138
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00240014
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000031))
+    
+    
+Class: OEO_00140139
+
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010362
+    
+    
 Class: OEO_00140149
 
     
@@ -1284,6 +806,9 @@ Class: OEO_00140151
 
     
 Class: OEO_00240003
+
+    
+Class: OEO_00240014
 
     
 Class: OEO_00240026

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -90,15 +90,9 @@ ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
-    Characteristics: 
-        Transitive
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
-    Characteristics: 
-        Transitive
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -119,9 +119,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
-    InverseOf: 
-        OEO_00010231
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
 
@@ -200,9 +197,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002230>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 
@@ -267,60 +261,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation to connect a unit to a quantifiable entity that it is the unit of.",
-        rdfs:comment "This relation has been imported from UO.",
-        rdfs:label "is unit of"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 ObjectProperty: OEO_00000500
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process and a process attribute that existentially depends on it.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domain and range; move to oeo-shared
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871",
-        rdfs:label "has process attribute"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00030019
-    
-    InverseOf: 
-        OEO_00000502
-    
     
 ObjectProperty: OEO_00000501
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 is required by c2 as input to work.",
-        rdfs:comment "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-add def and domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
-        rdfs:label "is used by"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    InverseOf: 
-        OEO_00000503
-    
     
 ObjectProperty: OEO_00000502
 
@@ -343,9 +289,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
-    InverseOf: 
-        OEO_00000500
-    
     
 ObjectProperty: OEO_00000503
 
@@ -367,33 +310,9 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000002>
     
-    InverseOf: 
-        OEO_00000501
-    
     
 ObjectProperty: OEO_00000504
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a continuant (A) and a continuant or occurent (B) in which (A) determines the semantic of (B)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/460
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/480/
-
-domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
-
-adapt domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085
-
-Move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463",
-        rdfs:label "is defined by"
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00000505
 
@@ -459,9 +378,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
         rdfs:label "has physical input"
     
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
@@ -471,57 +387,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
 ObjectProperty: OEO_00000533
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-
-restrict range to 'material entity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has physical output"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    InverseOf: 
-        OEO_00240025
-    
     
 ObjectProperty: OEO_00010121
 
     
 ObjectProperty: OEO_00010231
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an information artifact.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
-",
-        rdfs:label "has information content entity"@en
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
     
 ObjectProperty: OEO_00010234
 
@@ -534,33 +405,9 @@ ObjectProperty: OEO_00010235
     
 ObjectProperty: OEO_00010312
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a sector and the processes or material entities it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
-        rdfs:label "is sector of"@en
-    
-    Domain: 
-        OEO_00000367
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: OEO_00020056
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to its entity in reality.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/700
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
-        rdfs:label "quantity value of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    InverseOf: 
-        OEO_00140002
-    
     
 ObjectProperty: OEO_00020070
 
@@ -579,26 +426,6 @@ ObjectProperty: OEO_00020182
     
 ObjectProperty: OEO_00020188
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity and a licence.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "has license",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Relabel, redefine and add domain and range:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
-        rdfs:label "has licence"
-    
-    SubPropertyOf: 
-        OEO_00010231
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        OEO_00020015
-    
     
 ObjectProperty: OEO_00020189
 
@@ -638,65 +465,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
 ObjectProperty: OEO_00040010
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A property that links a quantity value to a unit in which the quantity value has been expressed.",
-        rdfs:label "has unit"@en
-    
-    Domain: 
-        OEO_00000350
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/UO_0000000>
-    
     
 ObjectProperty: OEO_00140002
 
-    InverseOf: 
-        OEO_00020056
-    
     
 ObjectProperty: OEO_00140008
 
     
 ObjectProperty: OEO_00140093
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information input c iff: p has input c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information input"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002233>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 ObjectProperty: OEO_00140094
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has information output c iff: p has output c, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-moved to oeo-shared
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "has information output"@en
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     
 ObjectProperty: OEO_00140164
 
@@ -721,9 +501,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        OEO_00000533
     
     
 ObjectProperty: owl:topObjectProperty

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -614,26 +614,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
 ObjectProperty: OEO_00000530
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has origin"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
-        OEO_00000150 or OEO_00000331
-    
-    Range: 
-        OEO_00000316
-    
     
 ObjectProperty: OEO_00000531
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -565,26 +565,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict 
     
 ObjectProperty: OEO_00000523
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00020039
-    
     
 ObjectProperty: OEO_00000524
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -803,18 +803,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
 ObjectProperty: OEO_00140164
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "models"@en
-    
-    Domain: 
-        OEO_00000274
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
     
 ObjectProperty: OEO_00240025
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -90,26 +90,12 @@ ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603"
-    
     Characteristics: 
         Transitive
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/596
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
-Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603
-
-fix duplicate implementation of `Inverse Of`
-issue https://github.com/OpenEnergyPlatform/ontology/issues/979
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086"
-    
     Characteristics: 
         Transitive
     
@@ -125,18 +111,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
@@ -176,12 +153,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001025>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002222>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002223>
 
@@ -212,20 +183,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
 
@@ -252,12 +209,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 
-    Annotations: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "As produces relates to an material entity, but energy is a quality in the OEO, produces cannot be used to describe the energy output of a process. Use 'has energy output' instead."
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
@@ -270,46 +221,9 @@ ObjectProperty: OEO_00000501
     
 ObjectProperty: OEO_00000502
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "A relation between a process attribute and the process it existentially depends on.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/472
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
-
-add domains and ranges:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/1085",
-        rdfs:label "process attribute of"
-    
-    Domain: 
-        OEO_00030019
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: OEO_00000503
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a continuant c1 and a continuant c2, where c1 requires c2 as input to work.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclass)
-https://github.com/OpenEnergyPlatform/ontology/pull/472 (move to oeo-shared)
-https://github.com/OpenEnergyPlatform/ontology/pull/478 (add definition)
-https://github.com/OpenEnergyPlatform/ontology/pull/871 (add domain and range)
-change def
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1117
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1508",
-        rdfs:label "uses"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00000504
 
@@ -328,9 +242,6 @@ ObjectProperty: OEO_00000508
     
 ObjectProperty: OEO_00000509
 
-    SubPropertyOf: 
-        owl:topObjectProperty
-    
     
 ObjectProperty: OEO_00000510
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -571,26 +571,6 @@ ObjectProperty: OEO_00000524
     
 ObjectProperty: OEO_00000529
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has normal state of matter"
-    
-    SubPropertyOf: 
-        OEO_00000531
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000530
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -467,20 +467,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
     
 ObjectProperty: OEO_00000510
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity or model and the organisation in which it was created."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
-
-improve definition:
-https://github.com/OpenEnergyPlatform/ontology/issues/1038
-https://github.com/OpenEnergyPlatform/ontology/pull/1042
-
-Relabel to `has organisation`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
-        rdfs:label "has organisation"
-    
     
 ObjectProperty: OEO_00000514
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -949,21 +949,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
 ObjectProperty: OEO_00020190
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information output of p iff: c is an output of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information output of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002353>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: OEO_00040010
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -440,22 +440,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     
 ObjectProperty: OEO_00000506
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has author' some ('has role' some author) is necessary, because 'has author' has the range 'has role some author' (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an independent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has author"
-    
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
-    
     
 ObjectProperty: OEO_00000507
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -760,20 +760,6 @@ ObjectProperty: OEO_00140002
     
 ObjectProperty: OEO_00140008
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity / model and a continuant, in which the continuant is somehow involved in the creation of the information content entity / model.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
-        rdfs:label "has contributor"@en
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: OEO_00140093
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -931,21 +931,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
     
 ObjectProperty: OEO_00020189
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "c is an information input of p iff: c is an input of p, and c is an information content entity",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1091
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
-        rdfs:label "information input of"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002352>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: OEO_00020190
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -607,31 +607,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     
 ObjectProperty: OEO_00000524
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
-
-move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "has global warming potential"
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00140002
-    
-    Domain: 
-        OEO_00000020
-    
-    Range: 
-        OEO_00010078
-    
     
 ObjectProperty: OEO_00000529
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -762,24 +762,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
     
 ObjectProperty: OEO_00010234
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy input"@en
-    
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
     Domain: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
     
     
 ObjectProperty: OEO_00010235

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -577,21 +577,6 @@ ObjectProperty: OEO_00000530
     
 ObjectProperty: OEO_00000531
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has state of matter"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000532
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -696,38 +696,6 @@ ObjectProperty: OEO_00000532
     
 ObjectProperty: OEO_00000533
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has physical output c iff: p has output c, and c is a material entity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/618
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/716
-
-restrict range to 'material entity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1041
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has physical output"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0002234>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838"
-        <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    InverseOf: 
-        OEO_00240025
-    
     
 ObjectProperty: OEO_00010121
 
@@ -1011,9 +979,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        OEO_00000533
     
     
 ObjectProperty: owl:topObjectProperty

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -813,22 +813,6 @@ ObjectProperty: OEO_00020180
     
 ObjectProperty: OEO_00020182
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "is energy participant of"
-    
-    Domain: 
-        OEO_00000150
-    
-    Range: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: OEO_00020188
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -87,25 +87,6 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy participant"@en
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    InverseOf: 
-        OEO_00020182
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -882,9 +863,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
     Range: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     
     
 ObjectProperty: OEO_00020188

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -527,19 +527,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
         rdfs:label "has organisation"
     
-    SubPropertyOf: 
-        OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
-    
     
 ObjectProperty: OEO_00000514
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -565,39 +565,9 @@ ObjectProperty: OEO_00000516
     
 ObjectProperty: OEO_00000522
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the thing it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/452 (delete unused subclasses)
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/584
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend for study)
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
-        rdfs:label "covers"
-    
     
 ObjectProperty: OEO_00000523
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00020039
-    
     
 ObjectProperty: OEO_00000524
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -1043,18 +1043,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
 ObjectProperty: OEO_00140164
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
-        rdfs:label "models"@en
-    
-    Domain: 
-        OEO_00000274
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
     
 ObjectProperty: OEO_00240025
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1154,9 +1154,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
         OEO_00020166
     
     
-Class: OEO_00000020
-
-    
 Class: OEO_00000051
 
     Annotations: 
@@ -1175,9 +1172,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
         OEO_00010121 some 
             (OEO_00000323 or OEO_00030022)
     
-    
-Class: OEO_00000061
-
     
 Class: OEO_00000064
 
@@ -1216,9 +1210,6 @@ Class: OEO_00000274
 Class: OEO_00000315
 
     
-Class: OEO_00000316
-
-    
 Class: OEO_00000323
 
     Annotations: 
@@ -1232,9 +1223,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
     
-    
-Class: OEO_00000331
-
     
 Class: OEO_00000340
 
@@ -1282,9 +1270,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000367
 
     
-Class: OEO_00000395
-
-    
 Class: OEO_00000407
 
     Annotations: 
@@ -1325,9 +1310,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/RO_0002233> some <http://purl.obolibrary.org/obo/BFO_0000002>,
         <http://purl.obolibrary.org/obo/RO_0002234> some <http://purl.obolibrary.org/obo/BFO_0000002>
     
-    
-Class: OEO_00010078
-
     
 Class: OEO_00010116
 
@@ -1455,9 +1437,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
-    
-Class: OEO_00020039
-
     
 Class: OEO_00020166
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -788,15 +788,6 @@ ObjectProperty: OEO_00010234
     
 ObjectProperty: OEO_00010235
 
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
     
 ObjectProperty: OEO_00010312
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -553,9 +553,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
     SubPropertyOf: 
         OEO_00140008
     
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
     Range: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -804,16 +804,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
     
 ObjectProperty: OEO_00010234
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy input"@en
-    
     SubPropertyOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1141,6 +1141,45 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
 Class: OEO_00000150
 
+    Annotations: 
+        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/364
+fix grammar error:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/657
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665
+move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101
+adjust definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165
+
+Axiomatise relations between origin, energy and portion of matter:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1183
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
+
+Add bearer:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 Class: OEO_00000323
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -637,26 +637,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
     
 ObjectProperty: OEO_00000530
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has origin"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
-        OEO_00000150 or OEO_00000331
-    
-    Range: 
-        OEO_00000316
-    
     
 ObjectProperty: OEO_00000531
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -467,17 +467,14 @@ ObjectProperty: OEO_00000506
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and its author."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has author' some ('has role' some author) is necessary, because 'has author' has the range 'has role some author' (PR https://github.com/OpenEnergyPlatform/ontology/pull/871). That is an independent continuant, i.e. a person, that takes over writing a text and as such the role of an author.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has author"
     
     SubPropertyOf: 
         OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000064
     
     
 ObjectProperty: OEO_00000507

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -448,9 +448,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     Domain: 
         OEO_00020011
     
-    Range: 
-        OEO_00000367
-    
     
 ObjectProperty: OEO_00000506
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -588,26 +588,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict 
     
 ObjectProperty: OEO_00000523
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "change range
-issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
-
-update definition
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/846
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
-        rdfs:label "covers energy carrier"
-    
-    SubPropertyOf: 
-        OEO_00000522
-    
-    Domain: 
-        OEO_00020011
-    
-    Range: 
-        OEO_00020039
-    
     
 ObjectProperty: OEO_00000524
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -110,15 +110,6 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    InverseOf: 
-        OEO_00020182
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
@@ -894,9 +885,6 @@ ObjectProperty: OEO_00020182
     
     Range: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    InverseOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     
     
 ObjectProperty: OEO_00020188

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -862,12 +862,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     
 ObjectProperty: OEO_00020182
 
-    Domain: 
-        OEO_00000150
-    
-    Range: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: OEO_00020188
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -785,15 +785,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
     
 ObjectProperty: OEO_00010234
 
-    SubPropertyOf: 
-        <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
     
 ObjectProperty: OEO_00010235
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -108,9 +108,6 @@ Datatype: xsd:integer
 Datatype: xsd:string
 
     
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
-
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     Annotations: 
@@ -549,15 +546,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         OEO_00140008
     
     
-ObjectProperty: OEO_00000514
-
-    
-ObjectProperty: OEO_00000515
-
-    
-ObjectProperty: OEO_00000516
-
-    
 ObjectProperty: OEO_00000522
 
     Annotations: 
@@ -570,21 +558,6 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821 (restrict to study)",
         rdfs:label "covers"
     
-    
-ObjectProperty: OEO_00000523
-
-    
-ObjectProperty: OEO_00000524
-
-    
-ObjectProperty: OEO_00000529
-
-    
-ObjectProperty: OEO_00000530
-
-    
-ObjectProperty: OEO_00000531
-
     
 ObjectProperty: OEO_00000532
 
@@ -693,12 +666,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
         <http://purl.obolibrary.org/obo/IAO_0000136>
     
     
-ObjectProperty: OEO_00010234
-
-    
-ObjectProperty: OEO_00010235
-
-    
 ObjectProperty: OEO_00010312
 
     Annotations: 
@@ -728,9 +695,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/710",
     InverseOf: 
         OEO_00140002
     
-    
-ObjectProperty: OEO_00020071
-
     
 ObjectProperty: OEO_00020179
 
@@ -769,9 +733,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     Range: 
         OEO_00140012
     
-    
-ObjectProperty: OEO_00020182
-
     
 ObjectProperty: OEO_00020188
 
@@ -1170,9 +1131,6 @@ Class: OEO_00000064
         OEO_00000051
     
     
-Class: OEO_00000087
-
-    
 Class: OEO_00000107
 
     Annotations: 
@@ -1188,12 +1146,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     
 Class: OEO_00000150
-
-    
-Class: OEO_00000274
-
-    
-Class: OEO_00000315
 
     
 Class: OEO_00000323

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -600,21 +600,6 @@ ObjectProperty: OEO_00000530
     
 ObjectProperty: OEO_00000531
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001",
-        rdfs:label "has state of matter"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/RO_0000086>
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000532
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -630,31 +630,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852",
     
 ObjectProperty: OEO_00000524
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
-
-move to oeo-shared:
-https://github.com/OpenEnergyPlatform/ontology/pull/1410",
-        rdfs:label "has global warming potential"
-    
-    SubPropertyOf: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
-        OEO_00140002
-    
-    Domain: 
-        OEO_00000020
-    
-    Range: 
-        OEO_00010078
-    
     
 ObjectProperty: OEO_00000529
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1522,8 +1522,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "organisation"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+        <http://purl.obolibrary.org/obo/BFO_0000141>
     
     
 Class: OEO_00030035

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -816,16 +816,6 @@ ObjectProperty: OEO_00010234
     
 ObjectProperty: OEO_00010235
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy output"@en
-    
     SubPropertyOf: 
         <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -883,11 +883,11 @@ ObjectProperty: OEO_00140008
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/530
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/556
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has contributor"@en
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000002>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -503,17 +503,14 @@ ObjectProperty: OEO_00000508
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the person to contact with issues about it."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has contact person"
     
     SubPropertyOf: 
         OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
     
     
 ObjectProperty: OEO_00000509
@@ -547,7 +544,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1042
 
 Relabel to `has organisation`
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1226
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has organisation"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -594,26 +594,6 @@ ObjectProperty: OEO_00000524
     
 ObjectProperty: OEO_00000529
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "make subproperty of 'has state of matter'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has normal state of matter"
-    
-    SubPropertyOf: 
-        OEO_00000531
-    
-    Domain: 
-        OEO_00000331
-    
-    Range: 
-        OEO_00000395
-    
     
 ObjectProperty: OEO_00000530
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -889,16 +889,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
     
 ObjectProperty: OEO_00020182
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "is energy participant of"
-    
     Domain: 
         OEO_00000150
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -115,9 +115,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 Pull request https://github.com/OpenEnergyPlatform/ontology/pull/599
 Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603"
     
-    Characteristics: 
-        Transitive
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 
@@ -129,9 +126,6 @@ Pull request https://github.com/OpenEnergyPlatform/ontology/pull/603
 fix duplicate implementation of `Inverse Of`
 issue https://github.com/OpenEnergyPlatform/ontology/issues/979
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086"
-    
-    Characteristics: 
-        Transitive
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -938,11 +938,12 @@ ObjectProperty: OEO_00140164
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and the thing it reproduces.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "models"@en
-    
-    Domain: 
-        OEO_00000274
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000004>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -485,17 +485,14 @@ ObjectProperty: OEO_00000507
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between an information content entity / model and the client that requested its creation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/626 (extend def for information content entity)
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871 (domain and range; move to oeo-shared)
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "has client"
     
     SubPropertyOf: 
         OEO_00140008
-    
-    Domain: 
-        OEO_00000274 or <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
     
     
 ObjectProperty: OEO_00000508

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -548,13 +548,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubPropertyOf: 
         OEO_00140008
     
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
-    
     
 ObjectProperty: OEO_00000514
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -110,16 +110,6 @@ Datatype: xsd:string
     
 ObjectProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390",
-        rdfs:label "has energy participant"@en
-    
     Domain: 
         OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1921,6 +1921,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
     
 Class: OEO_00030022
 
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
     
 Class: OEO_00030035
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -136,6 +136,13 @@ ObjectProperty: OEO_00000509
     
 ObjectProperty: OEO_00000510
 
+    Range: 
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "Replace `institution` as range by `organisation role`
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1161
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1200"
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000315
+    
     
 ObjectProperty: OEO_00000522
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -124,6 +124,9 @@ ObjectProperty: OEO_00000507
     
 ObjectProperty: OEO_00000508
 
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000107
+    
     
 ObjectProperty: OEO_00000509
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -121,6 +121,9 @@ ObjectProperty: OEO_00000506
     
 ObjectProperty: OEO_00000507
 
+    Range: 
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000087
+    
     
 ObjectProperty: OEO_00000508
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -115,6 +115,9 @@ ObjectProperty: OEO_00000504
     
 ObjectProperty: OEO_00000505
 
+    Range: 
+        OEO_00000367
+    
     
 ObjectProperty: OEO_00000506
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -80,12 +80,4 @@ AnnotationProperty: dct:title
 Datatype: rdf:PlainLiteral
 
     
-ObjectProperty: OEO_00010128
-
-    
-Class: OEO_00140150
-
-    
-Class: OEO_00140151
-
-    
+   


### PR DESCRIPTION
## Summary of the discussion

comes from #1703 

## Type of change (CHANGELOG.md)

### Updated
- place to live for several domain and ranges of object properties in oeo-shared

### Removed
- doubles axioms in oeo-shared

## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
