### PR TITLE
adding domain and ranges to has sink, has source and is connected to #1116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
+- is connected to, has sink, has source (1762)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
-- is connected to, has sink, has source (1762)
+- is connected to, has sink, has source (#1762)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -277,7 +277,7 @@ ObjectProperty: OEO_00000525
 ObjectProperty: OEO_00000526
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two nodes in a graph that are connected to each other through an edge.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two neighbouring grid nodes in a supply grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
         rdfs:label "is connected to"@en
@@ -287,6 +287,12 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
     
     Characteristics: 
         Symmetric
+    
+    Domain: 
+        OEO_00000296
+    
+    Range: 
+        OEO_00000296
     
     
 ObjectProperty: OEO_00000527

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -279,7 +279,10 @@ ObjectProperty: OEO_00000526
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two neighbouring grid nodes in a supply grid.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
         rdfs:label "is connected to"@en
     
     SubPropertyOf: 
@@ -300,7 +303,10 @@ ObjectProperty: OEO_00000527
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as an extraction point of the supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
         rdfs:label "has sink"@en
     
     SubPropertyOf: 
@@ -321,7 +327,10 @@ ObjectProperty: OEO_00000528
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as entry point to the supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
         rdfs:label "has source"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -319,7 +319,7 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
 ObjectProperty: OEO_00000528
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges starting but not ending there.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as entry point to the supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
         rdfs:label "has source"@en
@@ -329,6 +329,12 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
     
     DisjointWith: 
         OEO_00000527
+    
+    Domain: 
+        OEO_00000200
+    
+    Range: 
+        OEO_00000296
     
     
 ObjectProperty: OEO_00000529

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -298,7 +298,7 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
 ObjectProperty: OEO_00000527
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a directed graph and a node in that graph that has edges ending but not starting there.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as an extraction point of the supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
         rdfs:label "has sink"@en
@@ -308,6 +308,12 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478",
     
     DisjointWith: 
         OEO_00000528
+    
+    Domain: 
+        OEO_00000200
+    
+    Range: 
+        OEO_00000296
     
     
 ObjectProperty: OEO_00000528


### PR DESCRIPTION
## Summary of the discussion

adding domain and ranges to has sink, has source and is connected to
See #1116 

### Automation
Closes #1116 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
