### PR TITLE
restructure the concept of regions #1745

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - resilience, power system resilience, power system (#1744)
+- region of relevance, study subregion role, study region role, interacting region role, considered region role (#1749)
 
 ### Changed
+- subregion, study region, study subregion, interacting region, considered region (#1749)
+
 ### Removed
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3053,7 +3053,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711",
 Class: OEO_00360020
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is mentioned in any study or analysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is used in a study or analysis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "region of relevance"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1806,7 +1806,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+relocated, made equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study region"@en
     
     EquivalentTo: 
@@ -1822,7 +1826,11 @@ Class: OEO_00020033
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a region of relevance that is in every respect a component of a region of relevance, but never encompasses the entire extent of a region of relevance."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+
+changed definition, relocated 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "subregion"@en
     
     SubClassOf: 
@@ -1838,7 +1846,11 @@ In the study, a spatial region outside the study region plays a role. E.g. for m
 The union of the study region and the interacting/ external region ist the considered region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion that has the study subregion role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+
+relocated, made equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study subregion"@en
     
     EquivalentTo: 
@@ -1862,7 +1874,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+relocated, made equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "considered region"@en
     
     EquivalentTo: 
@@ -1883,7 +1899,11 @@ The union of the study region and the interacting/ external region ist the consi
         <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a region of relevance that has the interacting region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
+
+relocated, made equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "interacting region"@en
     
     EquivalentTo: 
@@ -3029,6 +3049,8 @@ Class: OEO_00360020
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is mentioned in any study or analysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "region of relevance"@en
     
     SubClassOf: 
@@ -3043,6 +3065,8 @@ The study region is not modelled as a whole, but several subregions are modelled
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
 The union of the study region and the interacting/ external region ist the considered region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study region role is a role of a region of relevance that is under investigation and consists entirely of one or more subregions."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study region role"@en
     
     SubClassOf: 
@@ -3057,6 +3081,8 @@ The study region is not modelled as a whole, but several subregions are modelled
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
 The union of the study region and the interacting/ external region ist the considered region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region role is the role of a region of relevance that is used in an analysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "considered region role"@en
     
     SubClassOf: 
@@ -3071,6 +3097,8 @@ The study region is not modelled as a whole, but several subregions are modelled
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
 The union of the study region and the interacting/ external region ist the considered region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region role is a role of a region of relevance that interacts with a region of relevance that has the study region role. It is part of a region of relevance that has the considered region role, but not a study region role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "interacting region role"@en
     
     SubClassOf: 
@@ -3081,6 +3109,8 @@ Class: OEO_00360024
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion role is a study region role that refers to a subregion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study subregion role"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1799,8 +1799,8 @@ Class: OEO_00020032
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a spatial region that is under investigation and consists entirely of one or more subregions.",
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a region of relevance that has the study region role and consists entirely of one or more subregions."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
 
@@ -1809,20 +1809,24 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "study region"@en
     
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360021)
+    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
+        OEO_00360020
     
     
 Class: OEO_00020033
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a spatial region that is a part of spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subregion is a region of relevance that is in every respect a component of a region of relevance, but never encompasses the entire extent of a region of relevance."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
         rdfs:label "subregion"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
+        OEO_00360020
     
     
 Class: OEO_00020034
@@ -1831,11 +1835,15 @@ Class: OEO_00020034
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion of a study region.",
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion is a subregion that has the study subregion role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
         rdfs:label "study subregion"@en
+    
+    EquivalentTo: 
+        OEO_00020033
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360024)
     
     SubClassOf: 
         OEO_00020033
@@ -1847,8 +1855,8 @@ Class: OEO_00020035
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a spatial region that is used in an analysis.",
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region is a region of relevance that has the considered region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585
 
@@ -1857,8 +1865,12 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "considered region"@en
     
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360022)
+    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
+        OEO_00360020
     
     
 Class: OEO_00020036
@@ -1867,15 +1879,19 @@ Class: OEO_00020036
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a spatial region that interacts with a study region. It is part of a considered region, but not a study region.",
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region is a region of relevance that has the interacting region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "external region",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/475
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/585",
         rdfs:label "interacting region"@en
     
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360023)
+    
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000006>
+        OEO_00360020
     
     
 Class: OEO_00020072
@@ -3007,6 +3023,68 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711",
     
     SubClassOf: 
         OEO_00010252
+    
+    
+Class: OEO_00360020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is mentioned in any study or analysis."@en,
+        rdfs:label "region of relevance"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+Class: OEO_00360021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study region role is a role of a region of relevance that is under investigation and consists entirely of one or more subregions."@en,
+        rdfs:label "study region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A considered region role is the role of a region of relevance that is used in an analysis."@en,
+        rdfs:label "considered region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360023
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
+The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
+In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
+The union of the study region and the interacting/ external region ist the considered region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An interacting region role is a role of a region of relevance that interacts with a region of relevance that has the study region role. It is part of a region of relevance that has the considered region role, but not a study region role."@en,
+        rdfs:label "interacting region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360024
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study subregion role is a study region role that refers to a subregion."@en,
+        rdfs:label "study subregion role"@en
+    
+    SubClassOf: 
+        OEO_00360021
     
     
 Individual: OEO_00000049

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2373,7 +2373,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "reference role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00360020
     
     
 Class: OEO_00020314
@@ -3074,7 +3075,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study region role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00360020
     
     
 Class: OEO_00360022
@@ -3090,7 +3092,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "considered region role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00360020
     
     
 Class: OEO_00360023
@@ -3106,7 +3109,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "interacting region role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        OEO_00010121 some OEO_00360020
     
     
 Class: OEO_00360024
@@ -3118,7 +3122,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "study subregion role"@en
     
     SubClassOf: 
-        OEO_00360021
+        OEO_00360021,
+        OEO_00010121 some OEO_00020033
     
     
 Individual: OEO_00000049


### PR DESCRIPTION
## Summary of the discussion

While discussing Issue https://github.com/OpenEnergyPlatform/ontology/issues/1489 with the OVGU-Group, we agreed that the current structure of `spatial region` should be slightly changed.
One reason for that is the fact that `study region` `considered region` and `interacting region` are currently on the same hierarchical level as one-two-three and zero-dimensional region.

We decided to add a meta concept that contains the different regions and to make the regions equivalent classes by adding corresponding roles. 

Since `subregion` was only parent to `study subregion`, which was not related in any way to `study region`, I moved `subregion` under the new meta-class and implemented a corresponding `study subregion role`, which is a child node of `study region role`. 

For now, I copied the examples of use from the regions, which means that they are part of both the role, and the equivalent class, which one could argue is somewhat superfluous. 

**New concepts:**

`region of relevance`:
definition: *A region of relevance is a spatial region that is mentioned in any study or analysis.*

`study region role`:
definition: *A study region role is a role of a region of relevance that is under investigation and consists entirely of one or more subregions.*

`study subregion role`:
definition: *A study subregion role is a study region role that refers to a subregion.*

`interacting region role`:
definition: *An interacting region role is a role of a region of relevance that interacts with a region of relevance that has the study region role. It is part of a region of relevance that has the considered region role, but not a study region role.*

`considered region role`:
definition: *A considered region role is the role of a region of relevance that is used in an analysis.*

**Updated definition:**

`subregion`:
definition: *A subregion is a region of relevance that is in every respect a component of a region of relevance, but never encompasses the entire extent of a region of relevance.*

## Type of change (CHANGELOG.md)

### Added
- region of relevance
- study region role
- interacting region role
- considered region role
- study subregion role

### Updated
- subregion


## Workflow checklist

### Automation
Closes #1745

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
