### PR TITLE
Add `non-energy use technology` #1773

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
 - priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
 - missing value reason, notation key (#1795)
+- non-energy use technology (#1803)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - region of relevance (#1791)
 - MMR sector division, EU emission sector division (#1797)
 - German energy balance sector division (#1798)
+- non-energy use (#1803)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8582,6 +8582,8 @@ Class: OEO_00010471
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-energy use technology is a technology that describes among other things how to combine non-energy use of energy carriers with other processes and artificial objects or other material entities in a specific way."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption technology"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
         rdfs:label "non-energy use technology"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8577,6 +8577,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010141))
     
     
+Class: OEO_00010471
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-energy use technology is a technology that describes among other things how to combine non-energy use of energy carriers with other processes and artificial objects or other material entities in a specific way."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption technology"@en,
+        rdfs:label "non-energy use technology"@en
+    
+    EquivalentTo: 
+        OEO_00000407
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010211))
+    
+    SubClassOf: 
+        OEO_00000407
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8585,7 +8585,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
 Class: OEO_00010471
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-energy use technology is a technology that describes among other things how to combine non-energy use of energy carriers with other processes and artificial objects or other material entities in a specific way."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-energy use technology is a technology that describes among other things how to combine the consumption of energy carriers for non-energy use with other processes and artificial objects or other material entities in a specific way."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption technology"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6106,6 +6106,7 @@ Class: OEO_00010211
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
 
@@ -6118,7 +6119,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+Add alternative label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
         rdfs:label "non-energy use"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

Implement `non-energy use technology` as equivalent class.

## Type of change (CHANGELOG.md)

### Add
- Class: `non-energy use technology`
  - Definition: _A non-energy use technology is a technology that describes among other things how to combine non-energy use of energy carriers with other processes and artificial objects or other material entities in a specific way._
  - Alternative label: `non-energy consumption technology`
  - Axiom: `'non energy use technology' EquivalentTo: technology and ('is about' some ('participates in' some 'non-energy use'))`

### Update
- Add alternative label `non-energy consumption` to class `non-energy use`.

## Workflow checklist

### Automation
Closes #1773

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
