### PR TITLE
Add object properties for composed units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
 - priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
 - missing value reason, notation key (#1795)
-- has unit numerator, hasunit denominator and subproperties (#1816)
+- has unit numerator, has unit denominator and subproperties (#1816)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
 - priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
 - missing value reason, notation key (#1795)
+- has unit numerator, hasunit denominator and subproperties (#1816)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,95 @@
-﻿<a href="https://openenergy-platform.org/"><img align="right" width="200" height="200" src="https://avatars2.githubusercontent.com/u/37101913?s=400&u=9b593cfdb6048a05ea6e72d333169a65e7c922be&v=4" alt="OpenEnergyPlatform"></a>
+<a href="https://openenergy-platform.org/"><img align="right" width="200" height="200" src="https://avatars2.githubusercontent.com/u/37101913?s=400&u=9b593cfdb6048a05ea6e72d333169a65e7c922be&v=4" alt="OpenEnergyPlatform"></a>
 
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/OpenEnergyPlatform/ontology)
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/areleu/6d00affa9fbc89c79684d62091d96551/raw/open_energy_ontology__heads_feature-1419-competency-question-coverage-report.json)
 
-# Open Energy Family – Open Energy Ontology Extended (OEOX)
+# Open Energy Family - Open Energy Ontology (OEO)
 
-The Open Energy Ontology Extended (OEOX) extends this Open Energy Ontology. It is contains compositions of terms that are too specific for the OEO.
+Developing a common ontology for the domain of energy system analysis.
+
+## Introduction
+
+The **Open Energy Ontology (OEO)** is a domain ontology of the energy system analysis context. It is developed as part of the [Open Energy Family](https://github.com/OpenEnergyPlatform). The OEO is published on GitHub under an open source license. The language used is the Manchester OWL Syntax, which was chosen because it is user-friendly for editing and viewing differences of edited files. The OEO is constantly being extended. The first version of the OEO has been released on June 11th 2020. A Steering Committee (OEO-SC) was created to accompany the development, increase awareness of the ontology and include it in current projects.
+
+## Scope of this ontology
+
+This domain ontology is a collaborative effort to represent the context of **energy system analysis** based on standard terminologies used by human experts in this field of research. It is designed to improve transparency and facilitate comparability and transferability of energy system modelling and scenario analysis. This ontology makes use of the Basic Formal Ontology ([BFO](https://github.com/OpenEnergyPlatform/ontology/wiki/BFO-Upper-Ontology-Classes)) and its principles. It re-uses several other ontologies as described in the [GitHub Wiki](https://github.com/OpenEnergyPlatform/ontology/wiki/use-of-external-ontologies).
 
 ## License / Copyright / Citation
 
-This repository is licensed under `CC0 1.0 Universal (CC0 1.0) Public Domain Dedication`.
+This repository is licensed under `CC0 1.0 Universal (CC0 1.0) Public Domain Dedication`. <br>
+For a scientific citation please see the [CITATION.cff](CITATION.cff). <br>
+
+To cite a specific class of the ontology and its definition please use the following convention:
+> 'class label' (FUll-URI) from the [Open Energy Ontology (OEO)](https://github.com/OpenEnergyPlatform/ontology)
+
+Example:
+> 'energy system' (https://openenergy-platform.org/ontology/oeo/OEO_00030024) from the [Open Energy Ontology (OEO)](https://github.com/OpenEnergyPlatform/ontology)
+
+
+## Releases and installation
+
+The latest version of the OEO can be accessed on the [Open Energy Platform](https://openenergy-platform.org/ontology/oeo) and the [Master Branch](https://github.com/OpenEnergyPlatform/ontology/tree/master). <br>
+All released versions can be downloaded directly from the [GitGub Releases](https://github.com/OpenEnergyPlatform/ontology/releases/). <br>
+The currently developed version is available on the default [dev Branch](https://github.com/OpenEnergyPlatform/ontology/).
+
+The source code of the ontology is found in the folder `src/ontology/` <br>
+The main file is `src/ontology/oeo.omn` <br>
+
+All own modules are collected in the folder `src/ontology/edits/` <br>
+The following diagram illustrates the modular file structure of the OEO. It depicts the import and file hierarchy from external imports (right) to the main file oeo.omn (left).
+![Structure of the OEO](https://user-images.githubusercontent.com/38690039/275459325-1c6eb63d-287a-45b5-a107-839c8c09bfe0.png)
+
+The imported modules are under `src/ontology/imports/` <br>
+To get an overview of the existing modules, take a look at the following wiki article: [GitHub Wiki](https://github.com/OpenEnergyPlatform/ontology/wiki/Modules-of-the-OEO)
+We recommend to use the software [Protégé](https://protege.stanford.edu/) to open and edit the ontology. Additionally, an ontology viewer is available on the [Open Energy Platform](https://openenergy-platform.org/viewer/oeo/).
+
+
+## Collaboration
+This is an interdisciplinary open source project, help is always welcome. <br>
+Everyone is invited to develop this repository with good intentions.
+
+The development of the ontology happens mainly on [GitHub](https://github.com/OpenEnergyPlatform/ontology) and is supplemented by regular (online) developer meetings to review the progress and discuss more complicated topics. 
+
+If you're new to GitHub or ontologies check out our ["How to participate"](https://github.com/OpenEnergyPlatform/ontology/wiki/Welcome!-How-to-participate) article for some first advice and helpful links.
+The workflow is described in the [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CONTRIBUTING.md) file. Please check it out before you start working on this project. Points that are not clear in the file can be discussed in a [GitHub Issue](https://github.com/OpenEnergyPlatform/ontology/issues/new/choose).
+Please read the [GitHub Wiki](https://github.com/OpenEnergyPlatform/ontology/wiki) for more information about the ontology, its standards, its best practice principles and the BFO classification.
+ 
+## Teams
+Experts in ontology engineering, economy and energy-system modelling work together collaboratively.<br>
+We combine domain knowledge with knowledge about how an ontology should be designed.
+
+If you have a specific question about ontology design, energy system modelling or economy (in context of this ontology), you can [tag](https://github.com/OmahaGirlsWhoCode/OmahaGirlsWhoCode/wiki/How-to-tag-someone-in-a-pull-request) one of these teams (or persons) to notify its members that you need their feedback or help.
+
+The OEO is organised in a general team and several [subteams](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev/teams):
+ 
+- [@oeo-dev](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-dev)
+    - All developers of the OEO
+
+### Organisation
+
+- [@oeo-community-manager](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-community-manager)
+    - Contact point for personal and team related concerns
+- [@oeo-concept-owner](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-concept-owner)
+    - Strategic and long-term development and coordination of developers
+- [@oeo-steering-committee](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-steering-committee)
+    - Members of the [Steering Committee (OEO-SC)](https://openenergy-platform.org/ontology/oeo-steering-committee/)
+- [@oeo-release-team](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-release-team)
+    - Coordinates the periodic releases
+
+### Domain Experts
+
+- [@oeo-domain-expert-energy-modelling](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-energy-modelling)
+    - Knowledge related to energy system modelling and simulation
+- [@oeo-domain-expert-economy](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-economy)
+    - Knowledge related to economic system, costs, monetary issues
+- [@oeo-domain-expert-linked-open-data](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-linked-open-data)
+    - Knowledge related to linked open data
+- [@oeo-domain-expert-meteorology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-domain-expert-meteorology)
+    - Knowledge related to meteorology and weather
+
+### Ontology experts
+
+- [@oeo-general-expert-formal-ontology](https://github.com/orgs/OpenEnergyPlatform/teams/oeo-general-expert-formal-ontology)
+    - Knowledge related to formal ontology expertise and BFO

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -688,6 +688,10 @@ ObjectProperty: OEO_00010473
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has linear unit numerator"@en
     
     SubPropertyOf: 
@@ -713,6 +717,10 @@ ObjectProperty: OEO_00010474
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has squared unit numerator"@en
     
     SubPropertyOf: 
@@ -738,6 +746,10 @@ ObjectProperty: OEO_00010475
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 3."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has cubed unit numerator"@en
     
     SubPropertyOf: 
@@ -763,7 +775,7 @@ ObjectProperty: OEO_00010476
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit has is composed of at least two other units. Examples are:
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
 m/s has a linear numerator metre and a linear denominator second.
 kg/m³ has a linear numerator kilogram and a cubed denominator metre.
 Wh has two linear numerators: Watt and hour",
@@ -788,6 +800,10 @@ ObjectProperty: OEO_00010477
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has linear unit denominator"@en
     
     SubPropertyOf: 
@@ -813,6 +829,10 @@ ObjectProperty: OEO_00010478
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has squared unit denominator"@en
     
     SubPropertyOf: 
@@ -838,6 +858,10 @@ ObjectProperty: OEO_00010479
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A with exponent 3."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has cubed unit denominator"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -661,6 +661,8 @@ ObjectProperty: OEO_00010472
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit has is composed of at least two other units. Examples are:
 m/s has a linear numerator metre and a linear denominator second.
 kg/m³ has a linear numerator kilogram and a cubed denominator metre.

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -674,6 +674,8 @@ ObjectProperty: OEO_00010473
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has linear unit numerator"@en
     
     SubPropertyOf: 
@@ -690,6 +692,8 @@ ObjectProperty: OEO_00010474
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has squared unit numerator"@en
     
     SubPropertyOf: 
@@ -700,6 +704,8 @@ ObjectProperty: OEO_00010475
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 3."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has cubed unit numerator"@en
     
     SubPropertyOf: 
@@ -710,6 +716,8 @@ ObjectProperty: OEO_00010476
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has unit denominator"@en
     
     SubPropertyOf: 
@@ -720,6 +728,8 @@ ObjectProperty: OEO_00010477
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has linear unit denominator"@en
     
     SubPropertyOf: 
@@ -730,6 +740,8 @@ ObjectProperty: OEO_00010478
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has squared unit denominator"@en
     
     SubPropertyOf: 
@@ -740,6 +752,8 @@ ObjectProperty: OEO_00010479
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A with exponent 3."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
         rdfs:label "has cubed unit denominator"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -706,6 +706,46 @@ ObjectProperty: OEO_00010475
         OEO_00010472
     
     
+ObjectProperty: OEO_00010476
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A."@en,
+        rdfs:label "has unit denominator"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+    
+    
+ObjectProperty: OEO_00010477
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
+        rdfs:label "has linear unit denominator"@en
+    
+    SubPropertyOf: 
+        OEO_00010476
+    
+    
+ObjectProperty: OEO_00010478
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
+        rdfs:label "has squared unit denominator"@en
+    
+    SubPropertyOf: 
+        OEO_00010476
+    
+    
+ObjectProperty: OEO_00010479
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A with exponent 3."@en,
+        rdfs:label "has cubed unit denominator"@en
+    
+    SubPropertyOf: 
+        OEO_00010476
+    
+    
 ObjectProperty: OEO_00020056
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -663,6 +663,9 @@ ObjectProperty: OEO_00010472
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/BFO_0000051>
     
+    DisjointWith: 
+        OEO_00010476
+    
     Domain: 
         <http://purl.obolibrary.org/obo/UO_0000000>
     
@@ -680,6 +683,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     
     SubPropertyOf: 
         OEO_00010472
+    
+    DisjointWith: 
+        OEO_00010474,
+        OEO_00010475,
+        OEO_00010477,
+        OEO_00010478,
+        OEO_00010479
     
     Domain: 
         <http://purl.obolibrary.org/obo/UO_0000000>
@@ -699,6 +709,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     SubPropertyOf: 
         OEO_00010472
     
+    DisjointWith: 
+        OEO_00010473,
+        OEO_00010475,
+        OEO_00010477,
+        OEO_00010478,
+        OEO_00010479
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 ObjectProperty: OEO_00010475
 
@@ -710,6 +733,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     
     SubPropertyOf: 
         OEO_00010472
+    
+    DisjointWith: 
+        OEO_00010473,
+        OEO_00010474,
+        OEO_00010477,
+        OEO_00010478,
+        OEO_00010479
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 ObjectProperty: OEO_00010476
@@ -723,6 +759,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/BFO_0000051>
     
+    DisjointWith: 
+        OEO_00010472
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 ObjectProperty: OEO_00010477
 
@@ -734,6 +779,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     
     SubPropertyOf: 
         OEO_00010476
+    
+    DisjointWith: 
+        OEO_00010473,
+        OEO_00010474,
+        OEO_00010475,
+        OEO_00010478,
+        OEO_00010479
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 ObjectProperty: OEO_00010478
@@ -747,6 +805,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     SubPropertyOf: 
         OEO_00010476
     
+    DisjointWith: 
+        OEO_00010473,
+        OEO_00010474,
+        OEO_00010475,
+        OEO_00010477,
+        OEO_00010479
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
     
 ObjectProperty: OEO_00010479
 
@@ -758,6 +829,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
     
     SubPropertyOf: 
         OEO_00010476
+    
+    DisjointWith: 
+        OEO_00010473,
+        OEO_00010474,
+        OEO_00010475,
+        OEO_00010477,
+        OEO_00010478
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
     
     
 ObjectProperty: OEO_00020056

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -654,6 +654,58 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
         <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
+ObjectProperty: OEO_00010472
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A."@en,
+        rdfs:label "has unit numerator"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+ObjectProperty: OEO_00010473
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
+        rdfs:label "has linear unit numerator"@en
+    
+    SubPropertyOf: 
+        OEO_00010472
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    
+ObjectProperty: OEO_00010474
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
+        rdfs:label "has squared unit numerator"@en
+    
+    SubPropertyOf: 
+        OEO_00010472
+    
+    
+ObjectProperty: OEO_00010475
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 3."@en,
+        rdfs:label "has cubed unit numerator"@en
+    
+    SubPropertyOf: 
+        OEO_00010472
+    
+    
 ObjectProperty: OEO_00020056
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -42,6 +42,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000600>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
 
     
@@ -658,6 +661,10 @@ ObjectProperty: OEO_00010472
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit has is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has unit numerator"@en
     
     SubPropertyOf: 
@@ -754,6 +761,10 @@ ObjectProperty: OEO_00010476
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit has is composed of at least two other units. Examples are:
+m/s has a linear numerator metre and a linear denominator second.
+kg/m³ has a linear numerator kilogram and a cubed denominator metre.
+Wh has two linear numerators: Watt and hour",
         rdfs:label "has unit denominator"@en
     
     SubPropertyOf: 


### PR DESCRIPTION
## Summary of the discussion

## Type of change (CHANGELOG.md)

### Add
- `has unit numerator`
  - `has linear numerator`
  - `has squared numerator`
  - `has cubed numerator`
- `has unit denominator`
  - `has linear denominator`
  - `has squared denominator`
  - `has cubed denominator`

## Workflow checklist

### Automation
Closes #1815

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
