### PR TITLE
Add `temperature` and `pressure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
 - is connected to, has sink, has source (#1762)
+- temperature, pressure (#1767)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8461,6 +8461,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140003))
     
     
+Class: OEO_00010453
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Temperature is a quality representing the driving force for the flow of heat energy and is a measure of the heat content of a material entity."@en,
+        rdfs:label "temperature"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00010454
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pressure is a quality representing the force per unit area that its bearer exerts on itself or on a surface that bounds its bearer.",
+        rdfs:label "pressure"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8465,6 +8465,8 @@ Class: OEO_00010453
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Temperature is a quality representing the driving force for the flow of heat energy and is a measure of the heat content of a material entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1767",
         rdfs:label "temperature"@en
     
     SubClassOf: 
@@ -8476,6 +8478,8 @@ Class: OEO_00010454
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pressure is a quality representing the force per unit area that its bearer exerts on itself or on a surface that bounds its bearer.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1767",
         rdfs:label "pressure"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8468,7 +8468,8 @@ Class: OEO_00010453
         rdfs:label "temperature"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00010454
@@ -8478,7 +8479,8 @@ Class: OEO_00010454
         rdfs:label "pressure"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00020001


### PR DESCRIPTION
## Summary of the discussion

Add temperature and pressure.

## Type of change (CHANGELOG.md)

### Added
- `temperature`: _Temperature is a quality representing the driving force for the flow of heat energy and is a measure of the heat content of a material entity._
- `pressure`: _A pressure is a quality representing the force per unit area that its bearer exerts on itself or on a surface that bounds its bearer._

## Workflow checklist

### Automation
Closes #1505

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
