### PR TITLE
metadata / data descriptor #1548

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is connected to, has sink, has source (#1762)
 - carbon capture and storage technology (#1768)
 - temperature, pressure (#1767)
+- data descriptor (#1775)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -706,14 +706,17 @@ Class: OEO_00000119
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A data descriptor is an information content entity that contains additional information about some data.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "metadata",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/612
-		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724
-		move to oeo-shared
-		issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-		rework module structure 
-		issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-		pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724	move to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+rework module structure 	
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+add alternative label \"metadata\"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1548
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771",
         rdfs:label "data descriptor"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -716,7 +716,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 add alternative label \"metadata\"
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1548
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1775",
         rdfs:label "data descriptor"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

based on #1548 

## Type of change (CHANGELOG.md)

### Update
- `data descriptor` gets the alternative label `metadata`

## Workflow checklist

### Automation
Closes #1548

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
