### PR TITLE
Add class `forecasting` #1691

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - region of relevance (#1791)
 - MMR sector division, EU emission sector division (#1797)
 - German energy balance sector division (#1798)
-- forecasting (#1799)
+- forecasting model calculation (#1799)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - policy instrument (#1791)
 - region of relevance (#1791)
 - MMR sector division, EU emission sector division (#1797)
+- forecasting (#1799)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1684,6 +1684,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1795",
         OEO_00010468
     
     
+Class: OEO_00010470
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Forecasting is a model calculation that produces a forecast.",
+        rdfs:label "forecasting"@en
+    
+    SubClassOf: 
+        OEO_00000275,
+        OEO_00140094 some OEO_00010411
+    
+    
 Class: OEO_00020011
 
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1688,6 +1688,8 @@ Class: OEO_00010470
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Forecasting is a model calculation that produces a forecast.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1691
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1799",
         rdfs:label "forecasting"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1687,10 +1687,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1795",
 Class: OEO_00010470
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Forecasting is a model calculation that produces a forecast.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A forecasting model calculation is a model calculation that produces a forecast."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "forecasting"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1691
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1799",
-        rdfs:label "forecasting"@en
+        rdfs:label "forecasting model calculation"@en
     
     SubClassOf: 
         OEO_00000275,


### PR DESCRIPTION
## Summary of the discussion

## Type of change (CHANGELOG.md)

### Add
- Class: `forecasting model calculation`: _A forecasting model calculation is a model calculation that produces a forecast._
- Alternative label: `forecasting`
- Axiom: `'forecasting model calculation' 'has information output' some forecast`

## Workflow checklist

### Automation
Closes #1691

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
