### PR TITLE
Add `compressor`, `compressor station` and subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - economic instrument, voluntary agreement, voluntary agreement instrument, regulatory instrument, information instrument, education instrument (#1786)
 - priority region role, priority region, conditionally reserved region role, conditionally reserved region, suitable region role, suitable region, priority region with effect of suitable region, spatial planning policy (#1791)
 - missing value reason, notation key (#1795)
+- compressor, compressor station and subclasses (#1818)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8586,7 +8586,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         rdfs:label "compressor"@en
     
     SubClassOf: 
-        OEO_00010090
+        OEO_00010090,
+        OEO_00000503 some 
+            (OEO_00140116
+             and (OEO_00000531 value OEO_00000182))
     
     
 Class: OEO_00010481

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8577,6 +8577,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
              and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010141))
     
     
+Class: OEO_00010480
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor is a pump that converts energy into kinetic or potential energy of a gaseous fluid."@en,
+        rdfs:label "compressor"@en
+    
+    SubClassOf: 
+        OEO_00010090
+    
+    
+Class: OEO_00010481
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor station is an energy transformation unit that has a compressor to enable gas transport via a gas grid."@en,
+        rdfs:label "compressor station"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010480
+    
+    
 Class: OEO_00020001
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8581,6 +8581,8 @@ Class: OEO_00010480
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor is a pump that converts energy into kinetic or potential energy of a gaseous fluid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         rdfs:label "compressor"@en
     
     SubClassOf: 
@@ -8591,6 +8593,8 @@ Class: OEO_00010481
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor station is an energy transformation unit that has a compressor to enable gas transport via a gas grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         rdfs:label "compressor station"@en
     
     SubClassOf: 
@@ -8604,6 +8608,8 @@ Class: OEO_00010482
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine compressor station is a compressor station that has a gas turbine for driving the compressor."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         rdfs:label "gas turbine compressor station"@en
     
     SubClassOf: 
@@ -8616,6 +8622,8 @@ Class: OEO_00010483
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric compressor station is a compressor station that has en elecrtric motor for driving the compressor."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         rdfs:label "electric compressor station"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8600,6 +8600,30 @@ Class: OEO_00010481
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010480
     
     
+Class: OEO_00010482
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine compressor station is a compressor station that has a gas turbine for driving the compressor."@en,
+        rdfs:label "gas turbine compressor station"@en
+    
+    SubClassOf: 
+        OEO_00010481,
+        OEO_00000503 some OEO_00010146,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000185
+    
+    
+Class: OEO_00010483
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric compressor station is a compressor station that has en elecrtric motor for driving the compressor."@en,
+        rdfs:label "electric compressor station"@en
+    
+    SubClassOf: 
+        OEO_00010481,
+        OEO_00000503 some OEO_00000139,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010027
+    
+    
 Class: OEO_00020001
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Compressor stations are an important part of gas grids.

## Type of change (CHANGELOG.md)

### Add
- `compressor`: _A compressor is a pump that converts energy into kinetic or potential energy of a gaseous fluid._
- `compressor station`: _A compressor station is an energy transformation unit that has a compressor to enable gas transport via a gas grid._
  - `gas turbine compressor station`: _A gas turbine compressor station is a compressor station that has a gas turbine for driving the compressor._
  -  `electric compressor station`: _An electric compressor station is a compressor station that has en elecrtric motor for driving the compressor._

## Workflow checklist

### Automation
Closes #1813

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
