### PR TITLE
make boiler an equivalent class #1570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
 - is connected to, has sink, has source (#1762)
+- boiler (#1771)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12615,7 +12615,10 @@ Class: OEO_00310013
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1570
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771",
         rdfs:label "boiler"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12618,6 +12618,12 @@ Class: OEO_00310013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         rdfs:label "boiler"@en
     
+    EquivalentTo: 
+        OEO_00000210
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some 
+            (OEO_00010248
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140116)))
+    
     SubClassOf: 
         OEO_00000210,
         OEO_00000503 some OEO_00140116


### PR DESCRIPTION
Made `boiler` an equivalent class by adding the axiom `heater and ('participates in' some ('heat generation process' and 'has participant' some fluid))`, since `combustion heater` and `electrical heater` can also be boilers when heating a fluid. 

## Type of change (CHANGELOG.md)

### Updated
- boiler 

## Workflow checklist

### Automation
Closes #1570

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
