### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,12 @@ oeo.omn:
 
 oeo-shared:
  - src/ontology/edits/oeo-shared.omn
+
+oeo-shared-axioms:
+ - src/ontology/edits/oeo-shared-axioms.omn
+
+oeo-sector:
+ - src/ontology/edits/oeo-sector.omn
  
 external ontology:
   - src/ontology/modules/*


### PR DESCRIPTION
I updated the automated labeler action for PRs such that labels for the new modules `oeo-shared-axioms` and `oeo-sector` will be added, too.


### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
