### PR TITLE
Add class `methanol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [2.X.X] - 20XX-XX-XX
 
 ### Added
+- methanol (#1827)
+
 ### Changed
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8663,6 +8663,8 @@ Class: OEO_00010484
         <http://purl.obolibrary.org/obo/IAO_0000115> "Methanol is a hydrocarbon with the chemical formula CH3OH. It has a liquid normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH3OH",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4O",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1825
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1827",
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17790",
         rdfs:label "methanol"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8657,6 +8657,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010027
     
     
+Class: OEO_00010484
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Methanol is a hydrocarbon with the chemical formula CH3OH. It has a liquid normal state of matter. As it can be oxidised it can be used as a fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH3OH",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CH4O",
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17790",
+        rdfs:label "methanol"@en
+    
+    SubClassOf: 
+        OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000529 value OEO_00000256
+    
+    
 Class: OEO_00020001
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Add class `methanol` in parallel to `methane`

## Type of change (CHANGELOG.md)

### Add
Definition: _Methanol is a hydrocarbon with the chemical formula CH3OH. It has a liquid normal state of matter. As it can be oxidised it can be used as a fuel._

Axioms:
* `'has role' some 'fuel role'`
* `'has disposition' some 'combustible energy carrier disposition'`
* `'has normal state of matter' value liquid`

Annotations:
* may be identical to http://purl.obolibrary.org/obo/CHEBI_17790
* alternative label: `CH3OH`
* alternative label: `CH4O`

## Workflow checklist

### Automation
Closes #1825

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
