### PR TITLE
Add Axiom to Final Energy Consumption Value #1832

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - has documentation quality (#1834)
-- Final Energy Consumption Value (#1841)
+- Final Energy Consumption Value, Energy Consumption Value (#1841)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - has documentation quality (#1834)
+- Final Energy Consumption Value (#1841)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - has documentation quality (#1834)
-- Final Energy Consumption Value, Energy Consumption Value (#1841)
+- final energy consumption value, energy consumption value (#1841)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - has documentation quality (#1834)
-- final energy consumption value, energy consumption value (#1841)
+- energy consumption value, final energy consumption value, primary energy consumption value, gross inland energy consumption value, gross national electricity consumption value (#1841)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10722,6 +10722,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         OEO_00240019
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
     
+    SubClassOf: 
+        OEO_00240019
+    
     
 Class: OEO_00050018
 
@@ -10751,6 +10754,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     EquivalentTo: 
         OEO_00240019
          and (not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211))
+    
+    SubClassOf: 
+        OEO_00240019
     
     
 Class: OEO_00050019
@@ -12345,6 +12351,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
     EquivalentTo: 
         OEO_00240019
          and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00050017)
+    
+    SubClassOf: 
+        OEO_00240019
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10665,6 +10665,7 @@ Class: OEO_00050016
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy consumption"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
@@ -10688,7 +10689,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
 Class: OEO_00050017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption value is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
 Gross inland energy consumption covers:
@@ -10715,21 +10716,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
-        rdfs:label "gross inland energy consumption"@en
+        rdfs:label "gross inland energy consumption value"@en
     
     SubClassOf: 
         OEO_00240019,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211)
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211
     
     
 Class: OEO_00050018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption value is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
@@ -10749,15 +10749,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        rdfs:label "primary energy consumption"@en
+        rdfs:label "primary energy consumption value"@en
     
     SubClassOf: 
         OEO_00240019,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        (not (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010211))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010210)
+        not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
     
     
 Class: OEO_00050019
@@ -12343,10 +12342,11 @@ Class: OEO_00240018
 
     Annotations: 
         OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption value is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross national electricity consumption",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        rdfs:label "gross national electricity consumption"@en
+        rdfs:label "gross national electricity consumption value"@en
     
     SubClassOf: 
         OEO_00240019,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10718,12 +10718,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "gross inland energy consumption value"@en
     
-    SubClassOf: 
-        OEO_00240019,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211
+    EquivalentTo: 
+        OEO_00240019
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
     
     
 Class: OEO_00050018
@@ -10751,12 +10748,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "primary energy consumption value"@en
     
-    SubClassOf: 
-        OEO_00240019,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
-        not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
+    EquivalentTo: 
+        OEO_00240019
+         and (not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211))
     
     
 Class: OEO_00050019
@@ -12342,15 +12336,15 @@ Class: OEO_00240018
 
     Annotations: 
         OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross national electricity consumption value is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross national electricity consumption value is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gross national electricity consumption",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
         rdfs:label "gross national electricity consumption value"@en
     
-    SubClassOf: 
-        OEO_00240019,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00050017
+    EquivalentTo: 
+        OEO_00240019
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00050017)
     
     
 Class: OEO_00240019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10664,14 +10664,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050016
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption is an energy consumption value accounting for the energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
 Make 'energy consumption value'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1322
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340",
-        rdfs:label "final energy consumption"@en
+        rdfs:label "final energy consumption value"@en
+    
+    EquivalentTo: 
+        OEO_00240019
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
+            (OEO_00140039
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140080)))
     
     SubClassOf: 
         OEO_00240019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12362,9 +12362,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
 
 Move to oeo-shared:
 https://github.com/OpenEnergyPlatform/ontology/pull/1463
+
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+Add axiom 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841"@en,
         rdfs:label "energy consumption value"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10679,7 +10679,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
     
     EquivalentTo: 
         OEO_00240019
-         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140080)
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140080))
     
     SubClassOf: 
         OEO_00240019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10679,9 +10679,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
     
     EquivalentTo: 
         OEO_00240019
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some 
-            (OEO_00140039
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140080)))
+         and (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00140080)
     
     SubClassOf: 
         OEO_00240019
@@ -12371,6 +12369,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     SubClassOf: 
         OEO_00050019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010210,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00030035
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10664,7 +10664,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050016
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10729,7 +10729,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950"
 Class: OEO_00050018
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy consumption value is an energy consumption value accounting for the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10718,12 +10718,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         rdfs:label "gross inland energy consumption value"@en
     
-    EquivalentTo: 
-        OEO_00240019
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
-    
     SubClassOf: 
-        OEO_00240019
+        OEO_00240019,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211
     
     
 Class: OEO_00050018
@@ -10751,12 +10748,9 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "primary energy consumption value"@en
     
-    EquivalentTo: 
-        OEO_00240019
-         and (not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211))
-    
     SubClassOf: 
-        OEO_00240019
+        OEO_00240019,
+        not (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010211)
     
     
 Class: OEO_00050019

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10670,7 +10670,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
 Make 'energy consumption value'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1322
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340
+
+Add axiom 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1832
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
         rdfs:label "final energy consumption value"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -10689,7 +10689,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
 Class: OEO_00050017
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross inland energy consumption value is an energy consumption value accounting for the total consumption of energy in a spatial region (e.g. a country)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross inland energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
 Gross inland energy consumption covers:


### PR DESCRIPTION
## Summary of the discussion

As discussed in #1832 I added an axiom to final energy consumption and since it is a quantity value I adjusted the label and the definition, so that the distinction between quantity and quantity value becomes more clear.

### Add
- Added an axiom: Equivalent to 'energy consuption value' and 'is about' some (consumption and 'has participant' some 'final energy carrier')

### Update
- changed label: final energy consumption
- changed definition: Final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users.

## Workflow checklist

### Automation
Closes #1832

### PR-Assignee
- [x ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
