### PR TITLE
Add class "quantity" #1510

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - methanol (#1827)
 - has prefix (#1835)
+- quantity (#1839)
 
 ### Changed
 ### Removed

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1878,8 +1878,10 @@ Class: OEO_00340062
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1839",
         rdfs:label "quantity"@en
     
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>,
+    EquivalentTo: 
         OEO_00140002 some OEO_00000350
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1869,3 +1869,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/BFO_0000015>
     
     
+Class: OEO_00340062
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity is a quality of a material entity where the quality has a quantifiably magnitude (i.e. quantity value) that can be expressed as a number and a unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: https://jcgm.bipm.org/vim/en/1.1.html",
+        rdfs:label "quantity"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1879,6 +1879,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1839",
         rdfs:label "quantity"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00000350
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1872,7 +1872,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00340062
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity is a quality of a material entity where the quality has a quantifiably magnitude (i.e. quantity value) that can be expressed as a number and a unit.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity is a quality of a material entity where the magnitude  of the quality can be quantified via a quantity value, which means that it can be expressed as a number and a unit.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: https://jcgm.bipm.org/vim/en/1.1.html",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1510
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1839",

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1879,7 +1879,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1839",
         rdfs:label "quantity"@en
     
     EquivalentTo: 
-        OEO_00140002 some OEO_00000350
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+         and (OEO_00140002 some OEO_00000350)
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1874,6 +1874,8 @@ Class: OEO_00340062
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A quantity is a quality of a material entity where the quality has a quantifiably magnitude (i.e. quantity value) that can be expressed as a number and a unit.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: https://jcgm.bipm.org/vim/en/1.1.html",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1510
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1839",
         rdfs:label "quantity"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

As described in #1510 and #1752 we want to restructure quantity values. Therefore we need a class "quantity", which I added in this pull request. The definition has been derived from the International vocabulary of metrology — Basic and general concepts and associated terms (VIM).
Based on this implementation some existing entities have to be reclassified in following PRs.

### Add
- Added a new class "quantity": A quantity is a quality of a material entity where the quality has a quantifiably magnitude (i.e. quantity value) that can be expressed as a number and a unit.

## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
