### PR TITLE
Restructure `power rating` and `power capacity` #1492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
 - is connected to, has sink, has source (#1762)
+- power rating, power capacity (#1770)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11849,7 +11849,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00230001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power rating is a maximum value stating the maximum power an energy converting omponent can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power rating is a maximum value stating the maximum power an energy converting component can convert.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6673,7 +6673,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00010257
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a maximum value of a generator or power generating unit to generate power.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a power rating of a generator or power generating unit to generate power.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
@@ -6683,7 +6683,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
         rdfs:label "power capacity"@en
     
     SubClassOf: 
-        OEO_00010256,
+        OEO_00230001,
         OEO_00020056 some 
             (OEO_00000188 or OEO_00000334),
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
@@ -11778,7 +11778,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00230001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power rating is a power capacity stating the maximum power an energy converting component can convert.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power rating is a maximum value stating the maximum power an energy converting omponent can convert.",
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
@@ -11799,7 +11799,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
         rdfs:label "power rating"@en
     
     SubClassOf: 
-        OEO_00010257,
+        OEO_00010256,
         OEO_00020056 some OEO_00000011,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000113>
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6679,7 +6679,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
 Fix 'quantity value of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1223
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235
+
+Restructure 'power rating' and 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1492
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770",
         rdfs:label "power capacity"@en
     
     SubClassOf: 
@@ -11795,7 +11799,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 Make subclass of 'power capacity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
+
+Restructure 'power rating' and 'power capacity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1492
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770",
         rdfs:label "power rating"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

## Type of change (CHANGELOG.md)

### Updated
* `power rating`: _**A** ~P~**p**ower rating is a ~power capacity~ **maximum value** stating the maximum power value an energy converting component can convert._
* `power capacity`: _A power capacity is a ~maximum value~ **power rating** of a generator or power generating unit to generate power._

## Workflow checklist

### Automation
Closes #1492

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
