### PR TITLE
Add (electric) mobility technology #1572

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - control area, bidding zone, bidding zone role (#1718)
 - climate neutrality criterion, process climate neutrality, climate neutral process, material climate neutrality (#1722)
 - blended liquid fuel, bioethanol, E10, B7 (#1723)
+- mobility technology, electric mobility technology (#1727)
 
 ### Changed
 - energy transformation (#1625)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8689,6 +8689,8 @@ Class: OEO_00010449
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mobility technology is a technology that describes how vehicles participate in transport"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
         rdfs:label "mobility technology"@en
     
     SubClassOf: 
@@ -8702,6 +8704,8 @@ Class: OEO_00010450
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric mobility is a technology that describes how electric vehicles participate in transport."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
         rdfs:label "electric mobility technology"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8685,6 +8685,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000183)
     
     
+Class: OEO_00010449
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mobility technology is a technology that describes how vehicles participate in transport"@en,
+        rdfs:label "mobility technology"@en
+    
+    SubClassOf: 
+        OEO_00000407,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00010023
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140003))
+    
+    
+Class: OEO_00010450
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric mobility is a technology that describes how electric vehicles participate in transport."@en,
+        rdfs:label "electric mobility technology"@en
+    
+    SubClassOf: 
+        OEO_00010449,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00000146
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140003))
+    
+    
 Class: OEO_00020001
 
     Annotations: 
@@ -14523,30 +14549,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en,
             (OEO_00000150 or OEO_00010116)
     
     
-Class: OEO_00360007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
-        rdfs:label "flexibility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/RO_0002577>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
-    
-    
-Class: OEO_00360008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy balancing is a process that levels out energy supply and demand for system stability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
-        rdfs:label "energy balancing"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: OEO_00360004
 
     Annotations: 
@@ -14585,6 +14587,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
+        rdfs:label "flexibility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/RO_0002577>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
+    
+    
+Class: OEO_00360008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy balancing is a process that levels out energy supply and demand for system stability."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
+        rdfs:label "energy balancing"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00360010


### PR DESCRIPTION
## Summary of the discussion

Part of the larger technologies project: Add mobility technology and a subclass.

Note: Protégé does some reshuffling of other classes in oeo-physical.

## Type of change (CHANGELOG.md)

### Added
- `mobility technology`: _A mobility technology is a technology that describes how vehicles participate in transport_
`'is about' some (vehicle and ('participates in' some transport))`
- `electric mobility technology`: _An electric mobility is a technology that describes how electric vehicles participate in transport._
`'is about' some ('electric vehicle' and ('participates in' some transport))`

## Workflow checklist

### Automation
No automation, part of #1572

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
