### PR TITLE
Bug fix: make OEO_00140170 a data property #1802

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - methanol (#1827)
 
 ### Changed
+- has documentation quality (#1834)
+
 ### Removed
 
 ## [2.2.0] - 2024-03-04

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -488,6 +488,18 @@ ObjectProperty: OEO_00140164
 ObjectProperty: owl:topObjectProperty
 
     
+DataProperty: OEO_00140170abc
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
+	pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
+        rdfs:label "has documentation quality"@en
+    
+    Domain: 
+        OEO_00000274
+    
+    
 DataProperty: OEO_00140178
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -42,18 +42,6 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
 AnnotationProperty: <http://purl.org/dc/terms/title>
-
-    
-AnnotationProperty: OEO_00140170
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
-        rdfs:label "has documentation quality"@en
-    
-    Domain: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00000274>
     
     
 AnnotationProperty: dc:contributor

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -42,7 +42,7 @@ AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
 AnnotationProperty: <http://purl.org/dc/terms/title>
-    
+
     
 AnnotationProperty: dc:contributor
 
@@ -481,7 +481,10 @@ DataProperty: OEO_00140170
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/526
-	pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/825
+make data property
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1802
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1834",
         rdfs:label "has documentation quality"@en
     
     Domain: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -476,7 +476,7 @@ ObjectProperty: OEO_00140164
 ObjectProperty: owl:topObjectProperty
 
     
-DataProperty: OEO_00140170abc
+DataProperty: OEO_00140170
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Has documentation quality is the relation between a model and a statement about how well it is documented.",


### PR DESCRIPTION
## Summary of the discussion

OEO_00140170 `has documentation quality` was implemented as Annotation Property and did not show up properly. 
I made it a Data Property, which is fitting better and seemed to solve the problem. 

## Type of change (CHANGELOG.md)

### Update
- OEO_00140170 `has documentation quality`

## Workflow checklist

### Automation
Closes #1802

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
