### PR TITLE
Make `B7` and `E10` liquid fuels #1764

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - subregion, study region, study subregion, interacting region, considered region (#1749)
 - model factsheet (#1751)
 - is connected to, has sink, has source (#1762)
-- carbon capture and storage technology (#1768)
 - temperature, pressure (#1767)
+- carbon capture and storage technology (#1768)
+- B7, E10 (#1774)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8406,7 +8406,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
 Class: OEO_00010447
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "E10 is a gasoline fuel that consists of (fossil) gasoline and up to 10 % ethanol."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "E10 is a gasoline fuel that consists of (fossil) gasoline and up to 10 % ethanol and that is liquid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
         rdfs:label "E10"@en
@@ -8414,13 +8414,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
     SubClassOf: 
         OEO_00010241,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000183)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010446)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010446),
+        OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00010448
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "B7 is a diesel fuel that consists of fossil diesel fuel and up to 7 % biodiesel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "B7 is a diesel fuel that consists of fossil diesel fuel and up to 7 % biodiesel and that is liquid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
         rdfs:label "B7"@en
@@ -8428,7 +8429,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
     SubClassOf: 
         OEO_00010242,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000071)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000183)
+         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000183),
+        OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00010449
@@ -8460,23 +8462,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
             (OEO_00000146
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140003))
     
-   
-Class: OEO_00010455
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon capture and storage technology is a technology that describes how to combine artificial objects and a carbon capture and storage process in a specific way to permanently store CO2."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS technology"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1760
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
-        rdfs:label "carbon capture and storage technology"@en
-
-  SubClassOf: 
-        OEO_00000407,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00000061
-             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010141))
-             
-
+    
 Class: OEO_00010451
 
     Annotations: 
@@ -8500,8 +8486,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
     SubClassOf: 
         OEO_00140127,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010451
-
-
+    
+    
 Class: OEO_00010453
 
     Annotations: 
@@ -8526,6 +8512,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1767",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
         OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    
+Class: OEO_00010455
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon capture and storage technology is a technology that describes how to combine artificial objects and a carbon capture and storage process in a specific way to permanently store CO2."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CCS technology"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1760
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
+        rdfs:label "carbon capture and storage technology"@en
+    
+    SubClassOf: 
+        OEO_00000407,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00000061
+             and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010141))
     
     
 Class: OEO_00020001

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8408,7 +8408,11 @@ Class: OEO_00010447
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "E10 is a gasoline fuel that consists of (fossil) gasoline and up to 10 % ethanol and that is liquid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723
+
+Make liquid fuel:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1764
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
         rdfs:label "E10"@en
     
     SubClassOf: 
@@ -8423,7 +8427,11 @@ Class: OEO_00010448
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "B7 is a diesel fuel that consists of fossil diesel fuel and up to 7 % biodiesel and that is liquid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723
+
+Make liquid fuel:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1764
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
         rdfs:label "B7"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Add axioms so that `B7` and `E10` can be inferred as subclasses of `blended liquid fuels`.

## Type of change (CHANGELOG.md)

### Update
Add axiom `'has normal state of matter' value liquid` and extend definitions of: 
- `B7`
- `B10`

## Workflow checklist

### Automation
Closes #1764

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
