### PR TITLE
Relabel `API` and `GUI` #1804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - region of relevance (#1791)
 - MMR sector division, EU emission sector division (#1797)
 - German energy balance sector division (#1798)
+- API -> application programming interface; GUI -> graphical user interface (#1810)
 
 ### Removed
 

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -9,7 +9,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1701427820472" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1701427820472" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1706110158375" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1706110158375" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -606,8 +606,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
 Class: OEO_00000059
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An API (Application Programming interface) is a software interface allowing two Software applications to communicate with each other.",
-        rdfs:label "API"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An application programming interface (API) is a software interface allowing two Software applications to communicate with each other."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "API"@en,
+        rdfs:label "application programming interface"@en
     
     SubClassOf: 
         OEO_00000239
@@ -864,8 +865,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/584",
 Class: OEO_00000202
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A GUI (Graphical user interface) is a software interface allowing users to communicate with a software application through a graphical window.",
-        rdfs:label "GUI"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A graphical user interface (GUI) is a software interface allowing users to communicate with a software application through a graphical window."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GUI"@en,
+        rdfs:label "graphical user interface"@en
     
     SubClassOf: 
         OEO_00000239

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -608,6 +608,9 @@ Class: OEO_00000059
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An application programming interface (API) is a software interface allowing two Software applications to communicate with each other."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "API"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Change label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1804
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1810",
         rdfs:label "application programming interface"@en
     
     SubClassOf: 
@@ -867,6 +870,9 @@ Class: OEO_00000202
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A graphical user interface (GUI) is a software interface allowing users to communicate with a software application through a graphical window."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GUI"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Change label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1804
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1810",
         rdfs:label "graphical user interface"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -606,7 +606,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
 Class: OEO_00000059
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An application programming interface (API) is a software interface allowing two Software applications to communicate with each other."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An application programming interface (API) is a software interface allowing two software applications to communicate with each other."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "API"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "Change label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1804


### PR DESCRIPTION
## Summary of the discussion

API and GUI are abbreviations and thus not a proper labels.

## Type of change (CHANGELOG.md)

### Update
API
* Relabel `API` to `application programming interface`
* Add `API` as alternative label
* Improve definition: _An ~API (Application Programming interface)~ **application programming interface (API)** is a software interface allowing two ~S~**s**oftware applications to communicate with each other._

GUI
* Relabel `GUI` to `graphical user interface`
* Add `GUI` as alternative label
* Improve definition: _A ~GUI (Graphical user interface)~ **graphical user interface (GUI)** is a software interface allowing users to communicate with a software application through a graphical window._

## Workflow checklist

### Automation
Closes #1804

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
