### PR TITLE
fix `governs`

### DIFF
--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -182,6 +182,15 @@ ObjectProperty: OEO_00010121
     
 ObjectProperty: OEO_00010128
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
+        rdfs:label "governs"
+    
+    Domain: 
+        OEO_00140150 or OEO_00140151
+    
     
 ObjectProperty: OEO_00010231
 
@@ -268,15 +277,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
     
 ObjectProperty: OEO_00020179
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a policy or policy instrument and the thing it governs.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/855
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/868",
-        rdfs:label "governs"@en
-    
-    Domain: 
-        OEO_00140150 or OEO_00140151
-    
     
 ObjectProperty: OEO_00020180
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -65,8 +65,6 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -82,5 +80,12 @@ AnnotationProperty: dct:title
 Datatype: rdf:PlainLiteral
 
     
+ObjectProperty: OEO_00010128
+
+    
+Class: OEO_00140150
+
+    
+Class: OEO_00140151
 
     


### PR DESCRIPTION
## Summary of the discussion

`governs` (OEO_00010128) got mixed with `has economic value`. I recovered it now.
Part of #1703 

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
