### PR TITLE
add energy storage technologies #1572

### DIFF
--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10102,6 +10102,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00330008))
     
     
+Class: OEO_00020362
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage object is an energy storage object that has the function to store electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
+        rdfs:label "electrical energy storage object"
+    
+    EquivalentTo: 
+        OEO_00000159
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010322)
+    
+    SubClassOf: 
+        OEO_00000159
+    
+    
 Class: OEO_00030000
 
     Annotations: 
@@ -14523,30 +14539,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en,
             (OEO_00000150 or OEO_00010116)
     
     
-Class: OEO_00360007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
-        rdfs:label "flexibility"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010121 some <http://purl.obolibrary.org/obo/RO_0002577>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
-    
-    
-Class: OEO_00360008
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy balancing is a process that levels out energy supply and demand for system stability."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
-        rdfs:label "energy balancing"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
 Class: OEO_00360004
 
     Annotations: 
@@ -14585,6 +14577,32 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
+        rdfs:label "flexibility"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000016>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/RO_0002577>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
+    
+    
+Class: OEO_00360008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy balancing is a process that levels out energy supply and demand for system stability."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
+        rdfs:label "energy balancing"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
 Class: OEO_00360010


### PR DESCRIPTION
## Summary of the discussion
To introduce the `energy storage technology` hierarchy, in https://github.com/OpenEnergyPlatform/ontology/issues/1572#issuecomment-1767977144 it was decided to extend the energy storage objects in parallel to the energy storage functio hierarchy and add the `energy storage technology` hierarchy on top.

## Type of change (CHANGELOG.md)

### Added
- `electrical energy storage object`

### Updated
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Removed
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
