### PR TITLE
Add size and adjust area value #1848

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - quantity (#1839)
 - model coupling, sector coupling, sector coupling technology (#1842)
 - emission value, greenhouse gas emission value, CO2 emission value, emission factor value (#1846)
+- size (#1851)
 
 ### Changed
 - has documentation quality (#1834)
 - emission factor, emission rate, greenhouse gas emission rate, CO2 emission rate, carbon dioxide equivalent quantity value (#1846)
+- area value (#1851)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9437,9 +9437,14 @@ Class: OEO_00020143
         <http://purl.obolibrary.org/obo/IAO_0000118> "area quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+restructuring of quantity values
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851",
         rdfs:label "area value"@en
     
     SubClassOf: 
@@ -14543,6 +14548,9 @@ Class: OEO_00340068
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity that quantifies the spatial extend/physical magnitude of an entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "restructuring of quantity values
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851",
         rdfs:label "size"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9434,6 +9434,7 @@ Class: OEO_00020143
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "area quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
 rework module structure 
@@ -9443,8 +9444,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00000350,
-        OEO_00020056 some <http://purl.obolibrary.org/obo/BFO_0000009>,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
+        OEO_00020056 some OEO_00340068,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000009>
     
     
 Class: OEO_00020144
@@ -14475,6 +14477,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         OEO_00020056 some OEO_00000159
     
     
+Class: OEO_00340062
+
+    
 Class: OEO_00340063
 
     Annotations: 
@@ -14531,6 +14536,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
     SubClassOf: 
         OEO_00340065,
         OEO_00020056 some OEO_00260008
+    
+    
+Class: OEO_00340068
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity that quantifies the spatial extend/physical magnitude of an entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
+        rdfs:label "size"@en
+    
+    SubClassOf: 
+        OEO_00340062
     
     
 Class: OEO_00360001


### PR DESCRIPTION
## Summary of the discussion

As discussed in #1848 for the restructuring of the quantity values and quantities we need size as a quantity and adjust area value accordingly.

### Add
- `size` as a `quantity`
- `Size is a quantity that quantifies the spatial extend/physical magnitude of an entity.`(Derived from AFO and PATO)

### Update
- `area value`
- add the alternative label: `area quantity value`.
- add axiom:  `quantity value of some size`
- add axiom:  `is about some two-dimensional spatial region`

## Workflow checklist

### Automation
Closes #1848 
