### PR TITLE
Import SKOS mapping relations #636

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [2.X.X] - 20XX-XX-XX
 ### Added
 - subsector, has subsector, subsector of (#1788)
+- SKOS annotaions: skos:closeMatch, skos:exactMatch, skos:relatedMatch (#1874)
 
 ### Changed
 - electricity sector, industry sector, CRF sector (IPCC 2006) individuals (#1788)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3,6 +3,7 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -57,6 +58,15 @@ AnnotationProperty: rdfs:isDefinedBy
 
     
 AnnotationProperty: rdfs:label
+
+    
+AnnotationProperty: skos:closeMatch
+
+    
+AnnotationProperty: skos:exactMatch
+
+    
+AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3,6 +3,7 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -69,6 +70,15 @@ AnnotationProperty: rdfs:isDefinedBy
 
     
 AnnotationProperty: rdfs:label
+
+    
+AnnotationProperty: skos:closeMatch
+
+    
+AnnotationProperty: skos:exactMatch
+
+    
+AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -3,6 +3,7 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -72,6 +73,15 @@ AnnotationProperty: rdfs:label
 
     
 AnnotationProperty: rdfs:seeAlso
+
+    
+AnnotationProperty: skos:closeMatch
+
+    
+AnnotationProperty: skos:exactMatch
+
+    
+AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -3,6 +3,7 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -103,6 +104,15 @@ AnnotationProperty: rdfs:label
 
     
 AnnotationProperty: rdfs:seeAlso
+
+    
+AnnotationProperty: skos:closeMatch
+
+    
+AnnotationProperty: skos:exactMatch
+
+    
+AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -3,6 +3,7 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -72,6 +73,15 @@ AnnotationProperty: rdfs:seeAlso
 
     
 Datatype: rdf:PlainLiteral
+
+    
+AnnotationProperty: skos:closeMatch
+
+    
+AnnotationProperty: skos:exactMatch
+
+    
+AnnotationProperty: skos:relatedMatch
 
     
 Datatype: xsd:string


### PR DESCRIPTION
## Summary of the discussion

This PR imports SKOS mapping relations. The replacement of the current use of `may be identical to` annotations will be done in a follow-up pull request.

## Type of change (CHANGELOG.md)

### Add
- `skos:closeMatch`
- `skos:exactMatch`
- `skos:relatedMatch`

## Workflow checklist

### Automation
Part of #636

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
