### PR TITLE
Update `MMR sector division` and `EU emission sector division` #1796

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
 - priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
-- - missing value reason, notation key (#1795)
+- missing value reason, notation key (#1795)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)
 - effort sharing, feed-in tariff, levy, market premium (#1786)
 - policy instrument (#1791)
 - region of relevance (#1791)
+- MMR sector division, EU emission sector division (#1797)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -589,7 +589,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+Update hierarchy:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1796
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1797",
         rdfs:label "EU emission sector division"@en
     
     SubClassOf: 
@@ -2940,7 +2944,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+Update hierarchy and add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1796
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1797",
         rdfs:label "MMR sector division"@en
     
     Types: 

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -579,7 +579,7 @@ Class: OEO_00010117
 Class: OEO_00010130
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU emission sector division is used in the EU climate policy.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An EU emission sector division is an EU legislation sector division used in the EU climate policy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
 
@@ -593,7 +593,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "EU emission sector division"@en
     
     SubClassOf: 
-        OEO_00000368
+        OEO_00010403
     
     
 Class: OEO_00010227
@@ -2933,7 +2933,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/967"
 Individual: OEO_00010204
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is a sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The MMR sector division is an EU emission sector division defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014 https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32014R0749&from=EN#d1e32-67-1",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/928
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/944
@@ -2944,7 +2944,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
         rdfs:label "MMR sector division"@en
     
     Types: 
-        OEO_00000368
+        OEO_00010130
     
     Facts:  
      OEO_00000503  OEO_00000242

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -876,6 +876,12 @@ Individual: OEO_00010132
 Individual: OEO_00010133
 
     
+Individual: OEO_00010204
+
+    Facts:  
+     OEO_00000501  OEO_00010129
+    
+    
 Individual: OEO_00010205
 
     


### PR DESCRIPTION
## Summary of the discussion

Update hierarchy and axioms of some sector divisions.

## Type of change (CHANGELOG.md)

### Update
* Make `MMR sector division` an instance of `EU emission sector division`: _The MMR sector division is a**n EU emission sector division** defined in Annex XII, Table 1 of Commission Implementing Regulation (EU) 749/2014. It uses CRF sectors (IPCC 2006) and adds further sectors._ Further add the axiom `'MMR sector division' 'is used by' 'EU climate policy'` to make it an inferred subclass of `CRF-based sector division`.
* Make `EU emission sector division` a subclass of `EU legislation sector division`: _An EU emission sector division is **an EU legislation sector division** that is used in the EU climate policy._

## Workflow checklist

### Automation
Closes #1796

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
