### PR TITLE
Add `missing value reason` and `notation key` #1765

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
+- missing value reason, notation key (#1795)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1664,6 +1664,8 @@ Class: OEO_00010468
         <http://purl.obolibrary.org/obo/IAO_0000118> "absent data"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "missing data"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from http://purl.obolibrary.org/obo/NCIT_C48655",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1765
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1795",
         rdfs:label "missing value reason"@en
     
     SubClassOf: 
@@ -1674,6 +1676,8 @@ Class: OEO_00010469
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A notation key is a missing value reason defined by the UNFCCC to indicate why data is missing."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1765
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1795",
         rdfs:label "notation key"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1657,6 +1657,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1255",
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
     
+Class: OEO_00010468
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A missing value reason is a data item that is used to indicate that data is not available and to provide a specific reason explaining why a meaningful value is not available."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "absent data"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "missing data"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from http://purl.obolibrary.org/obo/NCIT_C48655",
+        rdfs:label "missing value reason"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000027>
+    
+    
+Class: OEO_00010469
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A notation key is a missing value reason defined by the UNFCCC to indicate why data is missing."@en,
+        rdfs:label "notation key"@en
+    
+    SubClassOf: 
+        OEO_00010468
+    
+    
 Class: OEO_00020011
 
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Add data items to indicate missing data values.

## Type of change (CHANGELOG.md)

### Add
* `missing value reason`: _A missing value reason is a data item that is used to indicate that data is not available and to provide a specific reason explaining why a meaningful value is not available._
Alternative labels: `missing data` and `absent data`
* `notation key`: _A notation key is a missing value reason defined by the UNFCCC to indicate why data is missing._

## Workflow checklist

### Automation
Closes #1765

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
