### PR TITLE
added area classification concepts from regional planning #1766

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - energy transfer function, energy transformation function and subclasses (#1785)
 - effort sharing, feed-in tariff, levy, market premium (#1786)
 - policy instrument (#1791)
+- region of relevance (#1791)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
+- priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)
 - effort sharing, feed-in tariff, levy, market premium (#1786)
+- policy instrument (#1791)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3156,6 +3156,8 @@ Class: OEO_00360026
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region role is a role of a region of interest that gives high priority to building wind park projects, excluding building projects that are not compatible with this priority."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region role"@en
     
     SubClassOf: 
@@ -3166,6 +3168,8 @@ Class: OEO_00360027
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region role is a role of a region of interest that is prioritised to be used for wind park projects during the planning process, without excluding incompatible building projects.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "conditionally reserved region role"@en
     
     SubClassOf: 
@@ -3176,6 +3180,8 @@ Class: OEO_00360028
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region role is a role of a region of interest that designates an agreeable location for wind park projects within the planning region while excluding the building of wind park projects in the rest of the planning region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "suitable region role"@en
     
     SubClassOf: 
@@ -3186,6 +3192,9 @@ Class: OEO_00360029
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region is a region of relevance that has the priority region role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Vorranggebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region"@en
     
     EquivalentTo: 
@@ -3200,6 +3209,9 @@ Class: OEO_00360030
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region is a region of relevance that has the conditionally reserved region role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Vorbehaltsgebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "conditionally reserved region"@en
     
     EquivalentTo: 
@@ -3214,6 +3226,9 @@ Class: OEO_00360031
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region is a region of relevance that has the suitable region role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Eignungsgebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "suitable region"@en
     
     EquivalentTo: 
@@ -3228,6 +3243,9 @@ Class: OEO_00360032
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region with effect of suitable region is a region of relevance that has both the priority region role and the suitable region role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Vorranggebiet mit der Wirkung eines Eignungsgebiets"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region with effect of suitable region"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3152,6 +3152,93 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         OEO_00010121 some OEO_00020033
     
     
+Class: OEO_00360026
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region role is a role of a region of interest that gives high priority to building wind park projects, excluding building projects that are not compatible with this priority."@en,
+        rdfs:label "priority region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360027
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region role is a role of a region of interest that is prioritised to be used for wind park projects during the planning process, without excluding incompatible building projects.",
+        rdfs:label "conditionally reserved region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region role is a role of a region of interest that designates an agreeable location for wind park projects within the planning region while excluding the building of wind park projects in the rest of the planning region."@en,
+        rdfs:label "suitable region role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00360029
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region is a region of relevance that has the priority region role."@en,
+        rdfs:label "priority region"@en
+    
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360026)
+    
+    SubClassOf: 
+        OEO_00360020
+    
+    
+Class: OEO_00360030
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region is a region of relevance that has the conditionally reserved region role."@en,
+        rdfs:label "conditionally reserved region"@en
+    
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360027)
+    
+    SubClassOf: 
+        OEO_00360020
+    
+    
+Class: OEO_00360031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region is a region of relevance that has the suitable region role."@en,
+        rdfs:label "suitable region"@en
+    
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360028)
+    
+    SubClassOf: 
+        OEO_00360020
+    
+    
+Class: OEO_00360032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region with effect of suitable region is a region of relevance that has both the priority region role and the suitable region role."@en,
+        rdfs:label "priority region with effect of suitable region"@en
+    
+    EquivalentTo: 
+        OEO_00360020
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360026)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360028)
+    
+    SubClassOf: 
+        OEO_00360020
+    
+    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3156,6 +3156,7 @@ Class: OEO_00360026
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region role is a role of a region of interest that gives high priority to building wind park projects, excluding building projects that are not compatible with this priority."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region role"@en
@@ -3168,6 +3169,7 @@ Class: OEO_00360027
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region role is a role of a region of interest that is prioritised to be used for wind park projects during the planning process, without excluding incompatible building projects.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "conditionally reserved region role"@en
@@ -3180,6 +3182,7 @@ Class: OEO_00360028
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region role is a role of a region of interest that designates an agreeable location for wind park projects within the planning region while excluding the building of wind park projects in the rest of the planning region."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "suitable region role"@en
@@ -3193,6 +3196,7 @@ Class: OEO_00360029
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region is a region of relevance that has the priority region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Vorranggebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region"@en
@@ -3210,6 +3214,7 @@ Class: OEO_00360030
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conditionally reserved region is a region of relevance that has the conditionally reserved region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Vorbehaltsgebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "conditionally reserved region"@en
@@ -3227,6 +3232,7 @@ Class: OEO_00360031
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A suitable region is a region of relevance that has the suitable region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Eignungsgebiet"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "suitable region"@en
@@ -3244,6 +3250,7 @@ Class: OEO_00360032
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A priority region with effect of suitable region is a region of relevance that has both the priority region role and the suitable region role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Vorranggebiet mit der Wirkung eines Eignungsgebiets"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "See §7 Absatz 3 ROG: https://www.gesetze-im-internet.de/rog_2008/__7.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "priority region with effect of suitable region"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3081,7 +3081,11 @@ Class: OEO_00360020
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is used in a study or analysis, or is part of spatial planning."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749
+
+updated definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1766
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "region of relevance"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3079,7 +3079,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711",
 Class: OEO_00360020
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is used in a study or analysis."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A region of relevance is a spatial region that is used in a study or analysis, or is part of spatial planning."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1745
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         rdfs:label "region of relevance"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2087,7 +2087,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 reclassify
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1684
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         rdfs:label "policy instrument"@en
     
     SubClassOf: 
@@ -2343,6 +2347,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1748",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000141>
+    
+    
+Class: OEO_00360033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Spatial planning policy is a policy of a German federal state that designates portions of a spatial region to purposes like settlement, infrastructur and sustainability."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1776
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
+        rdfs:label "spatial planning policy"@en
+    
+    SubClassOf: 
+        OEO_00140150
     
     
 Individual: OEO_00010122

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2068,7 +2068,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778",
 Class: OEO_00140151
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is a plan specification of an organisation (e.g. a government) that promotes transformative measures.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A policy instrument is an action specification of an organisation (e.g. a government) that promotes transformative measures."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797


### PR DESCRIPTION
To describe data sets, different areas of German regional planning had to be added. These are: 
**Vorranggebiete**
**Vorbehaltsgebiete**
**Eignungsgebiete**
**Vorranggebiete mit der Wirkung von Eignungsgebieten** 
After finding English labels and definitions we decided to implement these as roles and corresponding equivalent regions, where `priority region with effect of suitable region` has not one corresponding roles but inheres the roles of priority regions and suitable regions. 
Since the concept of spatial planning policies was not yet in the ontology, we decided to add it. 
While working on the issue, we realised that the definition of `policy instrument` was outdated and decided to change it. 
For a more detailed overview, see issue #1766. 

### Add
- priority region role 
- priority region
- conditionally reserved region role
- conditionally reserved region
- suitable region role
- suitable region
- priority region with effect of suitable region
- spatial planning policy 

### Change 
- policy instrument 

## Workflow checklist

### Automation
Closes #1766 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
