### PR TITLE
fix disjointness between person, organisation, organisational role #1702

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - new module oeo-shared-axioms.omn (#1649)
 - acceptance (#1698)
 - scenario projection comparison, model intercomparison study (#1711)
+- person, organisational role, organisation (#1716)
 
 
 ### Changed

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1191,6 +1191,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>
     
+    DisjointWith: 
+        OEO_00030022
+    
     
 Class: OEO_00000340
 
@@ -1509,6 +1512,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    DisjointWith: 
+        OEO_00000323
     
     
 Class: OEO_00030035

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1185,7 +1185,10 @@ Class: OEO_00000323
         <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+corrected disjointness 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1702
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1716",
         rdfs:label "person"
     
     SubClassOf: 
@@ -1507,7 +1510,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/983
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/992
 rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+added disjointness 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1702
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1716",
         rdfs:label "organisation"
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -603,15 +603,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
-    DisjointWith: 
-        OEO_00000323
-    
     
 Class: OEO_00000323
 
-    DisjointWith: 
-        OEO_00000315
-    
     
 Class: OEO_00000329
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -597,7 +597,10 @@ Class: OEO_00000315
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+remove disjointness with person
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1702
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1716",
         rdfs:label "organisation role"
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

`person` was disjoint with `organisational role` instead of `organisation`, that was fixed 

## Type of change (CHANGELOG.md)

### Updated
- person 
- organisational role
- organisation

## Workflow checklist

### Automation
Closes #1702

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
