### PR TITLE
clean oeo import edits

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -9,7 +9,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1700232911492" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1700232911492" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1701421100632" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1701421100632" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -9,7 +9,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1701421100632" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1701421100632" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1701422767391" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1701422767391" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -356,6 +356,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1754</obo:IAO_
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
+        <obo:IAO_0000233>add axiom has copyright license
+issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
+pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
+
+Delete axiom has (copyright) licence:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
     </owl:Class>
     
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -294,24 +294,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00000150 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00000150"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020143 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020143"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020187 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
@@ -326,14 +308,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000009 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000009">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00140002"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020143"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
     
 
 
@@ -362,19 +337,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/BFO_0000020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000020">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010121"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00000150"/>
-                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>add bearer axiom to oeo-import-edits
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>
@@ -397,12 +359,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-                <owl:someValuesFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00020187"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -330,7 +330,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
+        <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+move axiom to oeo-model
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1738</obo:IAO_0000233>
+    </owl:Class>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -78,24 +78,6 @@ Currently, it covers the `ro-extracted.owl`-file which is a subset of the Relati
     
 
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010121 -->
-
-    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010121"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020188 -->
-
-    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020188"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00140002 -->
-
-    <owl:ObjectProperty rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00140002"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/BFO_0000050 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
@@ -315,12 +297,6 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <!-- http://purl.obolibrary.org/obo/BFO_0000016 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://openenergy-platform.org/ontology/oeo/OEO_00010121"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000233>add bearer axiom to oeo-import-edits
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -300,21 +300,9 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00010412 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00010412"/>
-    
-
-
     <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020143 -->
 
     <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020143"/>
-    
-
-
-    <!-- http://openenergy-platform.org/ontology/oeo/OEO_00020186 -->
-
-    <owl:Class rdf:about="http://openenergy-platform.org/ontology/oeo/OEO_00020186"/>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -49,6 +49,12 @@ Currently, it covers the `ro-extracted.owl`-file which is a subset of the Relati
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233"/>
@@ -449,6 +455,17 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1741</obo:IAO_0000233>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
+        <obo:IAO_0000115>A data item is an information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.</obo:IAO_0000115>
+        <obo:IAO_0000119>http://www.ontobee.org/ontology/IAO?iri=http://purl.obolibrary.org/obo/IAO_0000027</obo:IAO_0000119>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A data item is an information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.</owl:annotatedTarget>
+        <obo:IAO_0000233>issue: https://github.com/OpenEnergyPlatform/ontology/issues/823
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/826</obo:IAO_0000233>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
         <obo:IAO_0000233>add subset of relation below &apos;causally related to&apos;
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -334,11 +334,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
-        <obo:IAO_0000233>Add &apos;has licence&apos; axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547</obo:IAO_0000233>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010"/>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -296,11 +296,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000016 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
-        <obo:IAO_0000233>add bearer axiom to oeo-import-edits
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016"/>
     
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -541,6 +541,13 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000148>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000010>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has licence' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
+move axiom to oeo-model
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1738"
+    
     SubClassOf: 
         OEO_00020188 some OEO_00020187
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -541,6 +541,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000148>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000010>
 
+    SubClassOf: 
+        OEO_00020188 some OEO_00020187
+    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000027>
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -541,13 +541,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000148>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000010>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Add 'has licence' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547
-move axiom to oeo-model
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1738"
-    
     SubClassOf: 
         OEO_00020188 some OEO_00020187
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -681,6 +681,11 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000006>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "move axiom to oeo-physical
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
     SubClassOf: 
         OEO_00140002 some OEO_00020143
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -683,8 +683,8 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "move axiom to oeo-physical
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1738
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1776"
     
     SubClassOf: 
         OEO_00140002 some OEO_00020143

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -681,6 +681,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000006>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
+    SubClassOf: 
+        OEO_00140002 some OEO_00020143
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000015>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -363,6 +363,14 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add bearer axiom to oeo-import-edits
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
+move bearer axiom to oeo-shared
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1738
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1776"
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000020>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1057,15 +1057,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/826"
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000233> "add axiom has copyright license
-issue https://github.com/OpenEnergyPlatform/ontology/issues/1061
-pull request https://github.com/OpenEnergyPlatform/ontology/pull/1090
-
-Delete axiom has (copyright) licence:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1275
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1547"
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000088>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1047,13 +1047,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000148>
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000027>
 
-    Annotations: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/823
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/826"
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A data item is an information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "http://www.ontobee.org/ontology/IAO?iri=http://purl.obolibrary.org/obo/IAO_0000027"
-    
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1001,6 +1001,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000015>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000016>
 
+    SubClassOf: 
+        OEO_00010121 some <http://purl.obolibrary.org/obo/BFO_0000004>
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000017>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1010,6 +1010,10 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000019>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000020>
 
+    SubClassOf: 
+        OEO_00010121 some 
+            (OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>)
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 


### PR DESCRIPTION
## Summary of the discussion

After restructuring and rearranging the modules, as well as updating IAO import and removing OMO import, tidying oeo-import-edits becomes necessary.
The changes for each entity are minor and refer to the place where an axiom is stored. Therefore I chose not to describe them in CHANGELOG.
see #1738
## Type of change (CHANGELOG.md)

### Update
- place axioms in the right modules
- put term tracker items of imported entities in oeo-import-edits


## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
