### PR TITLE
Fix SubClassOf axioms of `model factsheet` #1750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - resilience, power system resilience, power system (#1744)
 
 ### Changed
+- model factsheet (#1751)
+
 ### Removed
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -979,8 +979,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
         rdfs:label "model factsheet"@en
     
     SubClassOf: 
-        OEO_00000162
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274)
+        OEO_00000162,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00000274
     
     
 Class: OEO_00000279

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -975,7 +975,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/577
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/851
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/854
+
+Fix SubClassOf axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1751",
         rdfs:label "model factsheet"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Class `model factsheet` currently has the only SubClassOf axiom `factsheet and ('is about' some 'numerical computer model')`. Therefore the OEO viewer cannot show this.

Solution: Split this into two SubClassOf axioms which is in line with all the other factsheet classes.

## Type of change (CHANGELOG.md)

### Updated
- `model factsheet`

## Workflow checklist

### Automation
Closes #1750

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
