### PR TITLE
Add `fuel blending quota` #1413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - resilience, power system resilience, power system (#1744)
 - service product role, service product (#1748)
 - region of relevance, study subregion role, study region role, interacting region role, considered region role (#1749)
+- fuel blending quota (#1763)
 
 ### Changed
 - subregion, study region, study subregion, interacting region, considered region (#1749)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - resilience, power system resilience, power system (#1744)
 - service product role, service product (#1748)
 - region of relevance, study subregion role, study region role, interacting region role, considered region role (#1749)
-- fuel blending quota (#1763)
+- fuel blending quota, fuel quota blending value (#1763)
 
 ### Changed
 - subregion, study region, study subregion, interacting region, considered region (#1749)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8437,7 +8437,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
 Class: OEO_00010451
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a fraction value quality of a blended fuel that indicates the share of liquid renewable fuel or liquid biofuel mixed into fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a quality of a blended fuel that indicates the share of liquid renewable fuel or liquid biofuel mixed into fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
         rdfs:label "fuel blending quota"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8434,6 +8434,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140003))
     
     
+Class: OEO_00010451
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a fraction value that indicates the share of renewable fuel or biofuel mixed into fossil fuel."@en,
+        rdfs:label "fuel blending quota"@en
+    
+    SubClassOf: 
+        OEO_00140127
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8438,6 +8438,8 @@ Class: OEO_00010451
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a fraction value that indicates the share of renewable fuel or biofuel mixed into fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
         rdfs:label "fuel blending quota"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8449,7 +8449,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
 Class: OEO_00010452
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota value is a fraction value that quantifies a fuel blending quota.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota value is a fraction value that quantifies a fuel blending quota."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
         rdfs:label "fuel quota blending value"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8437,13 +8437,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
 Class: OEO_00010451
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a fraction value that indicates the share of renewable fuel or biofuel mixed into fossil fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a fraction value quality of a blended fuel that indicates the share of liquid renewable fuel or liquid biofuel mixed into fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
         rdfs:label "fuel blending quota"@en
     
     SubClassOf: 
-        OEO_00140127
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00010452
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota value is a fraction value that quantifies a fuel blending quota.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
+        rdfs:label "fuel quota blending value"@en
+    
+    SubClassOf: 
+        OEO_00140127,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010451
     
     
 Class: OEO_00020001


### PR DESCRIPTION
## Summary of the discussion

Describe a certain share of renewable fuel mixed into fossil fuel.

## Type of change (CHANGELOG.md)

### Added
- `fuel blending quota`: _A fuel blending quota is a fraction value that indicates the share of renewable fuel or biofuel mixed into fossil fuel._
- `fuel blending quota value`: _A fuel blending quota value is a fraction value that quantifies a fuel blending quota._

## Workflow checklist

### Automation
Closes #1413

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
