### PR TITLE
adding the concept of climate neutrality #1392

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14499,6 +14499,51 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
+Class: OEO_00360010
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system."@en,
+        rdfs:comment "There are several climate neutrality criteria defined, e.g. by UNFCCC, IPCC or other institutions, with more or less differing sprecifications. A climate neutrality criterion usually includes net-zero emissions but might, e.g. include non-emission effects like surface albedo."@en,
+        rdfs:label "climate neutrality criterion"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>
+    
+    
+Class: OEO_00360011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Process climate neutrality is a process attribute that conforms to some climate neutrality criteria."@en,
+        rdfs:label "process climate neutrality"@en
+    
+    SubClassOf: 
+        OEO_00030019
+    
+    
+Class: OEO_00360013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutral process is a process that has a process climate neutrality attribute."@en,
+        rdfs:label "climate neutral process"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+         and (OEO_00000500 some OEO_00360011)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+Class: OEO_00360014
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Material climate neutrality is a disposition of a material entity that conforms to some climate neutrality criterion."@en,
+        rdfs:label "material climate neutrality"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>
+    
+    
 Individual: OEO_00000182
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

The concept of climate neutrality was implemented, similar to the concept of sustainability. 
The following classes were added: 

`climate neutrality criterion`: 
*A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system.*

`process climate neutrality`: 
*Process climate neutrality is a process attribute that conforms to some climate neutrality criteria.*

`climate neutral process`: (equivalent class)
*A climate neutral process is a process that has a process climate neutrality attribute.*

`material climate neutrality`:
*Material climate neutrality is a disposition of a material entity that conforms to some climate neutrality criterion.*

## Type of change (CHANGELOG.md)

### Added
- climate neutrality criterion 
- process climate neutrality
- climate neutral process
- material climate neutrality


## Workflow checklist

### Automation
Closes #1392 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
