### PR TITLE
add control area, bidding zone, bidding zone role #1481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - regionalisation (#1639)
 - sufficiency scenario (#1642)
 - recycling (#1638)
+- control area, bidding zone, bidding zone role (#1718)
 
 ### Changed
 - energy transformation (#1625)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14463,6 +14463,8 @@ Class: OEO_00360004
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A control area is a supply grid that is under the responsibility of a transmission system operator and is a part of a supply grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         rdfs:label "control area"@en
     
     SubClassOf: 
@@ -14473,6 +14475,8 @@ Class: OEO_00360005
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone is a two-dimensional spatial region in which market participants are able to exchange energy without capacity allocation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         rdfs:label "bidding zone"@en
     
     EquivalentTo: 
@@ -14487,6 +14491,8 @@ Class: OEO_00360006
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone role is a role of a two-dimensional spatial region that is realised in market participants trading energy without capacity allocation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         rdfs:label "bidding zone role"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14459,6 +14459,40 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en,
             (OEO_00000150 or OEO_00010116)
     
     
+Class: OEO_00360004
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A control area is a supply grid that is under the responsibility of a transmission system operator and is a part of a supply grid."@en,
+        rdfs:label "control area"@en
+    
+    SubClassOf: 
+        OEO_00000200
+    
+    
+Class: OEO_00360005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone is a two-dimensional spatial region in which market participants are able to exchange energy without capacity allocation."@en,
+        rdfs:label "bidding zone"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360006)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000009>
+    
+    
+Class: OEO_00360006
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone role is a role of a two-dimensional spatial region that is realised in market participants trading energy without capacity allocation."@en,
+        rdfs:label "bidding zone role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
 Individual: OEO_00000182
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Added: 
`control area` 
*A control area is a supply grid that is under the responsibility of a transmission system operator and is a part of a supply grid.*

`bidding zone`: 
*A bidding zone is a two-dimensional spatial region in which market participants are able to exchange energy without capacity allocation.*

With the Equivalency relation: 
`'bidding zone' EquivalentTo: 'two-dimensional spatial region' and 'has role' some 'bidding zone role'.`

`bidding zone role`: 
*A bidding zone role is a role of a two-dimensional spatial region that is realised in market participants trading energy without capacity allocation.*

## Type of change (CHANGELOG.md)

### Added
- bidding zone
- bidding zone role
- control area 


## Workflow checklist

### Automation
Closes #1481 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
