### PR TITLE
Improve individual `German energy balance sector division` #1793

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - policy instrument (#1791)
 - region of relevance (#1791)
 - MMR sector division, EU emission sector division (#1797)
+- German energy balance sector division (#1798)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -59,6 +59,9 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:identifier
 
     
+AnnotationProperty: dc:source
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -794,7 +797,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000193
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The German energy balance sector division is an energy balance used by AG Energiebilanzen (Working Group on Energy Balances) to compile the official national German energy balances.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Change type and label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
+move to oeo-sector 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
+        
+            Annotations: dc:source "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115"
+        rdfs:comment "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.
 
 Als Energieträger werden alle Quellen oder Stoffe bezeichnet, in denen Energie mechanisch, thermisch, chemisch oder physikalisch gespeichert ist. Fünf Kerngruppe werden bei der Energiebilanz unterschieden:
 
@@ -819,16 +833,7 @@ In der Primärenergiebilanz werden die Energieträger mit ihrem Mengenaufkommen 
     inländische Gewinnung von Energieträgern,
     Außenhandel mit Energieträgern, unterteilt nach Einfuhr und Ausfuhr,
     Hochseebunkerungen (Heizöl, Dieselkraftstoff und Schmierstoffe für die nationale und internationale Seeschifffahrt in deutschen Häfen. Ohne Lieferungen an Binnen- und Küstenmotorschiffe und Fischerei, die zum Sektor Verkehr (Endenergieverbrauch) zählen.)
-    Bestandsveränderungen, getrennt erfasst nach Bestandsentnahmen und -aufstockungen",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "Change type and label:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
-
-move to oeo-sector 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
+    Bestandsveränderungen, getrennt erfasst nach Bestandsentnahmen und -aufstockungen"@de,
         rdfs:label "German energy balance sector division"@en
     
     Types: 

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -797,7 +797,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
 Individual: OEO_00000193
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The German energy balance sector division is an energy balance used by AG Energiebilanzen (Working Group on Energy Balances) to compile the official national German energy balances.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The German energy balance sector division is an energy balance used by AG Energiebilanzen (Working Group on Energy Balances) to compile the official national German energy balances."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "The German Energy Balance is managed by the 'AG Energiebilanzen', where aso the energy balances can be found: https://ag-energiebilanzen.de/",
         <http://purl.obolibrary.org/obo/IAO_0000233> "Change type and label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1400
@@ -805,7 +805,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1463
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+New definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1793
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1798",
         
             Annotations: dc:source "https://de.wikipedia.org/w/index.php?title=Energiebilanz_(Energiewirtschaft)&oldid=176259115"
         rdfs:comment "Das Schema der Energiebilanzen umfasst eine Matrix von 33 Spalten und 68 Zeilen (einschließlich der Summenspalten und -zeilen). In der horizontalen Gliederung (Spalten) werden die Energieträger ausgewiesen, die der energetischen und nichtenergetischen Nutzung dienen. In der vertikalen Gliederung (Zeilen) werden für die jeweiligen Energieträger Aufkommen, Umwandlung und Verwendung erfasst.


### PR DESCRIPTION
## Summary of the discussion

Make definition of `German energy balance sector division` Aristotelian.

## Type of change (CHANGELOG.md)

### Update
- Convert existing definition to a rdf:comment.
- Add new definition: _The German energy balance sector division is an energy balance used by AG Energiebilanzen (Working Group on Energy Balances) to compile the official national German energy balances._

## Workflow checklist

### Automation
Closes #1793

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
