### PR TITLE
project lifetime dates #1536

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - quantity (#1839)
 - model coupling, sector coupling, sector coupling technology (#1842)
 - emission value, greenhouse gas emission value, CO2 emission value, emission factor value (#1846)
+- (de)commissioning start, (de)commissioning end (#1853)
 
 ### Changed
 - has documentation quality (#1834)
 - emission factor, emission rate, greenhouse gas emission rate, CO2 emission rate, carbon dioxide equivalent quantity value (#1846)
+- time stamp (#1853)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2593,6 +2593,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
         OEO_00030031
     
     
+Class: OEO_00020420
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning end is an end time that indicates the beginning of a decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
+        rdfs:label "decommissioning end"
+    
+    SubClassOf: 
+        OEO_00030032
+    
+    
+Class: OEO_00020421
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commissioning end is an end time that indicates the beginning of a commissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
+        rdfs:label "commissioning end"
+    
+    SubClassOf: 
+        OEO_00030032
+    
+    
 Class: OEO_00030007
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -581,6 +581,9 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000300>
 Class: <http://purl.obolibrary.org/obo/IAO_0000310>
 
     
+Class: <http://purl.obolibrary.org/obo/IAO_0000582>
+
+    
 Class: <http://purl.obolibrary.org/obo/RO_0002577>
 
     
@@ -2597,6 +2600,7 @@ Class: OEO_00020420
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning end is an end time that indicates the beginning of a decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "decommissioning date",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
         rdfs:label "decommissioning end"
@@ -2609,6 +2613,7 @@ Class: OEO_00020421
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A commissioning end is an end time that indicates the beginning of a commissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "commissioning date",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
         rdfs:label "commissioning end"
@@ -2901,7 +2906,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140043
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a temporal region.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a zero-dimensional temporal region, or a data item that is related to a zero-dimensional temporal region, e.g. a time stamped measurement datum.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
 
@@ -2920,7 +2925,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
     
     SubClassOf: 
         OEO_00000119,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000008>
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000008>,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/IAO_0000582>
     
     
 Class: OEO_00140044

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -503,6 +503,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000003>
 Class: <http://purl.obolibrary.org/obo/BFO_0000006>
 
     
+Class: <http://purl.obolibrary.org/obo/BFO_0000008>
+
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000009>
 
     
@@ -2850,7 +2853,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/565",
 Class: OEO_00140043
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a zero-dimensional temporal region that is used to describe a time step.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a temporal region.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/570
 
@@ -2860,11 +2863,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+reclassify as data descriptor
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "time stamp"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000148>
+        OEO_00000119,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000008>
     
     
 Class: OEO_00140044

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2569,6 +2569,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842",
         OEO_00000275
     
     
+Class: OEO_00020416
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A commissioning start is a start time that indicates the beginning of a commissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
+        rdfs:label "commissioning start"
+    
+    SubClassOf: 
+        OEO_00030031
+    
+    
+Class: OEO_00020417
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning start is a start time that indicates the beginning of a decommissioning time.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
+        rdfs:label "decommissioning start"
+    
+    SubClassOf: 
+        OEO_00030031
+    
+    
 Class: OEO_00030007
 
     Annotations: 
@@ -2867,7 +2891,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 reclassify as data descriptor
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
         rdfs:label "time stamp"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

I added `(de)commissioning start/end`, as proposed in #1536 and changed the classification of time stamp.

To do: discuss the relation `has time stamp`

## Type of change (CHANGELOG.md)

### Add
- (de)commissioning start/end

### Update
- time stamp

## Workflow checklist

### Automation
Closes #1536

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
