### PR TITLE
Remove belongs to module annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Removed
 - import and annotation scripts removed from repo. New repo is https://github.com/OpenEnergyPlatform/oeo-tools (#1686)
 
+### Deprecated
+- belongs to module (#1732)
+
 ## [1.16.1] - 2023-08-01
 
 ### Added

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -44,9 +44,6 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
-AnnotationProperty: OEO_00040001
-
-    
 AnnotationProperty: OEO_00140170
 
     Annotations: 
@@ -608,7 +605,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0000046>
 Class: OEO_00000048
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An acronym is an abbreviation of the title by using the first letters of each part of the title."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make subclass of abbreviation:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
@@ -622,7 +618,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
 Class: OEO_00000059
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
         rdfs:label "API"
     
@@ -636,7 +631,6 @@ Class: OEO_00000059
 Class: OEO_00000063
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An assumption is an information content entity about a property of a system or process. It determines a part of a scenario content."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/353
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/525"@en,
@@ -653,7 +647,6 @@ Class: OEO_00000064
 Class: OEO_00000078
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boolean variable is a variable that represents a boolean value."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1148
@@ -671,7 +664,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1255",
 Class: OEO_00000085
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A citation reference is a reference stating where a citation was taken from.",
         rdfs:label "citation reference"
     
@@ -682,7 +674,6 @@ Class: OEO_00000085
 Class: OEO_00000090
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A code documentation is a documentation explaining and annotating software code.",
         rdfs:label "code documentation"
     
@@ -693,7 +684,6 @@ Class: OEO_00000090
 Class: OEO_00000091
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A code source is a data descriptor describing the origin of some code.",
         rdfs:label "code source"
     
@@ -704,7 +694,6 @@ Class: OEO_00000091
 Class: OEO_00000104
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "\"The carbon dioxide emissions in Germany have to be reduced by 95% till 2050.\" is a constraint for a model calculation about the energy system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A constraint is a condition that has to be fulfilled within a calculation."@en,
         rdfs:label "constraint"
@@ -716,7 +705,6 @@ Class: OEO_00000104
 Class: OEO_00000118
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A database is an information content entity that stores data items and data sets.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/253
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/272
@@ -735,7 +723,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
 Class: OEO_00000119
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
 		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724
@@ -754,7 +741,6 @@ Class: OEO_00000119
 Class: OEO_00000120
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data format is a data descriptor that specifies the structure in which the data item is encoded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1145
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1326",
@@ -770,7 +756,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1326",
 Class: OEO_00000122
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Data postprocessing is data processing that transforms the output of a model calculation into a form that is suitable for presentation.",
         rdfs:label "data postprocessing"
     
@@ -781,7 +766,6 @@ Class: OEO_00000122
 Class: OEO_00000123
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Data preprocessing is data processing that transforms the input into a form that is useable for a model calculation.",
         rdfs:label "data preprocessing"
     
@@ -792,7 +776,6 @@ Class: OEO_00000123
 Class: OEO_00000124
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/252
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
         rdfs:comment "data processing is a transformation in which a data item gets transformed.",
@@ -806,7 +789,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/289",
 Class: OEO_00000125
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "data processing software is software used in the context of data processing.",
         rdfs:label "data processing software"
     
@@ -817,7 +799,6 @@ Class: OEO_00000125
 Class: OEO_00000133
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A DOI (digital object identifier) is a persistent identifier or handle used to uniquely identify objects, standardized by the International Organization for Standardization (ISO).
 source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "digital object identifier",
@@ -830,7 +811,6 @@ source: https://en.wikipedia.org/wiki/Digital_object_identifier"@en,
 Class: OEO_00000149
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000112> "The measurement series of some experiment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An empirical data set is a dataset that is obtained from observations in the real world."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Move to oeo-shared and harmonise label:
@@ -850,7 +830,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000161
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An external optimiser is a software external to a model that computes an optimisation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "external optimizer",
         rdfs:label "external optimiser"
@@ -862,7 +841,6 @@ Class: OEO_00000161
 Class: OEO_00000162
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A factsheet is a document that collects information about a specific topic in a structured way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/250
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/271
@@ -881,7 +859,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
 Class: OEO_00000172
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A framework factsheet is a factsheet that contains information about a software framework.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
@@ -896,7 +873,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000202
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface) is a software interface allowing users to communicate with a software application through a graphical window.",
         rdfs:label "GUI"
     
@@ -910,7 +886,6 @@ Class: OEO_00000202
 Class: OEO_00000228
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An installation guide is a documentation intended to help users install a Software.",
         rdfs:label "installation guide"
     
@@ -921,7 +896,6 @@ Class: OEO_00000228
 Class: OEO_00000239
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software interface is a software that enables an agent to interact with it.",
         rdfs:label "software interface"
     
@@ -932,7 +906,6 @@ Class: OEO_00000239
 Class: OEO_00000264
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market model is a model that is about the energy market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/415
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821
@@ -949,7 +922,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000274
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model is a generically dependent continuant that is used for computing an idealised reproduction of a system and its behaviours."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/180
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/349
@@ -972,7 +944,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000275
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model calculation is a process of solving mathematical equations of a model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/73
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/504
@@ -996,7 +967,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
 Class: OEO_00000276
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model component is a generically dependent continuant that is part of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "model element",
         rdfs:label "model component"
@@ -1011,7 +981,6 @@ Class: OEO_00000276
 Class: OEO_00000277
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model factsheet is a model descriptor that contains a brief description of all relevant model information.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440 
@@ -1030,7 +999,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
 Class: OEO_00000279
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A modelling software is a software used to create and maintain a (mathematical) model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "modeling software",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/338
@@ -1049,7 +1017,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
 Class: OEO_00000281
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A modus is an information content entity describing the state of activity something has, e.g. active, inactive or passive.",
         rdfs:label "modus"
     
@@ -1060,7 +1027,6 @@ Class: OEO_00000281
 Class: OEO_00000304
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An objective function is an information content entity stating the function that should be maximised or minimised to solve a problem.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/725
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
@@ -1073,7 +1039,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/757",
 Class: OEO_00000312
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "open source is a software descriptor labelling software whose source code is available online for free and can be modified or redistributed.",
         rdfs:label "open source"
     
@@ -1087,7 +1052,6 @@ Class: OEO_00000312
 Class: OEO_00000313
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation is a model calculation with the goal to find a best choice or result for at least one variable or function in the model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "optimization",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has participant' axiom:
@@ -1105,7 +1069,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410",
 Class: OEO_00000314
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An optimisation model is a model that optimises a target function."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "optimization model",
         rdfs:label "optimisation model"
@@ -1124,7 +1087,6 @@ Class: OEO_00000323
 Class: OEO_00000327
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plotting is data processing where data is visualised in form of a diagram.",
         rdfs:label "plotting"
     
@@ -1135,7 +1097,6 @@ Class: OEO_00000327
 Class: OEO_00000328
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A political assumption is an assumption about political measures taken."@en,
         rdfs:label "political assumption"
     
@@ -1146,7 +1107,6 @@ Class: OEO_00000328
 Class: OEO_00000339
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "Settings for a random number generator."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A program parameter is a variable in a software."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Rework definition and change parent class:
@@ -1168,7 +1128,6 @@ Class: OEO_00000350
 Class: OEO_00000353
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reference is an information content entity naming a relevant document, position in a document or address.",
         rdfs:label "reference"
     
@@ -1179,7 +1138,6 @@ Class: OEO_00000353
 Class: OEO_00000364
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario is an information content entity that contains statements about a possible future development based on a coherent and internally consistent set of assumptions and their motivation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "narrative",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storyline",
@@ -1205,7 +1163,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000365
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario factsheet is a factsheet that contains information about a scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/414
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/440
@@ -1220,7 +1177,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000370
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation is a model calculation that simulates a process or system behaviour from the real world."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has participant' axiom:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410",
@@ -1237,7 +1193,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410",
 Class: OEO_00000371
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation model is a model that simulates the behaviour of a system without a target function."@en,
         rdfs:label "simulation model"
     
@@ -1252,7 +1207,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/821"
 Class: OEO_00000372
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A single node model is a model where a region is represented as a single node.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
@@ -1265,7 +1219,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358",
 Class: OEO_00000378
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software descriptor is an information content entity that contains additional information about the software.",
         rdfs:label "software descriptor"
     
@@ -1276,7 +1229,6 @@ Class: OEO_00000378
 Class: OEO_00000380
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/251
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/285
 
@@ -1294,7 +1246,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547",
 Class: OEO_00000382
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software framework is a Software that is generic and can be adapted to a specific application.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
@@ -1307,7 +1258,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/286",
 Class: OEO_00000392
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solver is a software that solves a mathematical problem.",
         rdfs:label "solver"
     
@@ -1318,7 +1268,6 @@ Class: OEO_00000392
 Class: OEO_00000403
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "The projected power usage during an idealised model year."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic data set is a dataset that is obtained by artificially creating data items. It is constructed to be an estimation of a real-world dataset."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Harmonise label:
@@ -1339,7 +1288,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000408
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A test data set is a data set used for testing.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Harmonise label:
 https://github.com/OpenEnergyPlatform/ontology/pull/1463",
@@ -1355,7 +1303,6 @@ Class: OEO_00000419
 Class: OEO_00000423
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity transshipment model is a model that applies the transshipment problem to the electricity grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358
@@ -1372,7 +1319,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000432
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A user documentation is a documentation intended to assist users in using the software.",
         rdfs:label "user documentation"
     
@@ -1383,7 +1329,6 @@ Class: OEO_00000432
 Class: OEO_00000435
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A variable is an information content entity that represents a changeable value, vector, matrix or function within a mathematical expression."@en,
         rdfs:label "variable"
     
@@ -1394,7 +1339,6 @@ Class: OEO_00000435
 Class: OEO_00010051
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensitivity analysis is the process of comparing different model calculations based on a variation of input parameters (exogenous data items).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/483
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
@@ -1407,7 +1351,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/550",
 Class: OEO_00010213
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission constraint is a constraint that determines the emissions a model calculation describes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "decarbonisation pathway",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
@@ -1421,7 +1364,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
 Class: OEO_00010233
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forecast error is a quantity value that quantifies the difference between a measured and a forecasted value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/907
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
@@ -1434,7 +1376,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1002",
 Class: OEO_00010247
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An abbreviation is a symbol of a textual entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1039
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
@@ -1490,7 +1431,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1391",
 Class: OEO_00010255
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nationally determined contribution (NDC) is a target description of future greenhouse gas emission reductions prepared, communicated and maintained by a party to the Paris Agreement.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NDC",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/947
@@ -1508,7 +1448,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706",
 Class: OEO_00010260
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Parameterisation is the process of translating assumptions into exogenous data the model can use.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "parametrise",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
@@ -1524,7 +1463,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00010261
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model calibration is a process of varying exogenous data, so that the model reproduces the known data (e.g. historical) as far as possible, and thus a part of validation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1040
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
@@ -1540,7 +1478,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1216",
 Class: OEO_00010262
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario projection is an intentional process in which output (endogenous) data of interest are quantified for future points in time using one or more model calculation based on a scenario.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "A scenario projection is an intentional process (with human participation): A scenario is either created or selected, its assumptions are translated into data sets. These datasets are quantified and serve as inputs to a model calculation which is applied to quantitatively project one or more variables of interest into the future.
 (Intentional: a research question is basis for the projection to be done)",
@@ -1732,7 +1669,6 @@ Class: OEO_00020012
 Class: OEO_00020013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Output data is endogenous data that is determined by a model calculation and presented as a result.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "modelling results",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/520
@@ -1752,7 +1688,6 @@ Class: OEO_00020015
 Class: OEO_00020016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model descriptor is an information content entity that contains information about some model."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
@@ -1777,7 +1712,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A analytical approach is a model descriptor that contains information about the analysis strategy of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
@@ -1792,7 +1726,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/981",
 Class: OEO_00020018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodical focus is a model descriptor that specifies the primary calculation method used in a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methodology",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
@@ -1812,7 +1745,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary modelling purpose is a model descriptor stating the main purpose of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "primary modeling purpose",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
@@ -1826,7 +1758,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A model documentation is a model descriptor that contains a detailed description of a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/82
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
@@ -1839,7 +1770,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577",
 Class: OEO_00020023
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Top down is an analytical approach where design starts from the system as a whole. The system is then divided into smaller sub-applications with more details. Each part again goes through the top down approach till the complete system is designed with all minute details. Top down approach is also termed as breaking the bigger problem into smaller problems and solving them individually in a recursive manner. A top down model is based on a decomposition approach.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Convert to subclass and add definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1147
@@ -1853,7 +1783,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1302",
 Class: OEO_00020024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Bottom up is an analytical approach where parts of the system are defined in details. Once these parts are designed and developed, then these parts or components are linked together to prepare a bigger component. This approach is repeated until the complete system is built. A bottom up model is based on a composition approach.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Convert to subclass and add definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1147
@@ -1867,7 +1796,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1302",
 Class: OEO_00020026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hybrid is an analytical approach that combines the top down and the bottom up approach. Some parts are based on composition approach while other parts are based on decomposition approach.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Convert to subclass and add definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1147
@@ -1881,7 +1809,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1302",
 Class: OEO_00020032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1902,7 +1829,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
@@ -1915,7 +1841,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1932,7 +1857,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1953,7 +1877,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
@@ -1971,7 +1894,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
 Class: OEO_00020072
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An analysis scope is an information content entity that describes the boundaries of what a study or scenario covers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/638
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/764
@@ -1997,7 +1919,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020089
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical period is a time series that represents a couple of real time periods that have certain characteristics in common, e.g. seasonal specifications, weekly routines, etc. It doesn't refer to a real date. Typical periods are used to reduce computing time of energy system models.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition adapted from: https://www.enargus.de/pub/bscw.cgi/d13068-2/*/*/Typtag.html?op=Wiki.getwiki&scope=all",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom `uses some 'aggregation type'`:
@@ -2016,7 +1937,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875",
 Class: OEO_00020090
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical year is a typical period with the duration of one year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
@@ -2038,7 +1958,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020091
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A typical day is a typical period with the duration of one day.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/830
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/875
@@ -2060,7 +1979,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020093
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an information content entity that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
@@ -2073,7 +1991,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881",
 Class: OEO_00020097
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario year is a time step that has a duration of one year and is part of a scenario horizon.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
@@ -2095,7 +2012,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020098
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario horizon is a time step that is under investigation and consists entirely of one or more scenario years.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882
@@ -2116,7 +2032,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020099
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A meteorological year is a time step in which meteorological data was collected and that has a duration of one year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -2133,7 +2048,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020100
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A weather time series is a time series that contains data about a specific meteorological year.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "meteorological time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
@@ -2148,7 +2062,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020101
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario time series is a time series that contains data about a specific scenario year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/474
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
@@ -2162,7 +2075,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882",
 Class: OEO_00020121
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Resolution is a quality of a dataset that indicates the level of detail of the data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/972
@@ -2184,7 +2096,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020122
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Temporal resolution is the resolution of a time series that indicates time-dependent the level of detail.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
@@ -2212,7 +2123,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020123
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial resolution is the resolution of a georeferenced dataset that indicates the geographical level of detail.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/849
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/912
@@ -2235,7 +2145,6 @@ Class: OEO_00020166
 Class: OEO_00020185
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A copyright licence is a licence that states the ownership and contractually sets the rights and obligations to use, copy, and distribute a creative work.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "copyright license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add relation has copyright license
@@ -2258,7 +2167,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020186
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data licence is a licence that determines ownership, database protection, and permissions for data.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "data license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
@@ -2280,7 +2188,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020187
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software licence is a copyright licence that determines ownership and permissions for software, code, or models.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "software license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
@@ -2513,7 +2420,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648",
 Class: OEO_00030007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A climate scenario is a scenario that describes a possible future state of a climate system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
@@ -2533,7 +2439,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706",
 Class: OEO_00030008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic scenario is a scenario that describes a possible future state of economic systems.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344 
@@ -2549,7 +2454,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1642",
 Class: OEO_00030009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission scenario is a scenario that describes a possible emission trajectory.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
@@ -2570,7 +2474,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy scenario is a scenario that describes a possible future state of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/328
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/344
@@ -2591,7 +2494,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706",
 Class: OEO_00030015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system model is a model of an energy system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/337
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/358
@@ -2607,7 +2509,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Exogenous data is a data item whose quantity value is determined outside of a model and is imposed on a model.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "input data",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
@@ -2636,7 +2537,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030030
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Endogenous data is a data item whose quantity value is determined by a model.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/482
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/500
@@ -2664,7 +2564,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030031
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start time is a zero-dimensional temporal region that indicates the beginning of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
@@ -2681,7 +2580,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ending time is a zero-dimensional temporal region that indicates the end of a one-dimensional temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
@@ -2698,7 +2596,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time step is a one-dimensional temporal region that has a start time and an ending time and thus a finite duration.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
@@ -2724,7 +2621,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time series is a data set that references to a set of time steps or zero-dimensional temporal regions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/538
@@ -2757,7 +2653,6 @@ Class: OEO_00030035
 Class: OEO_00140024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Validation is the process of checking if something works correctly.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -2770,7 +2665,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cross-checking against other models is a validation where a model gets cross-checked against other models of the domain.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -2783,7 +2677,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against measurements is a validation where something gets checked by using relevant measurements.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -2796,7 +2689,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Checking against empirical data is a validation where something gets checked against empirical data.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/487
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
@@ -2809,7 +2701,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140043
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
@@ -2830,7 +2721,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140044
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp alignment is a data descriptor that indicates the position of a time stamp in a time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
@@ -2851,7 +2741,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140068
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000112> "aggregation of a data set with spatial references",
         <http://purl.obolibrary.org/obo/IAO_0000112> "temporal aggregation of continuous measurements for a discrete time series",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aggregation type is a data descriptor that contains information on the aggregation method applied on a data set.",
@@ -2871,7 +2760,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Class: OEO_00140098
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quality control flag is a data descriptor that describes the measurement quality of a data set, e.g. a time series.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
@@ -2885,7 +2773,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724",
 Class: OEO_00140099
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
@@ -2898,7 +2785,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729",
 Class: OEO_00140138
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A generation time series is a time series that describes the specific electricity generation of a particular power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793
@@ -2918,7 +2804,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706",
 Class: OEO_00140139
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A yield profile is a generation time series of a particular renewable power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793
@@ -2939,7 +2824,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706",
 Class: OEO_00140161
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cooperative programming is the process of two or more people working on program code together at the same time (according to a specified routine).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "collaborative programming",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/254
@@ -2958,7 +2842,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00140167
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An uncertainty approach is a model descriptor that specifies how a model deals with uncertainty.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
@@ -2971,7 +2854,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
 Class: OEO_00240004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An objective variable is a variable that should be maximised or minimised to solve a problem."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/878",
@@ -3112,7 +2994,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711",
 Individual: OEO_00000049
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "active"
     
     Types: 
@@ -3122,7 +3003,6 @@ Individual: OEO_00000049
 Individual: OEO_00000081
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "c++"
     
     Types: 
@@ -3132,7 +3012,6 @@ Individual: OEO_00000081
 Individual: OEO_00000092
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "coin- or_cbc"
     
     Types: 
@@ -3142,7 +3021,6 @@ Individual: OEO_00000092
 Individual: OEO_00000114
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "cplex"
     
     Types: 
@@ -3152,7 +3030,6 @@ Individual: OEO_00000114
 Individual: OEO_00000121
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "data frame"
     
     Types: 
@@ -3162,7 +3039,6 @@ Individual: OEO_00000121
 Individual: OEO_00000130
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "dict"
     
     Types: 
@@ -3172,7 +3048,6 @@ Individual: OEO_00000130
 Individual: OEO_00000163
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "False is a boolean value which is intended to represent the truth value false (denoted by 0, by -, the falsum ⊥, or falsch (F) in German).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "falsch"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
@@ -3190,7 +3065,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1255",
 Individual: OEO_00000170
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "fortran"
     
     Types: 
@@ -3200,7 +3074,6 @@ Individual: OEO_00000170
 Individual: OEO_00000180
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "gams"
     
     Types: 
@@ -3210,7 +3083,6 @@ Individual: OEO_00000180
 Individual: OEO_00000187
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "gdx"
     
     Types: 
@@ -3220,7 +3092,6 @@ Individual: OEO_00000187
 Individual: OEO_00000195
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "glpk"
     
     Types: 
@@ -3230,7 +3101,6 @@ Individual: OEO_00000195
 Individual: OEO_00000196
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "gnu"
     
     Types: 
@@ -3240,7 +3110,6 @@ Individual: OEO_00000196
 Individual: OEO_00000203
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "gurobi"
     
     Types: 
@@ -3250,7 +3119,6 @@ Individual: OEO_00000203
 Individual: OEO_00000225
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "inactive"
     
     Types: 
@@ -3260,7 +3128,6 @@ Individual: OEO_00000225
 Individual: OEO_00000244
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "java"
     
     Types: 
@@ -3270,7 +3137,6 @@ Individual: OEO_00000244
 Individual: OEO_00000266
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "math prog"
     
     Types: 
@@ -3280,7 +3146,6 @@ Individual: OEO_00000266
 Individual: OEO_00000267
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "matlab"
     
     Types: 
@@ -3290,7 +3155,6 @@ Individual: OEO_00000267
 Individual: OEO_00000280
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "modelica"
     
     Types: 
@@ -3300,7 +3164,6 @@ Individual: OEO_00000280
 Individual: OEO_00000285
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "mosek"
     
     Types: 
@@ -3310,7 +3173,6 @@ Individual: OEO_00000285
 Individual: OEO_00000287
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "ms_ excel"
     
     Types: 
@@ -3320,7 +3182,6 @@ Individual: OEO_00000287
 Individual: OEO_00000288
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "vba"
     
     Types: 
@@ -3330,7 +3191,6 @@ Individual: OEO_00000288
 Individual: OEO_00000319
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "passive"
     
     Types: 
@@ -3340,7 +3200,6 @@ Individual: OEO_00000319
 Individual: OEO_00000325
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "php"
     
     Types: 
@@ -3350,7 +3209,6 @@ Individual: OEO_00000325
 Individual: OEO_00000349
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "python"
     
     Types: 
@@ -3360,7 +3218,6 @@ Individual: OEO_00000349
 Individual: OEO_00000351
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "r"
     
     Types: 
@@ -3370,7 +3227,6 @@ Individual: OEO_00000351
 Individual: OEO_00000362
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "ruby"
     
     Types: 
@@ -3380,7 +3236,6 @@ Individual: OEO_00000362
 Individual: OEO_00000424
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "True is a boolean value which is intended to represent the truth value true (denoted by 1, by +, the verum ⊤, or wahr (W) in German).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wahr"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "definition:
@@ -3398,7 +3253,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1255",
 Individual: OEO_00000450
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "xlsx"
     
     Types: 
@@ -3408,7 +3262,6 @@ Individual: OEO_00000450
 Individual: OEO_00000451
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "xml"
     
     Types: 
@@ -3418,7 +3271,6 @@ Individual: OEO_00000451
 Individual: OEO_00020027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "spreadsheet"@en
     
     Types: 
@@ -3428,7 +3280,6 @@ Individual: OEO_00020027
 Individual: OEO_00020028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "monte carlo"@en
     
     Types: 
@@ -3438,7 +3289,6 @@ Individual: OEO_00020028
 Individual: OEO_00020029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         rdfs:label "econometric"@en
     
     Types: 
@@ -3448,7 +3298,6 @@ Individual: OEO_00020029
 Individual: OEO_00020161
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per year",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -3462,7 +3311,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00020162
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per week",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -3476,7 +3324,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00020163
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per day",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -3490,7 +3337,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00020164
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per hour",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -3504,7 +3350,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00020165
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "one value per month",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -3518,7 +3363,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00140045
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A start alignment is a time stamp alignment indicating that the time stamp marks the start of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "left alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -3532,7 +3376,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140046
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A middle alignment is a time stamp alignment indicating that the time stamp marks the middle of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "center alignment",
         <http://purl.obolibrary.org/obo/IAO_0000118> "centre alignment",
@@ -3547,7 +3390,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140047
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An end alignment is a time stamp alignment indicating that the time stamp marks the end of the time step.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "right alignment",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -3561,7 +3403,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570",
 Individual: OEO_00140069
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "value measured at or modelled for exactly one 0-dim temporal region, referenced by a time stamp, e.g. to represent a time step in a time series",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -3574,7 +3415,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140070
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "sum or integral of values, e.g. within a time step or a spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -3587,7 +3427,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140071
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "average value calculated by arithmetic mean over a set of data values, e.g. within a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -3600,7 +3439,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140072
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "minimum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -3613,7 +3451,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140073
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000115> "maximum value within a set of data values, e.g. in a time step or spatial region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/571
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
@@ -3626,7 +3463,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/610",
 Individual: OEO_00140168
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "stochastic"@en
@@ -3638,7 +3474,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
 Individual: OEO_00140169
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-model",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/183
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
         rdfs:label "deterministic"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -50,9 +50,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
-AnnotationProperty: OEO_00040001
-
-    
 AnnotationProperty: OEO_00110012
 
     
@@ -757,7 +754,6 @@ Class: <http://purl.obolibrary.org/obo/UO_0010006>
 Class: OEO_00000001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
@@ -787,7 +783,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power unit is a power generating unit using biofuel.",
         rdfs:label "biofuel power unit"
     
@@ -803,7 +798,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -817,7 +811,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power unit is a biofuel power unit using biogas as fuel.",
         rdfs:label "biogas power unit"
     
@@ -829,7 +822,6 @@ Class: OEO_00000005
 Class: OEO_00000006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
@@ -854,7 +846,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
@@ -878,7 +869,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -897,7 +887,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "fix energy axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1281
@@ -919,7 +908,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
 Class: OEO_00000010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electro motive generator is a generator that converts kinetic energy into electric energy.",
         rdfs:label "electro motive generator"
     
@@ -934,7 +922,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -971,7 +958,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is the function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
@@ -989,7 +975,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluorinated greenhouse gas is a greenhouse gas that is produced by fluorination. Hence it contains Fluor (F) atoms and is of anthropogenic origin.",
         rdfs:label "fluorinated greenhouse gas"
     
@@ -1003,7 +988,6 @@ Class: OEO_00000013
 Class: OEO_00000014
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
@@ -1034,7 +1018,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve axioms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1337
@@ -1057,7 +1040,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gas power unit",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'gas power unit' as alternative term:
@@ -1079,7 +1061,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752
@@ -1107,7 +1088,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -1137,7 +1117,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power unit is a coal power unit using hard coal as fuel.",
         rdfs:label "hard coal power unit"
     
@@ -1149,7 +1128,6 @@ Class: OEO_00000021
 Class: OEO_00000022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1168,7 +1146,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power unit is a coal power unit using lignite as fuel.",
         rdfs:label "lignite power unit"
     
@@ -1180,7 +1157,6 @@ Class: OEO_00000024
 Class: OEO_00000025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification changed:
@@ -1204,7 +1180,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen trifluoride is a portion of matter with the chemical formula NF3. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NF3",
         rdfs:label "nitrogen trifluoride"
@@ -1218,7 +1193,6 @@ Class: OEO_00000026
 Class: OEO_00000027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrous oxide is a portion of matter with the chemical formula N2O. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and it can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "N2O",
         
@@ -1240,7 +1214,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -1253,7 +1226,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1272,7 +1244,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000030
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An oil power unit is a power generating unit using oil as fuel.",
         rdfs:label "oil power unit"
     
@@ -1293,7 +1264,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000031
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -1330,7 +1300,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell",
         <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell",
@@ -1364,7 +1333,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -1386,7 +1354,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
@@ -1409,7 +1376,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
 Class: OEO_00000035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -1428,7 +1394,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1442,7 +1407,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power unit is a biomass power unit using solid biomass as fuel.",
         rdfs:label "solid biomass power unit"
     
@@ -1454,7 +1418,6 @@ Class: OEO_00000037
 Class: OEO_00000038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur hexafluoride is a portion of matter with the chemical formula SF6. It has a gaseous normal state of matter. It can work as a potent greenhouse gas and has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SF6",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur hexafluoride",
@@ -1469,7 +1432,6 @@ Class: OEO_00000038
 Class: OEO_00000039
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
@@ -1483,7 +1445,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -1504,7 +1465,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000041
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1523,7 +1483,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000042
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of a material entity that has been discarded after primary use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
@@ -1549,7 +1508,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000043
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
@@ -1567,7 +1525,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000044
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
@@ -1601,7 +1558,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000047
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -1621,7 +1577,6 @@ Class: OEO_00000051
 Class: OEO_00000054
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add origin
@@ -1652,7 +1607,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000055
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
@@ -1671,7 +1625,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000056
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -1684,7 +1637,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00000058
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         
@@ -1701,7 +1653,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000061
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
@@ -1723,7 +1674,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000062
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Associated gas is a natural gas that is a byproduct from crude oil exploitation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "associated gas"
@@ -1735,7 +1685,6 @@ Class: OEO_00000062
 Class: OEO_00000066
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/1028
@@ -1755,7 +1704,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000068
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
@@ -1772,7 +1720,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000071
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "redefine and change axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
@@ -1790,7 +1737,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
 Class: OEO_00000072
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
@@ -1831,7 +1777,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
 Class: OEO_00000073
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1845,7 +1790,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000074
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -1871,7 +1815,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000075
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
@@ -1898,7 +1841,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
 Class: OEO_00000077
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Blast furnace gas is manufactured coal based gas produced during the combustion of coke in blast furnaces in the iron and steel industry. It is recovered and used as a fuel partly within the plant and partly in other steel industry processes or in power stations equipped to burn it. The quantity of fuel should be reported on a gross calorific value basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "blast furnace gas"
@@ -1910,7 +1852,6 @@ Class: OEO_00000077
 Class: OEO_00000084
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter and can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -1935,7 +1876,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000088
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
         
@@ -1960,7 +1900,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000089
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -1978,7 +1917,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000093
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coke oven gas is manufactured coal based gas obtained as a by-product of the manufacture of coke oven coke for the production of iron and steel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "coke oven gas"
@@ -1990,7 +1928,6 @@ Class: OEO_00000093
 Class: OEO_00000094
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coking coal is hard coal that is bituminous with a quality that allows the production of a coke suitable to support a blast furnace charge. Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "coking coal"
@@ -2002,7 +1939,6 @@ Class: OEO_00000094
 Class: OEO_00000096
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "firedamp",
         <http://purl.obolibrary.org/obo/IAO_0000118> "mine gas",
@@ -2017,7 +1953,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1406",
 Class: OEO_00000097
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'realized in' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
@@ -2040,7 +1975,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000099
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
@@ -2068,7 +2002,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000102
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
@@ -2083,7 +2016,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000115
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2116,7 +2048,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000117
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
@@ -2130,7 +2061,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
 Class: OEO_00000126
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
@@ -2147,7 +2077,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000129
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -2162,7 +2091,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000131
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "transport diesel"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2184,7 +2112,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000132
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -2198,7 +2125,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000139
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
@@ -2240,7 +2166,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000143
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
@@ -2268,7 +2193,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000144
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
@@ -2292,7 +2216,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000146
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric traction motors."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -2319,7 +2242,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00000147
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -2339,7 +2261,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000148
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that quantifies the emissions or removals of a gas per unit activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
@@ -2366,7 +2287,6 @@ Class: OEO_00000150
 Class: OEO_00000151
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
@@ -2393,7 +2313,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000159
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
@@ -2417,7 +2336,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00000165
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A field photovoltaic power plant (also: solar farm, solar park) is a photovoltaic power plant that is installed out in the open on the ground."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solar park",
         rdfs:label "field photovoltaic power plant"
@@ -2432,7 +2350,6 @@ Class: OEO_00000165
 Class: OEO_00000169
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
@@ -2447,7 +2364,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000173
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
@@ -2483,7 +2399,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000174
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
@@ -2500,7 +2415,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000175
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
@@ -2518,7 +2432,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000181
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
@@ -2548,7 +2461,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000183
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
         
@@ -2587,7 +2499,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000184
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2601,7 +2512,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000185
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that participates in a gas turbine process. It is also called combustion turbine.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
@@ -2633,7 +2543,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000186
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gasworks gas is manufactured coal based gas that covers all types of gases produced in public utility or private plants, whose main purpose is manufacture, transport and distribution of gas. It includes gas produced by carbonisation (including gas produced by coke ovens and transferred to gasworks gas), by total gasification with or without enrichment with oil products (LPG, residual fuel oil, etc.), and by reforming and simple mixing of gases and/or air, reported under the rows ‘from other sources’. Under the transformation sector identify amounts of gasworks gas transferred to blended natural gas which will be distributed and consumed through the natural gas grid.
 
 The production of other coal gases (i.e. coke oven gas, blast furnace gas and oxygen steel furnace gas) should be reported in the columns concerning such gases, and not as production of gasworks gas. The coal gases transferred to gasworks plants should then be reported (in their own column) in the transformation sector in the gasworks plants row. The total amount of gasworks gas resulting from transfers of other coal gases should appear in the production line for gasworks gas."@en,
@@ -2647,7 +2556,6 @@ The production of other coal gases (i.e. coke oven gas, blast furnace gas and ox
 Class: OEO_00000188
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -2675,7 +2583,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000189
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geographic coordinate system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803
@@ -2693,7 +2600,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000191
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
@@ -2711,7 +2617,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000192
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2729,7 +2634,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000198
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -2766,7 +2670,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000199
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
@@ -2797,7 +2700,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000200
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "grid",
         <http://purl.obolibrary.org/obo/IAO_0000118> "network",
@@ -2819,7 +2721,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000204
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hard coal is coal with a gross calorific value greater than 23 865 kJ/kg (5 700 kcal/kg) on an ashfree but moist basis and with a mean random reflectance of vitrinite of at least 0,6."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         rdfs:label "hard coal"
@@ -2834,7 +2735,6 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -2848,7 +2748,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000206
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
@@ -2869,7 +2768,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000207
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
@@ -2894,7 +2792,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000210
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
@@ -2918,7 +2815,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000211
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "other gas oil"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -2935,7 +2831,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000212
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat pump is a heater that transforms low temperature heat to high temperature heat using external energy."@en,
         rdfs:label "heat pump"
     
@@ -2946,7 +2841,6 @@ Class: OEO_00000212
 Class: OEO_00000218
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
@@ -2973,7 +2867,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00000219
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrofluorocarbons (HFCs) are portions of matter consisting of organic compounds that contain fluorine and hydrogen atoms, and are the most common type of organofluorine compounds. They are frequently used in air conditioning and as refrigerants in place of the older chlorofluorocarbons such as R-12 and hydrochlorofluorocarbons such as R-21."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "HFC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Hydrofluorocarbon&oldid=904556263"@en,
@@ -2987,7 +2880,6 @@ Class: OEO_00000219
 Class: OEO_00000220
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
@@ -3007,7 +2899,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000221
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3021,7 +2912,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000222
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
@@ -3043,7 +2933,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000226
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -3056,7 +2945,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000240
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle that uses an internal combustion engine for propulsion.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
@@ -3089,7 +2977,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00000245
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International Air Transport Association (IATA).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -3109,7 +2996,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
 Class: OEO_00000246
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
 [...]
 
@@ -3141,7 +3027,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000248
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "LIB",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery",
@@ -3157,7 +3042,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000251
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         
@@ -3181,7 +3065,6 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
 Class: OEO_00000252
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3199,7 +3082,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000253
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
@@ -3220,7 +3102,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000255
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
@@ -3243,7 +3124,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00000257
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "redefine definition and add equivalent
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
@@ -3261,7 +3141,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00000258
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -3284,7 +3163,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000259
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification and integration of molten state battery
@@ -3299,7 +3177,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000263
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
@@ -3321,7 +3198,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000269
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Improve definition and classification:
@@ -3337,7 +3213,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000282
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "reclassification
@@ -3352,7 +3227,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000286
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 °C and 215 °C. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
 
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
@@ -3374,7 +3248,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00000290
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -3387,7 +3260,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000292
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
@@ -3421,7 +3293,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000293
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -3434,7 +3305,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
 Class: OEO_00000296
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -3450,7 +3320,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00000297
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non associated gas is natural gas originating from fields producing hydrocarbons only in gaseous form.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN",
         rdfs:label "non associated gas"
@@ -3462,7 +3331,6 @@ Class: OEO_00000297
 Class: OEO_00000298
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
@@ -3477,7 +3345,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00000299
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
@@ -3497,7 +3364,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000300
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
@@ -3519,7 +3385,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000302
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
@@ -3537,7 +3402,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000303
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3555,7 +3419,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000308
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind farm is a wind farm that is build in a body of water, usually the ocean."@en,
         rdfs:label "offshore wind farm"
     
@@ -3569,7 +3432,6 @@ Class: OEO_00000308
 Class: OEO_00000310
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3583,7 +3445,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000311
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind farm is a wind farm that is build on land."@en,
         rdfs:label "onshore wind farm"
     
@@ -3597,7 +3458,6 @@ Class: OEO_00000311
 Class: OEO_00000316
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -3635,7 +3495,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000318
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -3655,7 +3514,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000320
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
@@ -3682,7 +3540,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
 Class: OEO_00000322
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Perfluorocarbons (PFCs) are portions of matter consisting of organic compounds that contain fluorine atoms but no hydrogen atoms.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PFC",
         rdfs:label "perfluorocarbon"
@@ -3698,7 +3555,6 @@ Class: OEO_00000323
 Class: OEO_00000324
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -3712,7 +3568,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000330
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
@@ -3729,7 +3584,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000331
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
@@ -3761,7 +3615,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000332
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solid biomass is a portion of matter consisting of organic, non-fossil material of biological origin which may be used as fuel for heat production or electricity generation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "portion of solid biomass",
         <http://purl.obolibrary.org/obo/IAO_0000118> "solid biomass"@en,
@@ -3787,7 +3640,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000333
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
@@ -3815,7 +3667,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000334
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "block",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
@@ -3862,7 +3713,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000335
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is a power-to-fuel system that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -3885,7 +3735,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00000345
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
@@ -3909,7 +3758,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000348
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -3932,7 +3780,6 @@ Class: OEO_00000350
 Class: OEO_00000356
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "remove origin 
@@ -3959,7 +3806,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00000361
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rooftop photovoltaic power plant is a photovoltaic power plant that is installed on top of the roof of a building."@en,
         rdfs:label "rooftop photovoltaic power plant"
     
@@ -3973,7 +3819,6 @@ Class: OEO_00000361
 Class: OEO_00000374
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Shorten definition and new label:
@@ -3993,7 +3838,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00000376
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "SIB",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
@@ -4008,7 +3852,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000377
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S). This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
@@ -4024,7 +3867,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000384
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
@@ -4048,7 +3890,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620",
 Class: OEO_00000386
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -4066,7 +3907,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000387
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that converts solar energy to solar thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
@@ -4102,7 +3942,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000388
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
@@ -4116,7 +3955,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000389
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -4131,7 +3969,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000391
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
@@ -4153,7 +3990,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00000395
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A state of matter is a quality of a portion of matter that describes the distinct physical form in which the matter exists."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
@@ -4185,7 +4021,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1720",
 Class: OEO_00000396
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
@@ -4219,7 +4054,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000399
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage unit is a grid component that stores energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1338
@@ -4242,7 +4076,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00000401
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         
@@ -4264,7 +4097,6 @@ Class: OEO_00000419
 Class: OEO_00000420
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -4279,7 +4111,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00000425
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "use energy converting component in definition:
 https://github.com/OpenEnergyPlatform/ontology/pull/993
@@ -4307,7 +4138,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000429
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
@@ -4326,7 +4156,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000437
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "VOC",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
@@ -4355,7 +4184,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000439
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "label and definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
@@ -4383,7 +4211,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000440
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -4397,7 +4224,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000441
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
@@ -4430,7 +4256,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000442
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
@@ -4465,7 +4290,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000446
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
@@ -4497,7 +4321,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00000447
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
@@ -4511,7 +4334,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000448
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
@@ -4546,7 +4368,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000449
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -4567,7 +4388,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
 Class: OEO_00010000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen trihydride",
@@ -4595,7 +4415,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4615,7 +4434,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4635,7 +4453,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide",
@@ -4651,7 +4468,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4665,7 +4481,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide",
@@ -4682,7 +4497,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4700,7 +4514,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
@@ -4718,7 +4531,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
@@ -4736,7 +4548,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00010012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
@@ -4756,7 +4567,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
 Class: OEO_00010015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
@@ -4776,7 +4586,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
@@ -4800,7 +4609,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel",
         <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel",
@@ -4829,7 +4637,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00010018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -4854,7 +4661,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
         <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
@@ -4876,7 +4682,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
 Class: OEO_00010020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is a power-to-fuel system that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
@@ -4900,7 +4705,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
@@ -4936,7 +4740,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
@@ -4960,7 +4763,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
 Class: OEO_00010023
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
@@ -4990,7 +4792,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in a traction battery.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "BEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -5015,7 +4816,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -5046,7 +4846,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00010026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A traction battery is a battery that is used in vehicles for propulsion.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
@@ -5059,7 +4858,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -5080,7 +4878,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 Class: OEO_00010028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
@@ -5098,7 +4895,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
 Class: OEO_00010029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -5124,7 +4920,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
 Class: OEO_00010030
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both an electric traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
@@ -5157,7 +4952,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00010031
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that has a current collector to use electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
@@ -5178,7 +4972,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -5209,7 +5002,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010072
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -5222,7 +5014,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010073
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -5235,7 +5026,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010074
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "specific power",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -5250,7 +5040,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010075
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
@@ -5264,7 +5053,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010076
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -5278,7 +5066,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010077
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
@@ -5292,7 +5079,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010078
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GWP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -5314,7 +5100,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010079
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
@@ -5332,7 +5117,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010080
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add two has participant and redefine
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
@@ -5364,7 +5148,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010081
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
@@ -5382,7 +5165,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010084
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
@@ -5398,7 +5180,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
 Class: OEO_00010085
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5417,7 +5198,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010086
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5433,7 +5213,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010087
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
@@ -5449,7 +5228,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010088
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant",
@@ -5467,7 +5245,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
@@ -5486,7 +5263,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010090
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
@@ -5515,7 +5291,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010091
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5529,7 +5304,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010092
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
@@ -5543,7 +5317,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010093
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
@@ -5562,7 +5335,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010094
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
@@ -5576,7 +5348,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
 Class: OEO_00010095
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5589,7 +5360,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010096
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5603,7 +5373,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010097
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5629,7 +5398,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010098
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5659,7 +5427,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010099
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5683,7 +5450,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010100
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5704,7 +5470,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 Class: OEO_00010101
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5718,7 +5483,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010102
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5743,7 +5507,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010103
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5767,7 +5530,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
 Class: OEO_00010104
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5780,7 +5542,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010105
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sea",
@@ -5795,7 +5556,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010106
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5808,7 +5568,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010107
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5821,7 +5580,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010108
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5845,7 +5603,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
 Class: OEO_00010109
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5869,7 +5626,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
 Class: OEO_00010110
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -5893,7 +5649,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
 Class: OEO_00010111
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5908,7 +5663,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010112
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5923,7 +5677,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010113
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
@@ -5938,7 +5691,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010114
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
@@ -5969,7 +5721,6 @@ Class: OEO_00010117
 Class: OEO_00010127
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add alternative term:
@@ -6006,7 +5757,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010137
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "tonne",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
@@ -6021,7 +5771,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
 Class: OEO_00010138
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas. test",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
@@ -6035,7 +5784,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010139
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Direct air capture (DAC) is carbon dioxide capture from air.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
@@ -6050,7 +5798,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010140
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
@@ -6065,7 +5812,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010141
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS",
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration",
@@ -6085,7 +5831,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010144
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6102,7 +5847,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010145
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6119,7 +5863,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010146
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6136,7 +5879,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010147
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6153,7 +5895,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010148
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6170,7 +5911,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010149
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6187,7 +5927,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010150
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6204,7 +5943,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010151
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6221,7 +5959,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010153
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6238,7 +5975,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010154
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6255,7 +5991,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010155
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6272,7 +6007,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010156
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
@@ -6289,7 +6023,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010157
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
@@ -6310,7 +6043,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00010210
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
@@ -6338,7 +6070,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010211
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
@@ -6366,7 +6097,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010214
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
@@ -6380,7 +6110,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
 Class: OEO_00010215
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
@@ -6402,7 +6131,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
 Class: OEO_00010216
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
@@ -6431,7 +6159,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010217
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
@@ -6460,7 +6187,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010218
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
@@ -6475,7 +6201,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010219
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
@@ -6498,7 +6223,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010220
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
@@ -6515,7 +6239,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010221
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
@@ -6532,7 +6255,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
 Class: OEO_00010222
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
@@ -6551,7 +6273,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010223
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
@@ -6573,7 +6294,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010224
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -6590,7 +6310,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00010225
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
@@ -6612,7 +6331,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010226
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
@@ -6912,7 +6630,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
 Class: OEO_00010256
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
@@ -6929,7 +6646,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00010257
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
@@ -6949,7 +6665,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
 Class: OEO_00010258
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Bioenergy is chemical energy that is stored in biofuels.",
         <http://purl.obolibrary.org/obo/IAO_0000117> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1168
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
@@ -6966,7 +6681,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
 Class: OEO_00010259
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
@@ -6979,7 +6693,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
 Class: OEO_00010263
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
@@ -7000,7 +6713,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010264
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
@@ -7018,7 +6730,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010265
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
@@ -7036,7 +6747,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010266
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
@@ -7054,7 +6764,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010267
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reforming process is a chemical reaction that converts hydrocarbons and steam to syngas. As it converts chemical energy and thermal energy to a different type of chemical energy (and waste heat), it is also an energy transformation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
@@ -8728,7 +8437,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
 Class: OEO_00020001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -8757,7 +8465,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
@@ -8824,7 +8531,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
@@ -8838,7 +8544,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385",
@@ -8852,7 +8557,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/385",
 Class: OEO_00020006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
@@ -8872,7 +8576,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
@@ -8890,7 +8593,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
@@ -8908,7 +8610,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
@@ -8926,7 +8627,6 @@ Class: OEO_00020011
 Class: OEO_00020037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is an energy transfer by emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
@@ -8948,7 +8648,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the mereological sum of direct solar radiation and diffuse solar radiation",
         <http://purl.obolibrary.org/obo/IAO_0000118> "global radiation",
@@ -8971,7 +8670,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020039
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
@@ -8996,7 +8694,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
@@ -9013,7 +8710,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020043
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
@@ -9033,7 +8729,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00020045
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         
@@ -9050,7 +8745,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020046
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
@@ -9075,7 +8769,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00020047
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
@@ -9097,7 +8790,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020048
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
@@ -9119,7 +8811,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020050
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
@@ -9138,7 +8829,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020053
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
@@ -9152,7 +8842,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
 Class: OEO_00020054
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
@@ -9175,7 +8864,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00020058
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
@@ -9191,7 +8879,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
 Class: OEO_00020059
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
@@ -9209,7 +8896,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00020073
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
@@ -9226,7 +8912,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020074
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
@@ -9239,7 +8924,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020085
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
@@ -9266,7 +8950,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020086
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -9279,7 +8962,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020087
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rainwater, melted snow and ice).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -9294,7 +8976,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020088
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
@@ -9309,7 +8990,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020102
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
@@ -9336,7 +9016,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
 Class: OEO_00020103
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
@@ -9350,7 +9029,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
 Class: OEO_00020104
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
@@ -9371,7 +9049,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020105
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -9387,7 +9064,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020106
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
@@ -9403,7 +9079,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020107
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
@@ -9420,7 +9095,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020136
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land use",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
@@ -9441,7 +9115,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020137
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -9454,7 +9127,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020139
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to construct an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -9467,7 +9139,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020140
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930
@@ -9483,7 +9154,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020141
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
@@ -9497,7 +9167,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020142
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
         <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
         <http://purl.obolibrary.org/obo/IAO_0000118> "square km",
@@ -9515,7 +9184,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020143
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
@@ -9533,7 +9201,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020144
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
@@ -9554,7 +9221,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00020147
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
@@ -9579,7 +9245,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00020148
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of a material entity that contains non-renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
@@ -9592,7 +9257,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
 Class: OEO_00020149
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
@@ -9617,7 +9281,6 @@ Class: OEO_00020166
 Class: OEO_00020175
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
@@ -9634,7 +9297,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020176
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
@@ -9651,7 +9313,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020177
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
@@ -9668,7 +9329,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020178
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
@@ -9684,7 +9344,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020196
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
@@ -9704,7 +9363,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1196",
 Class: OEO_00020197
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
@@ -9718,7 +9376,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020198
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
@@ -9732,7 +9389,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020199
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
@@ -9749,7 +9405,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020200
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
@@ -9776,7 +9431,6 @@ Class: OEO_00020202
 Class: OEO_00020204
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
@@ -9792,7 +9446,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020205
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
@@ -9809,7 +9462,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020206
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
@@ -9826,7 +9478,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020207
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -9849,7 +9500,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020208
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -9872,7 +9522,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020210
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sirop",
         <http://purl.obolibrary.org/obo/IAO_0000118> "syrup",
@@ -9939,7 +9588,6 @@ A climate system is a system that has five interacting components: the atmospher
 Class: OEO_00020254
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy share is a process attribute that indicates the fraction of electrical energy related to the total energy of an energy generation or consumption process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "degree of electrification",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
@@ -9982,7 +9630,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
 Class: OEO_00020264
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
@@ -10320,7 +9967,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00030000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
@@ -10343,7 +9989,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -10364,7 +10009,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192",
 Class: OEO_00030002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
@@ -10402,7 +10046,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
@@ -10433,7 +10076,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -10472,7 +10114,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00030005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
@@ -10500,7 +10141,6 @@ Class: OEO_00030022
 Class: OEO_00030024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
@@ -10525,7 +10165,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
@@ -10545,7 +10184,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
@@ -10572,7 +10210,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -10588,7 +10225,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -10607,7 +10243,6 @@ Class: OEO_00030035
 Class: OEO_00050000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial process is a process that has output object or object aggregates that are economic goods. An industrial process consists of several subprocesses. Examples of subprocesses that can be involved in an industrial process are energy transformations, mechanical operations and chemical reactions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
@@ -10622,7 +10257,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589",
 Class: OEO_00050001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel-powered electricity generation process is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fuel-powered electricity generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
@@ -10654,7 +10288,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
 Class: OEO_00050002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10668,7 +10301,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10682,7 +10314,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10696,7 +10327,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10710,7 +10340,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10724,7 +10353,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10738,7 +10366,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10752,7 +10379,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10766,7 +10392,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
@@ -10780,7 +10405,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add eurostat alternative term:
@@ -10799,7 +10423,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is an energy consumption value accounting for the energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
@@ -10816,7 +10439,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340",
 Class: OEO_00050017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
@@ -10858,7 +10480,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
 Class: OEO_00050018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
@@ -10893,7 +10514,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
 Class: OEO_00050019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
@@ -10915,7 +10535,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00050020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
@@ -10940,7 +10559,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00090000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
 Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
@@ -10954,7 +10572,6 @@ Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
 Class: OEO_00110000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -10969,7 +10586,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -10988,7 +10604,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
 Class: OEO_00110002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -11003,7 +10618,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
@@ -11017,7 +10631,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -11036,7 +10649,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
 Class: OEO_00110005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
@@ -11057,7 +10669,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509
@@ -11076,7 +10687,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00140001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
@@ -11090,7 +10700,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
 Class: OEO_00140003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -11122,7 +10731,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00140004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -11139,7 +10747,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -11161,7 +10768,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -11182,7 +10788,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
@@ -11203,7 +10808,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
@@ -11229,7 +10833,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
@@ -11243,7 +10846,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -11256,7 +10858,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -11269,7 +10870,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -11282,7 +10882,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
@@ -11295,7 +10894,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140039
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
@@ -11312,7 +10910,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
@@ -11336,7 +10933,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140049
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
@@ -11358,7 +10954,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140050
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
@@ -11384,7 +10979,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140051
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
@@ -11399,7 +10993,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140052
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
@@ -11414,7 +11007,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140056
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
@@ -11431,7 +11023,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140057
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11444,7 +11035,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140058
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11457,7 +11047,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140059
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11470,7 +11059,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140060
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11483,7 +11071,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140061
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11496,7 +11083,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140062
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
@@ -11513,7 +11099,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140063
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11526,7 +11111,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140064
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11539,7 +11123,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140065
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11552,7 +11135,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140066
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11565,7 +11147,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140067
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
@@ -11578,7 +11159,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140075
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -11599,7 +11179,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140076
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -11620,7 +11199,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140077
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
@@ -11634,7 +11212,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140078
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
@@ -11651,7 +11228,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140079
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
@@ -11678,7 +11254,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140080
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
@@ -11695,7 +11270,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140081
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a process attribute that quantifies the output of an emission process. It can be calculated using the emission factor of that emission process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -11721,7 +11295,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140082
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies the output of a greenhouse gas emission process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
@@ -11735,7 +11308,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
 Class: OEO_00140083
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -11749,7 +11321,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651",
 Class: OEO_00140091
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
@@ -11765,7 +11336,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140092
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
@@ -11781,7 +11351,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140101
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer of thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
@@ -11813,7 +11382,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140102
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an energy converting component that is used for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
@@ -11846,7 +11414,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00140104
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -11860,7 +11427,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140105
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
@@ -11875,7 +11441,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140106
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
@@ -11894,7 +11459,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00140116
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
@@ -11911,7 +11475,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
 Class: OEO_00140126
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availability is a quality that describes the amount of time a power plant is planned to be operational per year.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
@@ -11930,7 +11493,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00140127
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fraction value is a quantity value that has a fraction as it's unit.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "share",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
@@ -11944,7 +11506,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140128
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -11958,7 +11519,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140129
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availability is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
@@ -11977,7 +11537,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00140133
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "RE share",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share",
@@ -11996,7 +11555,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
 Class: OEO_00140134
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
@@ -12010,7 +11568,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140135
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
@@ -12024,7 +11581,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140144
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -12038,7 +11594,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140146
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796
@@ -12055,7 +11610,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140159
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
@@ -12078,7 +11632,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140160
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
@@ -12109,7 +11662,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00140162
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
@@ -12127,7 +11679,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
 Class: OEO_00160001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202
@@ -12147,7 +11698,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00160002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -12160,7 +11710,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -12173,7 +11722,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
@@ -12186,7 +11734,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00230000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
@@ -12204,7 +11751,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00230001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
@@ -12234,7 +11780,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
@@ -12258,7 +11803,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
@@ -12284,7 +11828,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
@@ -12301,7 +11844,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00230021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
@@ -12331,7 +11873,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
 Class: OEO_00240000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
@@ -12344,7 +11885,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
 Class: OEO_00240003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -12370,7 +11910,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generation (CHP) process is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
@@ -12396,7 +11935,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
 Class: OEO_00240010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is an energy transformation unit that has both the function to produce thermal energy and the function to produce electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
@@ -12434,7 +11972,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00240011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is an energy transformation unit that consists of combined heat and power generating units, a grid component feeding electric energy into an electricity grid, and a grid component feeding thermal energy into a heating grid.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
@@ -12456,7 +11993,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00240012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
@@ -12471,7 +12007,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
 Class: OEO_00240013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
@@ -12486,7 +12021,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
 Class: OEO_00240014
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
@@ -12519,7 +12053,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
@@ -12534,7 +12067,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00240016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor",
@@ -12557,7 +12089,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
 Class: OEO_00240018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
@@ -12572,7 +12103,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
 Class: OEO_00240019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
@@ -12592,7 +12122,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00240022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A protected area is a two-dimensional spatial region recognised, dedicated and managed, through legal or other effective means, to achieve the long term conservation of nature with associated ecosystem services and cultural values."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1052
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1078
@@ -12608,7 +12137,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00240024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
@@ -12626,7 +12154,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial material is a portion of matter that is the physical output of an industrial process and that has a good role."@en,
         rdfs:label "industrial material"
     
@@ -12637,7 +12164,6 @@ Class: OEO_00240026
 Class: OEO_00240027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12656,7 +12182,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12675,7 +12200,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12694,7 +12218,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240030
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12711,7 +12234,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240031
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
@@ -12730,7 +12252,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12747,7 +12268,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12766,7 +12286,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
@@ -12784,7 +12303,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
@@ -12800,7 +12318,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00260001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
@@ -12813,7 +12330,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
@@ -12827,7 +12343,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126
@@ -12887,7 +12402,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00290000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
@@ -12904,7 +12418,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00290001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "add slope
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
@@ -12933,7 +12446,6 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
 Class: OEO_00310000
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A datacenter is an artificial object that houses computer systems and associated components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
@@ -12947,7 +12459,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sewage plant is an artificial object that removes contaminants from wastewater to produce an effluent that is suitable for discharge to the surrounding environment or an intended reuse application."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
@@ -12962,7 +12473,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310004
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste thermal energy is waste thermal energy that is energy output of some industrial process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
@@ -12976,7 +12486,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recovered heat is a thermal energy that is physical output of an energy transformation process and that is recovered and would otherwise be emitted in the environment as waste thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
@@ -12989,7 +12498,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aerothermal energy is a natural ambient thermal energy that is stored in the air of a natural environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
@@ -13002,7 +12510,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generating unit is an energy transformation unit that has the function to produce thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13021,7 +12528,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rotary heat exchanger is a heat exchanger that uses a wheel for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
@@ -13034,7 +12540,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310010
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plate heat exchanger is a heat exchanger that uses a plate for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
@@ -13047,7 +12552,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat plant is an energy transformation unit consisting of heat generating units and a grid component that feeds thermal energy into a heating grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13068,7 +12572,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat transfer unit is a heat generating unit that contains a heat exchanger and not a heater.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13083,7 +12586,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
@@ -13097,7 +12599,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310014
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion-based heater is a heater that increases the thermal energy using combustion.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13112,7 +12613,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical heater is a heater that increases the thermal energy using electric energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13126,7 +12626,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal heat unit is a heat transfer unit that uses geothermal energy as source.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13141,7 +12640,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal heat plant is a heat plant that has geothermal heat units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13156,7 +12654,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tube collector is a solar thermal collector that consists of tubes.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
@@ -13169,9 +12666,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
-        OEO_00040001 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flat-plate collector is a solar thermal collector that consists of flat-plates.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
@@ -13184,7 +12678,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined cycle electricity generation process is a fuel-powered electricity generation process in which a gas turbine process is followed by an steam-electric process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "combined cycle electricity generation",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
@@ -13202,7 +12695,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
 Class: OEO_00310027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine process is an energy transformation that converts chemical energy into rotational energy using a continous internal combustion process. A gas turbine is participating in a gas turbine process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
@@ -13220,7 +12712,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
 Class: OEO_00310028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam power unit is a power generating unit that only has a steam turbine as turbine.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
@@ -13238,7 +12729,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
 Class: OEO_00310032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermo-chemical heat storage object (TCS) is a thermal energy storage object that stores thermal energy through reversible exotherm/endotherm chemical reaction with thermo-chemical materials (TCM).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "TCS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
@@ -13256,7 +12746,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical heat storage object is a thermo-chemical heat storage object that stores thermal energy by using the chemical binding energy in an endotherm reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13269,7 +12758,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sorption heat storage object is a thermo-chemical heat storage object that stores thermal energy by using desorption.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13283,7 +12771,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Adsorption is a process that leads to an accumulation of a substance within a phase or at an interface between two phases.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13300,7 +12787,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Desorption is a process that leads to a detaching of a substance that was accumulated within a phase or at an interface between two phases (for example by adsorption).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13317,7 +12803,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible heat storage object is a thermal energy storage object that stores thermal energy through temperature changes in some medium.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13334,7 +12819,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible fluid heat storage object is a sensible heat storage that uses fluids (like water, oil, …) to store thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13348,7 +12832,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310039
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible solid heat storage object is a sensible heat storage that uses solid materials (like bulk goods, powder, …) to store thermal energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13364,7 +12847,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A phase transition is a transformation of a medium from a solid, liquid, or gas state to a different state.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13379,7 +12861,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310041
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Evaporation is a phase transition from a liquid medium to their gaseous state.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "evaporating",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
@@ -13399,7 +12880,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310042
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Melting is a phase transition from a solid medium to their liquid state.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13418,7 +12898,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310043
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent heat storage object (LHS) is a thermal energy storage object that stores thermal energy through phase transitions in phase-change materials (PCM).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LHS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
@@ -13436,7 +12915,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310044
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent solid-fluid heat storage object is a latent heat storage object that stores thermal energy by converting solid materials to their liquid equivalent i.e. melting the material.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13450,7 +12928,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310045
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent fluid-gaseous heat storage object is a latent heat storage object that stores thermal energy by converting liquid materials to their gaseous equivalent i.e. evaporating the material.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
@@ -13464,7 +12941,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310047
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         rdfs:comment "A solar heat plant is a heat plant that has solar heat units as parts.",
@@ -13479,7 +12955,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310048
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar heat unit is a heat generating unit that has a solar collector.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
@@ -13760,7 +13235,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is an object aggregate of transport network components that enables the transport of people and/or goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13775,7 +13249,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road network is a transport network that enables transport on roads."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13789,7 +13262,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rail network is a transport network that enables transport on rails."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13804,7 +13276,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waterway network is a transport network that enables transport on water."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13818,7 +13289,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320020
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aviation network is a transport network that enables air transport."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13832,7 +13302,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
@@ -13853,7 +13322,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road is a transport network component with an artificial surface that allows transport for road vehicles."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13867,7 +13335,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320023
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bridge is a transport network component that spans a physical obstacle without blocking the way underneath."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13881,7 +13348,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320024
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tunnel is a transport network component that is built through a certain environment (e.g. a mountain or water) and allows to pass through that environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13895,7 +13361,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320025
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by trains."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13909,7 +13374,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320026
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A canal is a transport network component that is an artificially created waterway."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13922,7 +13386,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320027
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport hub is a transport network component that allows the exchange of people and/or goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13935,7 +13398,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320028
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A train station is a transport hub for trains."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13949,7 +13411,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320029
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight train station is a train station for the exchange of goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13963,7 +13424,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320030
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger train station is a train station for the exchange of passengers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13977,7 +13437,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320031
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bus station is a transport hub for busses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -13991,7 +13450,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320032
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A port is a transport hub for ships."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -14005,7 +13463,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320033
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight port is a port for the exchange of goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -14019,7 +13476,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger port is a port for the exchange of passengers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -14033,7 +13489,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An airport is a transport hub for airplanes."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
@@ -14047,7 +13502,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
@@ -14062,7 +13516,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
@@ -14077,7 +13530,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320038
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the freight transport of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
@@ -14091,7 +13543,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320039
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport of combustion fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
@@ -14107,7 +13558,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320040
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle charging station is an electricity grid component that transfers electrical energy into the traction battery of a battery electric vehicle."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1307
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
@@ -14140,7 +13590,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320042
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel supply system is an energy system covering the distribution of fuels.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1300
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1316",
@@ -14722,7 +14171,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00360001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recycling is a material transformation that regains materials and/or energy from an artificial product or waste."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "class added: 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1376
@@ -14889,7 +14337,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Individual: OEO_00000326
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a plasma. A portion of matter is in plasmatic state if and only if it has has no definite shape and no definite volume and is electrically conductive.",
         rdfs:label "plasmatic"
     
@@ -14900,7 +14347,6 @@ Individual: OEO_00000326
 Individual: OEO_00000390
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-physical",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         rdfs:label "solid"
     

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -50,9 +50,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: OEO_00010037
 
     
-AnnotationProperty: OEO_00040001
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -337,7 +334,6 @@ Class: OEO_00000107
 Class: OEO_00000128
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy demand sector is a sector that covers energy consumers."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1014
@@ -358,7 +354,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000145
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity sector is a transformation sector that covers electricity generation and transport of electrical energy to consumers of electrical energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484
@@ -375,7 +370,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000158
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation sector is a sector that covers energy production, energy transformation from primary to secondary energy and transport of energy to the demand sector.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy industry sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy sector",
@@ -394,7 +388,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000213
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating and cooling sector is a sector that covers heating and cooling activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H&C sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -412,7 +405,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000214
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A household sector is a sector that covers households."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "private household sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -430,7 +422,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000227
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industry sector is a sector that covers industrial activities with other main purposes of energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484
@@ -453,7 +444,6 @@ Class: OEO_00000350
 Class: OEO_00000367
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector is generically dependent continuant that is a subdivision of a system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/477
@@ -474,7 +464,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000368
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector division is a specific way to subdivide a system."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 
@@ -504,7 +493,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000405
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commercial sector is a sector that covers non-industrial commercial activities."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "TCS sector",
         <http://purl.obolibrary.org/obo/IAO_0000118> "service sector",
@@ -524,7 +512,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00000422
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport sector is a sector that covers transport of people and/or goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "traffic sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -542,7 +529,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00010034
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A building sector is a sector that covers buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484
@@ -559,7 +545,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00010035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A agriculture, forestry and land use (AFOLU) sector is a sector that covers activities and natural processes from agriculture, forestry, land use and land use change.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AFOLU sector",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
@@ -577,7 +562,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00010036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste and wastewater sector is a sector that covers activities related the collection and treatment of waste and wastewater.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/30
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/484
@@ -594,7 +578,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00010055
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The common reporting format (CRF) is a sector division used for compiling national inventory reports on greenhouse gas emissions and providing emission relevant data in so called CRF tables.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NIR sector division",
@@ -624,7 +607,6 @@ Class: OEO_00010117
 Class: OEO_00010130
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An EU emission sector division is used in the EU climate policy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -645,7 +627,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Class: OEO_00010227
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A memo item is an information content entity about a sector that describes that the sector is excluded from some kind of total and only reported to provide further information (memo).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965
@@ -817,7 +798,6 @@ Class: OEO_00140012
 Individual: OEO_00000160
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The concept of \"energy balance\" is an accounting framework for the compilation and understanding of data on all energy products entering, exiting and being used in a country. The energy balance is the most complete statistical accounting of energy products and their flow in the economy. Columns of the energy balance represent energy products (fuels). Rows represent energy flows.
 
 The energy balance expresses all forms of energy in a common accounting unit. The balance shows the relationships between supply, inputs to the energy transformation processes and their outputs as well as the actual energy consumption by different sectors of end-use.",
@@ -838,7 +818,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000193
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
@@ -883,7 +862,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000242
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 2006) is a version of the common reporting format that was used for national greenhouse gas inventories since the year 2015. It implements the 2006 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
@@ -903,7 +881,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000243
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "CRF sectors (IPCC 1996) is a version of the common reporting format that was used for national greenhouse gas inventories until the year 2014. It implements the Revised 1996 IPCC Guidelines for National Greenhouse Gas Inventories (with some deviations).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
@@ -920,14 +897,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000291
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Statistical classification of economic activities in the European Community, abbreviated as NACE, is the classification of economic activities in the European Union (EU); the term NACE is derived from the French Nomenclature statistique des activités économiques dans la Communauté européenne. Various NACE versions have been developed since 1970.
 
 NACE is a four-digit classification providing the framework for collecting and presenting a large range of statistical data according to economic activity in the fields of economic statistics (e.g. production, employment and national accounts) and in other statistical domains developed within the European statistical system (ESS).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Statistical_classification_of_economic_activities_in_the_European_Community_(NACE)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
-		rdfs:label "nace_ sectors"
+        rdfs:label "nace_ sectors"
     
     Types: 
         OEO_00000368
@@ -936,7 +912,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000355
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Renewable Energy Directive sector division is a sector division used in the Renewable Energy Directive of the European Union.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The Renewable energy Directive has been revised, but this should have had no impacts on the sectoral definitions. Factsheet on revision: https://ec.europa.eu/energy/sites/ener/files/documents/directive_renewable_factsheet.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32009L0028",
@@ -961,7 +936,6 @@ Individual: OEO_00010038
 
     Annotations: 
         OEO_00010037 "CRF 1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) energy is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All GHG emissions arising from combustion and fugitive releases of fuels. Emissions from the non-energy uses of fuels are generally not included here, but reported under Industrial Processes and Product Use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -989,7 +963,6 @@ Individual: OEO_00010039
 
     Annotations: 
         OEO_00010037 "CRF 1.A",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the intentional oxidation of materials within an apparatus that is designed to raise heat and provide it either as heat or as mechanical work to a process or for use away from the apparatus.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1013,7 +986,6 @@ Individual: OEO_00010040
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industry' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises emissions from fuels combusted by the fuel extraction or energy-producing industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1044,7 +1016,6 @@ Individual: OEO_00010041
 
     Annotations: 
         OEO_00010037 "CRF 1.A.2",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacturing industries and construction' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion of fuels in industry. Also includes combustion for the generation of electricity and heat for own use in these industries.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1068,7 +1039,6 @@ Individual: OEO_00010042
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from the combustion and evaporation of fuel for all transport activity (excluding military transport), regardless of the sector, specified by sub-categories below. Emissions from fuel sold to any air or marine vessel engaged in international transport (1 A 3 a i and 1 A 3 d i) should as far as possible be excluded from the totals and subtotals in this category and should be reported separately.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1095,7 +1065,6 @@ Individual: OEO_00010043
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion - other sectors' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from combustion activities as described below, including combustion for the generation of electricity and heat for own use in these sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1121,7 +1090,6 @@ Individual: OEO_00010044
 
     Annotations: 
         OEO_00010037 "CRF 1.A.5",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fuel combustion' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All remaining emissions from fuel combustion that are not specified elsewhere. Include emissions from fuel delivered to the military in the country and delivered to the military of other countries that are not engaged in multilateral operations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1145,7 +1113,6 @@ Individual: OEO_00010046
 
     Annotations: 
         OEO_00010037 "CRF 2",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'energy industrial processes and product use' (IPPU) is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 It covers greenhouse gas emissions occurring from industrial processes, from the use of greenhouse gases in products, and from non-energy uses of fossil fuel carbon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "IPPU",
@@ -1181,7 +1148,6 @@ Individual: OEO_00010047
 
     Annotations: 
         OEO_00010037 "CRF 3",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -1219,7 +1185,6 @@ Individual: OEO_00010048
 
     Annotations: 
         OEO_00010037 "CRF 4",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry' (LULUCF) is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LULUCF",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
@@ -1257,7 +1222,6 @@ Individual: OEO_00010049
 
     Annotations: 
         OEO_00010037 "CRF 5",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2), methane (CH4) and nitrous oxide (N2O) emissions from following categories: Solid waste disposal, Biological treatment of solid waste,
 Incineration and open burning of waste, Wastewater treatment and discharge.",
@@ -1293,7 +1257,6 @@ Individual: OEO_00010050
 
     Annotations: 
         OEO_00010037 "CRF 6",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
@@ -1317,7 +1280,6 @@ Individual: OEO_00010052
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.a",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'commercial and institutional' is a commercial sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in commercial and institutional buildings.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 1.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1341,7 +1303,6 @@ Individual: OEO_00010053
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.b",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'residential' is a household sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All emissions from fuel combustion in households.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1365,7 +1326,6 @@ Individual: OEO_00010054
 
     Annotations: 
         OEO_00010037 "CRF 1.A.4.c",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture, forestry and fishing' is an energy demand sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuel combustion in agriculture, forestry, fishing and fishing industries such as fish farms.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1388,7 +1348,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010056
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector division is a CRF-based sector division defined in annex 1 of the Bundes-Klimaschutzgesetz (KSG).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/580
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/595
@@ -1410,7 +1369,6 @@ Individual: OEO_00010057
 
     Annotations: 
         OEO_00010037 "CRF 1.B",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'fugitive emissions from fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of solid fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1436,7 +1394,6 @@ Individual: OEO_00010058
 
     Annotations: 
         OEO_00010037 "CRF 1.C",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide (CO2) capture and storage (CCS) involves the capture of CO2 from anthropogenic sources, its transport to a storage location and its long-term isolation from the atmosphere. Emissions associated with CO2 transport, injection and storage are covered under category 1C. Emissions (and reductions) associated with CO2 capture should be reported under the IPCC Sector in which capture takes place (e.g. Fuel Combustion or Industrial Activities).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1463,7 +1420,6 @@ Individual: OEO_00010059
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.a",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from civil domestic passenger and freight traffic that departs and arrives in the same country (commercial, private, agriculture, etc.), including take-offs and landings for these flight stages. Note that this may include journeys of considerable length between two airports in a country (e.g. San Francisco to Honolulu). Exclude military, which should be reported under 1 A 5 b.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1490,7 +1446,6 @@ Individual: OEO_00010060
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.b",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'road transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion and evaporative emissions arising from fuel use in road vehicles, including the use of agricultural vehicles on paved roads.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1514,7 +1469,6 @@ Individual: OEO_00010061
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.c",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'railways' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from railway transport for both freight and passenger traffic routes.",
@@ -1538,7 +1492,6 @@ Individual: OEO_00010062
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.d",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'domestic navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used by vessels of all flags that depart and arrive in the same country (exclude fishing, which should be reported under 1 A 4 c iii, and military, which should be reported under 1 A 5 b). Note that this may include journeys of considerable length between two ports in a country (e.g. San Francisco to Honolulu).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1565,7 +1518,6 @@ Individual: OEO_00010063
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.e",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other transportation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from all remaining transport activities including pipeline transportation, ground activities in airports and harbours, and off-road activities not otherwise reported under 1 A 4 c Agriculture or 1 A 2. Manufacturing Industries and Construction. Military transport should be reported under 1 A 5.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1589,7 +1541,6 @@ Individual: OEO_00010064
 
     Annotations: 
         OEO_00010037 "CRF 1.A.3.e.i",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'pipeline transport' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion related emissions from the operation of pump stations and maintenance of pipelines. Transport via pipelines includes transport of gases  liquids, slurry and other commodities via pipelines. Distribution of natural or manufactured gas, water or steam from the distributor to final users is excluded and should be reported in 1 A 1 c ii or 1 A 4 a.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1616,7 +1567,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010065
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector energy industry is an energy transformation sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): energy industry (CRF 1.A.1.a)
 - CRF sector (IPCC 2006): other transportation (CRF 1.A.3.e)
@@ -1643,7 +1593,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010066
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector industry is an industry sector defined by the KSG sector division. It is an aggregate of the following three sectors:
 - CRF sector (IPCC 2006): manufacturing industries and construction (CRF 1.A.2)
 - CRF sector (IPCC 2006): CO2 transport and storage (CRF 1.C)
@@ -1670,7 +1619,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010067
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector buildings is a building sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): commercial and institutional (CRF 1.A.4.a)
 - CRF sector (IPCC 2006): residential (CRF 1.A.4.b)
@@ -1701,7 +1649,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010068
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector transport is a transport sector defined by the KSG sector division. It is an aggregate of the following four sectors:
 - CRF sector (IPCC 2006): domestic aviation (CRF 1.A.3.a)
 - CRF sector (IPCC 2006): road transportation (CRF 1.A.3.b)
@@ -1730,7 +1677,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010069
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector agriculture is an agriculture, forestry and land use sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): agriculture, forestry and fishing (CRF 1.A.4.c)
 - CRF sector (IPCC 2006): agriculture (CRF 3)",
@@ -1755,7 +1701,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010070
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector waste management and other is a sector defined by the KSG sector division. It is an aggregate of the following two sectors:
 - CRF sector (IPCC 2006): waste (CRF 5)
 - CRF sector (IPCC 2006): other (CRF 6)",
@@ -1780,7 +1725,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010071
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The KSG sector land use, land-use change and forestry is an agriculture, forestry and land use sector defined by the KSG sector division.
 It is equivalent to the CRF sector (IPCC 2006): land use, land-use change and forestry (CRF 4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Bundes-Klimaschutzgesetz (KSG), Anlage 1 (zu den §§ 4 und 5) https://www.gesetze-im-internet.de/ksg/anlage_1.html",
@@ -1805,7 +1749,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010131
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS is a sector defined by an EU emission sector division that covers greenhouse gas emissions that are regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1827,7 +1770,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010132
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by an EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1852,7 +1794,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010133
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS aviation is a transport sector defined by an EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1877,7 +1818,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010134
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector effort sharing is a sector defined by the EU emission sector division that covers greenhouse gas emissions regulated by the Effort Sharing Decision and the Effort Sharing Regulation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1899,7 +1839,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010135
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by an EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1925,7 +1864,6 @@ Individual: OEO_00010158
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.a",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'public electricity and heat production' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Sum of emissions from main activity producers of electricity generation, combined heat and power generation, and heat plants.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1949,7 +1887,6 @@ Individual: OEO_00010159
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.b",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'petroleum refining' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 All combustion activities supporting the refining of petroleum products including on-site combustion for the generation of electricity and heat for own use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -1977,7 +1914,6 @@ Individual: OEO_00010160
 
     Annotations: 
         OEO_00010037 "CRF 1.A.1.c",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manufacture of solid fuels and other energy industries' is an energy transformation sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Combustion emissions from fuel use during the manufacture of secondary and tertiary products from solid fuels including production of charcoal.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 2.2, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2001,7 +1937,6 @@ Individual: OEO_00010161
 
     Annotations: 
         OEO_00010037 "CRF 1.B.1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid fuels' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Includes all intentional and unintentional emissions from the extraction, processing, storage and transport of fuel to the point of final use.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2025,7 +1960,6 @@ Individual: OEO_00010162
 
     Annotations: 
         OEO_00010037 "CRF 1.B.2",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'oil and natural gas' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Comprises fugitive emissions from all oil and natural gas activities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2048,7 +1982,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010163
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GovReg sector division is a sector division defined in Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XXV, Table 1a of Commission Implementing Regulation (EU) 2020/1208: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32020R1208&from=EN#d1e32-98-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -2078,7 +2011,6 @@ Individual: OEO_00010164
 
     Annotations: 
         OEO_00010037 "CRF 2.A",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'mineral industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related carbon dioxide (CO2) emissions resulting from the use of carbonate raw materials in the production and use of a variety of mineral industry products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 2.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2102,7 +2034,6 @@ Individual: OEO_00010165
 
     Annotations: 
         OEO_00010037 "CRF 2.A.1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cement production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Process-related emissions from the production of various types of cement (ISIC: D2694).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2126,7 +2057,6 @@ Individual: OEO_00010166
 
     Annotations: 
         OEO_00010037 "CRF 2.B",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'chemical industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of various inorganic and organic chemicals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2150,7 +2080,6 @@ Individual: OEO_00010167
 
     Annotations: 
         OEO_00010037 "CRF 2.C",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'metal industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Greenhouse gas emissions that result from the production of metals.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 4.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2174,7 +2103,6 @@ Individual: OEO_00010168
 
     Annotations: 
         OEO_00010037 "CRF 2.C.1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'iron and steel production' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Carbon dioxide is the predominant gas emitted from the production of iron and steel. The sources of the carbon dioxide emissions include that from carbon-containing reducing agents such as coke and pulverized coal, and, from minerals such as limestone and dolomite added.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2202,7 +2130,6 @@ Individual: OEO_00010169
 
     Annotations: 
         OEO_00010037 "CRF 2.D",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'non-energy products from fuels and solvent use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 The use of oil products and coal-derived oils primarily intended for purposes other than combustion",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2226,7 +2153,6 @@ Individual: OEO_00010170
 
     Annotations: 
         OEO_00010037 "CRF 2.E",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'electronics industry' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Several advanced electronics manufacturing processes utilise fluorinated compounds (FCs) for plasma etching intricate patterns, cleaning reactor chambers, and temperature control. The specific electronic industry sectors include semiconductor, thin-film-transistor flat panel display (TFT-FPD), and photovoltaic (PV) manufacturing (collectively termed ‘electronics industry’).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 6.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2250,7 +2176,6 @@ Individual: OEO_00010171
 
     Annotations: 
         OEO_00010037 "CRF 2.F",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'product uses as substitutes for ozone depleting substances' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Hydrofluorocarbons (HFCs) and, to a very limited extent, perfluorocarbons (PFCs), are serving as alternatives to ozone depleting substances (ODS) being phased out under the Montreal Protocol.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 7.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2274,12 +2199,11 @@ Individual: OEO_00010172
 
     Annotations: 
         OEO_00010037 "CRF 2.G",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other product manufacture and use' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions of sulphur hexafluoride (SF6) and perfluorocarbons
 (PFCs) from the manufacture and use of electrical equipment and a number of other products. It also includes emissions of nitrous oxide (N2O) from several products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 3, Chapter 8.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
-		<http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector: issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector: issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "CRF sector (IPCC 2006): other product manufacture and use"@en
     
@@ -2295,7 +2219,6 @@ Individual: OEO_00010173
 
     Annotations: 
         OEO_00010037 "CRF 2.H",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'industrial processes and product use - other' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2317,7 +2240,6 @@ Individual: OEO_00010174
 
     Annotations: 
         OEO_00010037 "CRF 5.A",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'solid waste disposal' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic microbial decomposition of organic matter in solid waste disposal sites.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2341,7 +2263,6 @@ Individual: OEO_00010175
 
     Annotations: 
         OEO_00010037 "CRF 5.B",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'biological treatment of solid waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Solid waste composting and other biological treatment. Emissions from biogas facilities (anaerobic digestion) with energy production are reported in the Energy Sector (1A4).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2365,7 +2286,6 @@ Individual: OEO_00010176
 
     Annotations: 
         OEO_00010037 "CRF 5.C",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'incineration and open burning of waste' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Incineration of waste and open burning waste, not including waste-to-energy facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2389,7 +2309,6 @@ Individual: OEO_00010177
 
     Annotations: 
         OEO_00010037 "CRF 5.D",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste water treatment and discharge' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane is produced from anaerobic decomposition of organic matter by bacteria in sewage facilities and from food processing and other industrial facilities during wastewater treatment. N2O is also produced by bacteria
 (denitrification and nitrification) in wastewater treatment and discharge.",
@@ -2414,7 +2333,6 @@ Individual: OEO_00010178
 
     Annotations: 
         OEO_00010037 "CRF 5.E",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'waste - other' is a waste and wastewater sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -2437,7 +2355,6 @@ Individual: OEO_00010179
 
     Annotations: 
         OEO_00010037 "CRF 3.A",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'enteric fermentation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane emissions from herbivores as a by-product of enteric fermentation (a digestive process by which carbohydrates are broken down by micro-organisms into simple molecules for absorption into the bloodstream). Ruminant animals (e.g., cattle, sheep) are major sources with moderate amounts produced from non-ruminant animals (e.g., pigs, horses).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2461,7 +2378,6 @@ Individual: OEO_00010180
 
     Annotations: 
         OEO_00010037 "CRF 3.B",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'manure management' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane and nitrous oxide emissions from the decomposition of manure under low oxygen or anaerobic conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2485,7 +2401,6 @@ Individual: OEO_00010181
 
     Annotations: 
         OEO_00010037 "CRF 3.C",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'rice cultivation' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Methane (CH4) emissions from anaerobic decomposition of organic material in flooded rice fields.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2509,7 +2424,6 @@ Individual: OEO_00010182
 
     Annotations: 
         OEO_00010037 "CRF 3.D",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agricultural soils' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2531,7 +2445,6 @@ Individual: OEO_00010183
 
     Annotations: 
         OEO_00010037 "CRF 3.E",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'prescribed burning of savannas' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2553,7 +2466,6 @@ Individual: OEO_00010184
 
     Annotations: 
         OEO_00010037 "CRF 3.F",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'field burning of agricultural residues' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from urea application",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2577,7 +2489,6 @@ Individual: OEO_00010185
 
     Annotations: 
         OEO_00010037 "CRF 3.G",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'liming' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 CO2 emissions from the use of lime in agricultural soils, managed forest soils or lakes.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2601,7 +2512,6 @@ Individual: OEO_00010186
 
     Annotations: 
         OEO_00010037 "CRF 3.H",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'urea application' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2623,7 +2533,6 @@ Individual: OEO_00010187
 
     Annotations: 
         OEO_00010037 "CRF 3.I",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other carbon-containing fertilizers' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2645,7 +2554,6 @@ Individual: OEO_00010188
 
     Annotations: 
         OEO_00010037 "CRF 3.J",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'agriculture - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2667,7 +2575,6 @@ Individual: OEO_00010189
 
     Annotations: 
         OEO_00010037 "CRF 4.A",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'forest land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from lands with woody vegetation consistent with thresholds used to define forest land in the national GHG inventory, sub-divided into managed and unmanaged, and possibly also by climatic region, soil type and vegetation type as appropriate. It also includes systems with vegetation that currently fall below, but are expected to later exceed, the threshold values used by a country to define the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2691,7 +2598,6 @@ Individual: OEO_00010190
 
     Annotations: 
         OEO_00010037 "CRF 4.B",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'cropland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from arable and tillage land, rice fields, and agro-forestry systems where vegetation falls below the thresholds used for the forest land category.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2715,7 +2621,6 @@ Individual: OEO_00010191
 
     Annotations: 
         OEO_00010037 "CRF 4.C",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'grassland' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from rangelands and pasture land that is not considered cropland. It also includes systems with woody vegetation that fall below the threshold values used in the forest land category and are not expected to exceed them, without human intervention. The category also includes all grassland from wild lands to recreational areas as well as agricultural and silvi-pastural systems, subdivided into managed and unmanaged, consistent with national definitions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2739,7 +2644,6 @@ Individual: OEO_00010192
 
     Annotations: 
         OEO_00010037 "CRF 4.D",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'wetlands' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from land that is covered or saturated by water for all or part of the year (e.g., peatland) and that does not fall into the forest land, cropland, grassland or settlements categories. The category can be subdivided into managed and unmanaged according to national definitions. It includes reservoirs as a managed sub-division and natural rivers and lakes as unmanaged sub-divisions.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2763,7 +2667,6 @@ Individual: OEO_00010193
 
     Annotations: 
         OEO_00010037 "CRF 4.E",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'settlements' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from all developed land, including transportation infrastructure and human settlements of any size, unless they are already included under other categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2787,7 +2690,6 @@ Individual: OEO_00010194
 
     Annotations: 
         OEO_00010037 "CRF 4.F",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'other land' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions and removals from bare soil, rock, ice, and all unmanaged land areas that do not fall into any of the other five categories.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2811,7 +2713,6 @@ Individual: OEO_00010195
 
     Annotations: 
         OEO_00010037 "CRF 4.G",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'harvested wood products' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories
 CO2 net emissions or removals resulting from Harvest Wood Products.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -2835,7 +2736,6 @@ Individual: OEO_00010196
 
     Annotations: 
         OEO_00010037 "CRF 4.H",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'land use, land-use change and forestry - other' is an agriculture, forestry and land use sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/941
@@ -2856,13 +2756,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010197
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions excluding LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA) https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
         <http://purl.obolibrary.org/obo/IAO_0000118> "Total emissions: (UNFCCC)",
-        
-		<http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
 
 move to oeo-sector 
@@ -2885,7 +2783,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010198
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'total emissions including LULUCF' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses the following IPCC 2006 sectors: energy; industrial processes and product use; agriculture; land use, land-use change and forestry; waste; and other.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -2915,7 +2812,6 @@ Individual: OEO_00010199
 
     Annotations: 
         OEO_00010037 "CRF 1.D",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) international bunkers is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international bunkers and multilateral operation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
@@ -2943,7 +2839,6 @@ Individual: OEO_00010200
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international bunkers' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses international aviation and maritime navigation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
@@ -2975,7 +2870,6 @@ Individual: OEO_00010201
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1.a",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'international aviation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. It encompasses emissions from flights that depart in one country and arrive in a different country.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3010,7 +2904,6 @@ Individual: OEO_00010202
 
     Annotations: 
         OEO_00010037 "CRF 1.D.1.b",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'maritime navigation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories. Emissions from fuels used by vessels of all flags that are engaged in international water-borne navigation. The international navigation may take place at sea, on inland lakes and waterways and in coastal waters. It includes emissions from journeys that depart in one country and arrive in a different country. It excludes consumption by fishing vessels.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3045,7 +2938,6 @@ Individual: OEO_00010203
 
     Annotations: 
         OEO_00010037 "CRF 1.D.2",
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'multilateral operation' is a transport sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Emissions from fuels used for aviation and waterborne navigation in multilateral operations pursuant to the Charter of the United Nations.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 3.1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
@@ -3073,7 +2965,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
 Individual: OEO_00010204
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
@@ -3094,7 +2985,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010205
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector 'M.International aviation in the EU ETS' is a transport sector that encompasses that part of the international aviation that is regulated by the European Union Emissions Trading System.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
@@ -3125,12 +3015,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/965"
 Individual: OEO_00010206
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
         <http://purl.obolibrary.org/obo/IAO_0000118> "total emissions with international transport (EEA)",
-		<http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "total emissions excluding LULUCF and including international bunkers"@en
@@ -3147,7 +3036,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010207
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international bunkers'.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Term used by the European Environment Agency (EEA): https://climate-energy.eea.europa.eu/topics/climate-change-mitigation/greenhouse-gas-emissions-inventory/data"
@@ -3155,7 +3043,7 @@ Individual: OEO_00010207
         <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
-		rdfs:label "total emissions including LULUCF and including international bunkers"@en
+        rdfs:label "total emissions including LULUCF and including international bunkers"@en
     
     Types: 
         OEO_00000367
@@ -3169,7 +3057,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010208
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that encompasses 'CRF sector (IPCC 2006): total emissions excluding LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2020 emission target of the European Union.",
         
@@ -3195,7 +3082,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010209
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "'Total emissions excluding LULUCF and including international aviation' is a sector that 'CRF sector (IPCC 2006): total emissions including LULUCF' and 'CRF sector (IPCC 2006): international aviation'.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This definition corresponds to the 2030 emission target as specified in the Nationally Determined Contribution (NDC) of the European Union .",
         
@@ -3221,7 +3107,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010228
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 emissions from biomass' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: CO2 emissions from biomass combustion are not included in national totals, but are recorded as an information item for cross-checking purposes as well as avoiding double counting.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 1, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3243,7 +3128,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010229
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'CO2 captured' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses the total amount of CO2 captured for storage.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 2, Chapter 5.9, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3268,7 +3152,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010230
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006): 'indirect CO2' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories: It encompasses Methane, carbon monoxide (CO) or NMVOC emissions that will eventually be oxidised to CO2 in the atmosphere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 7.2.1.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/858
@@ -3471,7 +3354,7 @@ Individual: OEO_00010338
 This comprises fugitive emissions from the systems used to transport captured CO2 from the source to the injection site. These emissions may comprise losses due to fugitive equipment leaks, venting and releases due to pipeline
 ruptures or other accidental releases (e.g., temporary storage).",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
-		<http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "CRF sector (IPCC 2006): transport of CO2"@en
@@ -3494,7 +3377,7 @@ Fugitive emissions from activities and equipment at the injection site and those
         <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
-		rdfs:label "CRF sector (IPCC 2006): injection and storage"@en
+        rdfs:label "CRF sector (IPCC 2006): injection and storage"@en
     
     Types: 
         OEO_00000367
@@ -3511,7 +3394,7 @@ Individual: OEO_00010340
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'CO2 transport and storage' is a sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Any other emissions from CCS not reported elsewhere.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
-		<http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "CRF sector (IPCC 2006): CO2 transport and storage - other"@en
@@ -4020,7 +3903,7 @@ Individual: OEO_00010365
         <http://purl.obolibrary.org/obo/IAO_0000115> "The CRF sector (IPCC 2006) 'photovoltaics' is an industry sector defined by the 2006 IPCC Guidelines for National Greenhouse Gas Inventories:
 Photovoltaic cell manufacture may use and emit CF4 and C2F6 among others.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "2006 IPCC Guidelines for National Greenhouse Gas Inventories, Volume 1, Chapter 8.5, https://www.ipcc-nggip.iges.or.jp/public/2006gl/",
-		<http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "CRF sector (IPCC 2006): photovoltaics"@en

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -70,6 +70,8 @@ AnnotationProperty: OEO_00040001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000116> "This annotation property was used to describe in which module a class was implemented. With OEO version 2.0.0 this annotation property gets deprecated."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Make the annotation property deprecated
+Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1732"@en,
         rdfs:label "belongs to module"
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -66,6 +66,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         dc:identifier
     
     
+AnnotationProperty: OEO_00040001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000116> "This annotation property was used to describe in which module a class was implemented. With OEO version 2.0.0 this annotation property gets deprecated."@en,
+        rdfs:label "belongs to module"
+    
+    
 AnnotationProperty: OEO_00110012
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -66,12 +66,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/523",
         dc:identifier
     
     
-AnnotationProperty: OEO_00040001
-
-    Annotations: 
-        rdfs:label "belongs to module"
-    
-    
 AnnotationProperty: OEO_00110012
 
     Annotations: 
@@ -1092,7 +1086,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576",
 Class: OEO_00000051
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Agent is a role of a person or organisation that directs its activity towards achieving goals."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue:https://github.com/OpenEnergyPlatform/ontology/issues/148
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/210
@@ -1111,7 +1104,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310",
 Class: OEO_00000064
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An author is an agent that creates or has created written work.",
         rdfs:label "author"
     
@@ -1122,7 +1114,6 @@ Class: OEO_00000064
 Class: OEO_00000107
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an agent that can be contacted for help or information about a specific service or good.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -1136,7 +1127,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000150
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy is a quality of material entities which manifests as a capacity to perform work (such as causing motion or the interaction of molecules)",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://www.lexico.com/en/definition/energy",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
@@ -1178,7 +1168,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000323
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A person is a human being."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -1198,7 +1187,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1716",
 Class: OEO_00000340
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A project is a process to achieve a specified goal that is unique in the sum of its conditions like its goal, time and cost budget and its organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/418
@@ -1214,7 +1202,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/869",
 Class: OEO_00000350
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity value is an information content entity defined by a numeral together with a unit of measurement to quantify an entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
@@ -1241,7 +1228,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000407
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technology is a plan specification that describes how to combine artificial objects or other material entities and processes in a specific way."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/136
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/334
@@ -1260,7 +1246,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000419
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformation is a process that transforms one or more inputs into at least one output."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/435
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/450
@@ -1282,7 +1267,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010116
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A good is a continuant that has the good role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/843
@@ -1307,7 +1291,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010117
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The role of an independent continuant or energy over which ownership rights can be established, whose ownership can be passed from one party to another by engaging in transactions, and that is not money.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/Good",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
@@ -1334,7 +1317,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020011
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study is a project with the goal to methodologically investigate something."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The construct 'has funding source' some ('has role' some funder) is necessary, because has funding source has the range has role some funder. This range comes from issue https://github.com/OpenEnergyPlatform/ontology/issues/850 : funding source is some kind of independent continuant, i.e. a organisation or person, that does something special (giving money). So it is anything that has role some funder.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
@@ -1368,7 +1350,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557"
 Class: OEO_00020012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study report is a report that is the output from some study."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/247
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/497
@@ -1392,7 +1373,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871"
 Class: OEO_00020015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licence is an information content entity that contains an official permission or permit to do, use or own something.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "license",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/31
@@ -1413,7 +1393,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020166
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methodology is a plan specification that describes processes that are part of a study.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/971
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1011
@@ -1434,7 +1413,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00020201
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Import is the process of purchasing goods or services abroad and their delivery to the domestic market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -1455,7 +1433,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020202
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Export is the process of selling goods or services abroad and their delivery to a foreign market.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
@@ -1476,7 +1453,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030019
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A process attribute is a dependent occurrent that existentially depends on a process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
@@ -1492,7 +1468,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030022
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation is an immaterial entity that has the organisation role and there exists some sort of legal framework that recognises the entity and its continued existence.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organization",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/416
@@ -1520,7 +1495,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1716",
 Class: OEO_00030035
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time span is a quantity value indicating the duration of a one-dimensional temporal region, measured in a time unit.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "duration",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
@@ -1541,7 +1515,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00090001
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A funder is a sponsor that supports by giving money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776
@@ -1557,7 +1530,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is an agent that supports a person, organisation, or project by giving money, allowance of kind, services or other help.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/473
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/557
@@ -1573,7 +1545,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140012
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/559

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -50,9 +50,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: OEO_00010037
 
     
-AnnotationProperty: OEO_00040001
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -413,7 +410,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1482",
 Class: OEO_00000045
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A producer is an agent that makes goods.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
@@ -439,7 +435,6 @@ Class: OEO_00000064
 Class: OEO_00000087
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A client is an agent that receives a product or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
@@ -453,7 +448,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000105
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A consumer is a user of a commercial product or service."@en,
         rdfs:label "consumer"
     
@@ -467,7 +461,6 @@ Class: OEO_00000107
 Class: OEO_00000238
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An institution is an organisation that serves a social purpose."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "moved term to oeo-shared:
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871
@@ -483,7 +476,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000315
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisation role is a role of an aggregate of people that has a collective goal and a set of organisation rules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organization role",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -506,7 +498,6 @@ Class: OEO_00000323
 Class: OEO_00000329
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A political party is an organisation of a group of people with common views or goals that wants to have influence in politics."@en,
         rdfs:label "political party"
     
@@ -517,7 +508,6 @@ Class: OEO_00000329
 Class: OEO_00000341
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A prosumer is an agent who is producer and consumer at the same time."@en,
         rdfs:label "prosumer"
     
@@ -531,7 +521,6 @@ Class: OEO_00000350
 Class: OEO_00000379
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A software developer is an agent that creates computer software.",
         rdfs:label "software developer"
     
@@ -542,7 +531,6 @@ Class: OEO_00000379
 Class: OEO_00000431
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A user is an agent that employs an aid, tool or information system to achieve a goal/benefit.",
         rdfs:label "user"
     
@@ -553,7 +541,6 @@ Class: OEO_00000431
 Class: OEO_00010082
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trade is a process in which one good or service is exchanged for another good or service or money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/307
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
@@ -578,7 +565,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010083
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market participant is an agent who participates in trading in a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/330
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/745
@@ -604,7 +590,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010115
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economy is a system of production, distribution, trade and consumption of goods and services.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "economic system",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/832
@@ -627,7 +612,6 @@ Class: OEO_00010117
 Class: OEO_00010123
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Effort sharing is a policy instrument that sets a common emission reduction goal for a number of countries. Each country has a national reduction goal. Under- or overachievement of that goal can be compensated by trading emission certificates.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
@@ -641,7 +625,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Class: OEO_00010126
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An Annual Emission Allocation (AEA) is an emission certificate used in the Effort Sharing Decision (ESD) and the Effort Sharing Regulation (ESR). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "AEA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -655,7 +638,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Class: OEO_00010136
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Distribution is the process of delivering goods and services to agents. ETst",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/836
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/876
@@ -673,7 +655,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00010212
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951",
@@ -815,7 +796,6 @@ Class: OEO_00020015
 Class: OEO_00020060
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel market exchange is an energy market exchange where fuels like oil, coal, renewable fuels, and natural gas are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
@@ -838,7 +818,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020063
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission certificate is a licence that permits its holder/owner a specific emission value. An emission certificate can be traded at a CO2 market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/740
@@ -859,7 +838,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020064
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An EU Allowance (EUA) is an emission certificate used in the European Union Emissions Trading System (EU ETS). It permits the emission of a CO2 equivalent quantity of 1 tonne.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EUA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/677
@@ -873,7 +851,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/740",
 Class: OEO_00020065
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy market exchange is a market exchange in which energy commodities are traded.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/748
@@ -894,7 +871,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020066
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel commodity role is the commodity role of fuels.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/748
@@ -953,7 +929,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748",
 Class: OEO_00020069
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market exchange is an organisation that has the market exchange role.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
@@ -985,7 +960,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
 Class: OEO_00020075
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission market exchange is a market exchange where emission certificates are traded",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue https://github.com/OpenEnergyPlatform/ontology/issues/302
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
@@ -999,7 +973,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
 Class: OEO_00020076
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
@@ -1013,7 +986,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/800",
 Class: OEO_00020077
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/256
 https://github.com/OpenEnergyPlatform/ontology/pull/800",
@@ -1027,7 +999,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/800",
 Class: OEO_00020108
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A feed-in tariff is a policy instrument designed to stimulate investment in renewable energy technologies by offering long-term contracts to agents who are producers of renewable energy.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/898
@@ -1042,7 +1013,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020109
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A market premium is a policy instrument that ensures a guaranteed remuneration, e.g. a fixed feed-in tariff, by paying to the producing agent the difference between a guaranteed return on a good/product and the monetary price for which the good/product is traded on the market",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
@@ -1056,7 +1026,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020110
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A levy is a policy instrument that consists of a compulsory financial charge imposed on an agent or institution by a governmental organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/900
@@ -1070,7 +1039,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020111
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A capacity premium is a market premium that guarantees remuneration for reserving capacity of energy transformation units to be available for unexpected events.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/903
@@ -1084,7 +1052,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020112
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tax is a levy whose returns are used by the government to finance expenditures for the common welfare.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/839
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/901
@@ -1098,7 +1065,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/909",
 Class: OEO_00020113
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Inflation rate is an economic value reprensenting the ratio between the monetary price for a good at two different points in time that equalises differences in monetary price levels between these two points in time.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/335
 https://github.com/OpenEnergyPlatform/ontology/pull/910",
@@ -1112,7 +1078,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020114
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000112> "The exchange rate between USD and EUR on March 15, 2020 was X.X.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The exchange rate is an economic value representing the ratio at which one currency can be exchanged for another.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "market exchange rate",
@@ -1129,7 +1094,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020115
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Purchasing power parity is an economic value representing the ratio between currencies that equalises differences in monetary price levels between countries for the same set of goods.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PPP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/867
@@ -1145,7 +1109,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020116
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
@@ -1158,7 +1121,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020117
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000112> "The electricity price is Y EUR per megawatt-hour.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity price is the monetary price per energy unit of electricity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
@@ -1173,7 +1135,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
 Class: OEO_00020124
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1187,7 +1148,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020125
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1201,7 +1161,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020126
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
@@ -1215,7 +1174,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020127
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
@@ -1230,7 +1188,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
 Class: OEO_00020128
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "add term
 https://github.com/OpenEnergyPlatform/ontology/issues/908
@@ -1245,7 +1202,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/929",
 Class: OEO_00020145
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A variable cost is a cost that depends on an amount of goods or services.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1263,7 +1219,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00020146
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are paid by the producer.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1277,7 +1232,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
 Class: OEO_00020154
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Emission certificate price is a monetary price of an emission certificate that allows the emission of a certain emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 price",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1320,7 +1274,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020156
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon tax is a tax for emitting CO2 or other greenhouse gases (measured in CO2 equivalent values).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 tax",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
@@ -1334,7 +1287,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956",
 Class: OEO_00020167
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed investment cost",
@@ -1353,7 +1305,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020168
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fixed cost is a cost for operation and maintenance that does not vary with the amount of goods or services produced.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fixed operation and maintenance cost",
@@ -1375,7 +1326,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00020169
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment cost is an investment cost for acquisition of the components and machinery including environmental facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
@@ -1392,7 +1342,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00020170
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "installation and development cost",
@@ -1408,7 +1357,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020171
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1421,7 +1369,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020172
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A property cost is an investment cost arising from the acquisition of a property.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
@@ -1439,7 +1386,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00020173
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
@@ -1452,7 +1398,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
 Class: OEO_00020174
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery cost is a cost for a product or service that refers to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
@@ -1469,7 +1414,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00020181
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
@@ -1485,7 +1429,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An organisational energy producer is an organisation that undertakes the generation of electricity and/or heat.\"",
         <http://purl.obolibrary.org/obo/IAO_0000118> "organisational energy producer",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
@@ -1501,7 +1444,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy autoproducer is an organisational energy producer who produces electrical energy and/or heat wholly or partly for their own use as an activity which supports their primary activity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1516,7 +1458,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
 Class: OEO_00030018
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A main activity energy producer is an organisational energy producer whose primary activity is electrical energy and/or heat production.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "inspired by https://ec.europa.eu/eurostat/documents/38154/41386/Ele_AQ_documentation.pdf/a06bf650-1830-4fcb-9376-7be1f8ab080c",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/314
@@ -1570,7 +1511,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00040003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary price is an economic value that describes the amount of money requested, expected, required or given in exchange for something else.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
@@ -1617,7 +1557,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00040005
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader is a market participant that engages in the transfer of financial assets in any financial market on behalf of a client or a financial services provider.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fbc-pas-fpas:Trader",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Implement in line with FIBO:
@@ -1637,7 +1576,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/745",
 Class: OEO_00040006
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A request is a process whereby an agent asks another agent for something or to do something.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/Request",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1656,7 +1594,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00040007
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A price request is a request in which an agent asks another agent for a price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
 https://github.com/OpenEnergyPlatform/ontology/pull/642",
@@ -1669,7 +1606,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
 Class: OEO_00040008
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1683,7 +1619,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
 Class: OEO_00040009
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-shared",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/268
@@ -1731,7 +1666,6 @@ Class: OEO_00090001
 Class: OEO_00090002
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A public funder is a funder that gives public money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
@@ -1744,7 +1678,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
 Class: OEO_00090003
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A private funder is a funder that gives private money.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/246
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/776",
@@ -1763,7 +1696,6 @@ Class: OEO_00140012
 Class: OEO_00140013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GDP",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/454
@@ -1784,7 +1716,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623",
 Class: OEO_00140023
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GVA",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/455
@@ -1801,7 +1732,6 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676",
 Class: OEO_00140109
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A contract is a document that contains an agreement between two or more competent agents to which those agents agree to be legally bound.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/Contract",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1815,7 +1745,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/756",
 Class: OEO_00140117
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Delivery time is a one-dimensional temporal region expressing the amount of time that it takes for goods that have been bought to arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1828,7 +1757,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140118
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery time point is a zero-dimensional temporal region expressing the point in time when goods that have been bought arrive at the place where they are wanted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1841,7 +1769,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140119
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sender is an agent who initiates a communication.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1854,7 +1781,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140120
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A receiver is an agent who obtains information from a sender.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1867,7 +1793,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140121
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bid is a document describing an offer made by an agent to another agent in an effort to exchange commodities or services via terms relating to price and quantity which will be part of the resulting contract.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1880,7 +1805,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140122
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An award is a document that signifies that a supplier for a particular commodity or service specified in a bid has been accepted.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
@@ -1893,7 +1817,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/778",
 Class: OEO_00140123
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A provider is an agent that transfers commodities or services to other agents.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/ServiceProvider (adapted)",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
@@ -1930,7 +1853,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140125
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery interval is the duration between repeated deliveries of services or commodities.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1944,7 +1866,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140130
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant operator is an agent that operates an electric utility generation station.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1957,7 +1878,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140131
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A trader that trades the power of fossil fuel power plants.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
@@ -1970,7 +1890,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140136
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Dispatch assignment is a plan specification that refers to resource planning at a power plant (usually by the plant’s operator).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1983,7 +1902,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
 Class: OEO_00140137
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant portfolio is an information content entity that describes a particular combination or mix of different power plants, e.g. renewables and fossil plants within one business unit or company or trader.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
@@ -1996,7 +1914,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/792",
 Class: OEO_00140140
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand trader is a trader that deals specifically with energy demand.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -2009,7 +1926,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140141
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A merit order is a plan specification that describes the dispatch ranking of power plants (electrical generation) based on ascending order of price.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -2022,7 +1938,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140143
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A direct marketer is a trader who is the relay between the energy exchange and power plant operators.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
@@ -2056,7 +1971,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140150
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A policy is a specifically dependent continuant that is a deliberate system of principles, rules and guidelines, adopted by an organisation to guide decision making with respect to particular situations and implemented to achieve stated goals.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
@@ -2110,7 +2024,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/853"
 Class: OEO_00140171
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An email address is an information content entity that identifies an email box to which messages are delivered.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/818
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/827",
@@ -2135,7 +2048,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
 Class: OEO_00230013
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A population is an aggregate of people in a spatial region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
 https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -2149,7 +2061,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230014
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An urban population is a population living in urban areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -2167,7 +2078,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230015
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rural population is a population living in rural areas, as defined by national statistical offices."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "United Nations Population Division. World Urbanization Prospects: 2018 Revision."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
@@ -2185,7 +2095,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230016
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The labour force is the population of people ages 15 and older who supply labour to the production of goods and services.  It includes people who are currently employed and people who are unemployed but seeking work as well as first-time job-seekers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "labor force",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://databank.worldbank.org/reports.aspx?source=2&type=metadata&series=SL.TLF.TOTL.IN"@en,
@@ -2201,7 +2110,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00230017
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The working age population is the population of people aged 15 to 65."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/301
 https://github.com/OpenEnergyPlatform/ontology/issues/479
@@ -2215,7 +2123,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/491"@en,
 Class: OEO_00240021
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A discount rate is an economic value with the unit percent that refers to the interest rate used in discounted cash flow (DCF) analysis to determine the present value of future cash flows."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1049
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
@@ -2229,7 +2136,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1077"@en,
 Class: OEO_00240036
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An import price is the monetary price for the import of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
@@ -2242,7 +2148,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
 Class: OEO_00240037
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An export price is the monetary price for the export of a material entity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1050
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1083",
@@ -2313,7 +2218,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1698"@en,
 Individual: OEO_00010122
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The European Union Emissions Trading System (EU ETS) is a policy instrument that implements an emissions trading system covering the European Union, Norway, Iceland and Liechtenstein.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "EU ETS",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2339,7 +2243,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00010124
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Decision (ESD) is the European effort sharing for the years 2013-2020. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons and sulphur hexafluoride. Emission quantities under the ESD are calculated using global warming potentials from the Fourth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESD",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2357,7 +2260,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010125
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The Effort Sharing Regulation (ESR) is the European effort sharing for the years 2021-2030. It covers the European Union, Norway, Iceland and Liechtenstein and the following greenhouse gases: carbon dioxide, methane, nitrous oxide, hydrofluorocarbons, perfluorocarbons, sulphur hexafluoride and nitrogen trifluoride. Emission quantities under the ESR are calculated using global warming potentials from the Fifth IPCC Assessment Report.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ESR",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
@@ -2375,7 +2277,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857",
 Individual: OEO_00010129
 
     Annotations: 
-        OEO_00040001 "http://openenergy-platform.org/ontology/oeo/oeo-social",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The EU climate policy is the policy of the European Union for reducing greenhouse gas emissions. It uses an EU emission sector division.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857


### PR DESCRIPTION
## Summary of the discussion

Discussed bilaterally with @stap-m : We don't need anymore the annotation property `belongs to module`.
With this PR all uses in the OEO are removed and the property itself will be marked as deprecated.

## Type of change (CHANGELOG.md)

### Updated
- Mark `belongs to module` via editor note as deprecated

### Removed
- All uses of `belongs to module`

## Workflow checklist

### Automation
No associated issue

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
