### PR TITLE
add has prefix #1402

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - methanol (#1827)
+- has prefix (#1835)
 
 ### Changed
 ### Removed

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -10,10 +10,10 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared/>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-import-edits.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/imports/iao-extracted.owl>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl>
+Import: <http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl>
 Import: <https://raw.githubusercontent.com/BFO-ontology/BFO/v2.0/bfo.owl>
 
 Annotations: 
@@ -991,6 +991,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1113",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    
+ObjectProperty: OEO_00020404
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a unit and a prefix that indicate the magnitude of the unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1402
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1835",
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/has_prefix",
+        rdfs:label "has prefix"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/UO_0000000>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/UO_0000046>
     
     
 ObjectProperty: OEO_00040010


### PR DESCRIPTION
## Summary of the discussion

To complete #1402 I added the object prperty `has prefix`. I decided against importing from OBO, since the IRI keeps leading to an error. Instead, I added the "may be identical to" annotation.

## Type of change (CHANGELOG.md)

### Add
- has prefix

## Workflow checklist

### Automation
Closes #1402

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
