### PR TITLE
add service product #1584

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - resilience, power system resilience, power system (#1744)
+- service product role, service product (#1748)
 
 ### Changed
 ### Removed

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1691,3 +1691,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00360018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product role is the role of an immaterial entity that is the result of a service process, and whose value is determined by the value and the costs of the service."@en,
+        rdfs:label "service product role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product is an immaterial entity that has the service product role."@en,
+        rdfs:label "service product"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360018)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1691,31 +1691,4 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-Class: OEO_00360018
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product role is the role of an immaterial entity that is the result of a service process, and whose value is determined by the value and the costs of the service."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
-        rdfs:label "service product role"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00360019
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product is an immaterial entity that has the service product role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
-        rdfs:label "service product"@en
-    
-    EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360018)
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000141>
-    
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1695,6 +1695,8 @@ Class: OEO_00360018
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A service product role is the role of an immaterial entity that is the result of a service process, and whose value is determined by the value and the costs of the service."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
         rdfs:label "service product role"@en
     
     SubClassOf: 
@@ -1705,6 +1707,8 @@ Class: OEO_00360019
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A service product is an immaterial entity that has the service product role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
         rdfs:label "service product"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1691,4 +1691,3 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
-    

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2271,3 +2271,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         OEO_00140150
     
     
+Class: OEO_00360018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product role is the role of an immaterial entity that is the result of a service process, and whose value is determined by the value and the costs of the service."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
+        rdfs:label "service product role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A service product is an immaterial entity that has the service product role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1584
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
+        rdfs:label "service product"@en
+    
+    EquivalentTo: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360018)
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000141>
+    


### PR DESCRIPTION
## Summary of the discussion

Discussions (e.g. in https://github.com/OpenEnergyPlatform/ontology/issues/1487 and https://github.com/OpenEnergyPlatform/ontology/issues/1239) have shown that we sometimes have to aggregate good and service which is difficult as good is a continuant and service is an occurent.

For this reason, we decided to add a continuant that expresses the value of a service. 
We decided on a similar solution to how `good` is implemented and added a role and an equivalent class. 

`service product role`
definition: A service product role is the role of an immaterial entity that is the result of a service process, and whose value is determined by the value and the costs of the service.

`service product`
definition: A service product is an immaterial entity that has the service product role.

## Type of change (CHANGELOG.md)

### Added
- service product role
- service product


## Workflow checklist

### Automation
Closes #1584 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
