### PR TITLE
bug fix with roles #1844

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - has documentation quality (#1834)
 - emission factor, emission rate, greenhouse gas emission rate, CO2 emission rate, carbon dioxide equivalent quantity value (#1846)
+- has bearer, has characteristic, characteristic of, role of, model role (#1852)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -127,13 +127,20 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000052">
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
+        <obo:IAO_0000233>add inverse:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1844
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1852</obo:IAO_0000233>
     </owl:ObjectProperty>
     
 
 
     <!-- http://purl.obolibrary.org/obo/RO_0000053 -->
 
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053">
+        <obo:IAO_0000233>update inverse:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1844
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1852</obo:IAO_0000233>
+    </owl:ObjectProperty>
     
 
 
@@ -172,6 +179,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <obo:IAO_0000233>add domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1844
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1852</obo:IAO_0000233>
     </owl:ObjectProperty>
     
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -152,6 +152,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1225</obo:IAO_
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0000081 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000081">
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0000085 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000085">

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -123,6 +123,20 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</obo:IAO_0
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0000052 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000052">
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0000053 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0000056 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056">

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -142,9 +142,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000020>
     
-    InverseOf: 
-        OEO_00010121
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
@@ -168,9 +165,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
         <http://purl.obolibrary.org/obo/IAO_0000233> "extend domain / definition
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1030
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1101"
-    
-    Domain: 
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000091>
@@ -621,9 +615,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484",
     
     Range: 
         OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
-    InverseOf: 
-        <http://purl.obolibrary.org/obo/RO_0000053>
     
     
 ObjectProperty: OEO_00010231

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -607,7 +607,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985
 
 correct definition with respect to energy:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1484
+
+remove inverse:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1844
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1852",
         rdfs:label "has bearer"@en
     
     Domain: 
@@ -1705,7 +1709,11 @@ Class: OEO_00020353
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model role is a a role of a continuant for representing a system and its behaviours in a simplified or idealised way.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1444
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1707",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1707
+
+add axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1844
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1852",
         rdfs:label "model role"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -139,12 +139,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000118> "has characteristic"
     
-    Domain: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/985"
-        OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>
-    
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000020>
     
@@ -1212,10 +1206,6 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000019>
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000020>
 
-    SubClassOf: 
-        OEO_00010121 some 
-            (OEO_00000150 or <http://purl.obolibrary.org/obo/BFO_0000004>)
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000023>
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -158,6 +158,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000081>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000085>
 
     
@@ -1725,7 +1728,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1707",
         rdfs:label "model role"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
+        <http://purl.obolibrary.org/obo/BFO_0000023>,
+        <http://purl.obolibrary.org/obo/RO_0000081> some OEO_00020352
     
     
 Class: OEO_00030019


### PR DESCRIPTION
## Summary of the discussion

Bug fix: models are inferred as energies because of 'has bearer'

## Type of change (CHANGELOG.md)

### Update
- add inverse, domain to role of
- make has characteristic and characteristic of inverses, remove inverse off of has bearer
- add axiom to model role
- 
## Workflow checklist

### Automation
Closes #1844

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
