### PR TITLE
tidy ro artifacts #1738

### DIFF
--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -167,6 +167,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0000087 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087">
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0001015 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001015">
@@ -329,6 +337,12 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_0000233>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023"/>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -210,6 +210,15 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0002222 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002222">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002223 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002223">
@@ -256,6 +265,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002233">
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002352"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
     </owl:ObjectProperty>
     
 
@@ -333,6 +343,12 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <!-- http://purl.obolibrary.org/obo/BFO_0000009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -127,6 +127,8 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056">
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
         <obo:IAO_0000233>make inverse of has participant
 issue https://github.com/OpenEnergyPlatform/ontology/issues/979
 pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0000233>
@@ -137,6 +139,7 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <!-- http://purl.obolibrary.org/obo/RO_0000057 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
         <obo:IAO_0000233>make inverse of participates in
 issue https://github.com/OpenEnergyPlatform/ontology/issues/979
@@ -312,6 +315,12 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
     
 
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -161,6 +161,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/RO_0000086 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000086">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
     </owl:ObjectProperty>
     

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -175,6 +175,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0000091 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000091">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0001015 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001015">

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -297,6 +297,31 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0002501 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002501">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002501"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <obo:IAO_0000233>add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</obo:IAO_0000233>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002501"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <obo:IAO_0000233>add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</obo:IAO_0000233>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002615 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002615">

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -149,6 +149,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0000085 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000085">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0000086 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000086">
@@ -325,6 +334,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485</obo:IAO_
     <!-- http://purl.obolibrary.org/obo/BFO_0000031 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000034 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000034"/>
     
 
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -163,20 +163,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002427>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002501>
 
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -109,9 +109,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -106,12 +106,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -115,12 +115,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001015>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -184,12 +184,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001025>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002222>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002223>
 
@@ -205,9 +199,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002230>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -151,18 +151,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -184,12 +184,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000016>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0001015>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -166,12 +166,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000034>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -169,9 +169,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000002>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -181,9 +181,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
     Domain: 
         OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
     
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -237,20 +237,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002427>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002501>
 
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 


### PR DESCRIPTION
## Summary of the discussion

see #1738 

- move axioms (domain, range, inverse) of imported RO relations, that were stored in oeo-shared / oeo-shared-axioms, to oeo-import-edits
- I don't update the CHANGELOG nor term trackers, since they are minor changes that only concern the place, where the axioms are stored. No content-related changes were made.
- I also left out obvious OEO-extensions like the domain `energy or independent continuant` for now

## Type of change (CHANGELOG.md)

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
