### PR TITLE
Convert ENVO matchings from `iao:may be identical` to `skos:closeMatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [2.X.X] - 20XX-XX-XX
 ### Added
 - subsector, has subsector, subsector of (#1788)
-- SKOS annotaions: skos:closeMatch, skos:exactMatch, skos:relatedMatch (#1874)
+- SKOS annotations: skos:closeMatch, skos:exactMatch, skos:relatedMatch (#1874)
 
 ### Changed
 - electricity sector, industry sector, CRF sector (IPCC 2006) individuals (#1788)
 - German alternative labels (#1862, #1868)
+- ENVO mappings (#1879)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -934,7 +934,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "chemical energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000023>
     
     SubClassOf: 
@@ -1583,7 +1587,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638",
         rdfs:label "waste role"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000665>
     
     SubClassOf: 
@@ -1600,7 +1608,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
         rdfs:label "wind"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000793>
     
     SubClassOf: 
@@ -1682,7 +1694,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
         rdfs:label "air"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002005>
     
     SubClassOf: 
@@ -1703,7 +1719,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
         rdfs:label "air pollution"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500037>
     
     SubClassOf: 
@@ -1734,7 +1754,11 @@ Class: OEO_00000058
         rdfs:label "anthracite"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000011>
     
     SubClassOf: 
@@ -1899,7 +1923,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         rdfs:label "biogas"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000556>
     
     SubClassOf: 
@@ -1964,7 +1992,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         rdfs:label "charcoal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000560>
     
     SubClassOf: 
@@ -1986,7 +2018,11 @@ Class: OEO_00000088
         rdfs:label "coal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000091>
     
     SubClassOf: 
@@ -2011,7 +2047,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "coal power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000038>
     
     SubClassOf: 
@@ -2271,7 +2311,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "electrical energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000020>
     
     SubClassOf: 
@@ -2746,7 +2790,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         rdfs:label "geothermal energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000034>
     
     SubClassOf: 
@@ -2763,7 +2811,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "geothermal power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002215>
     
     SubClassOf: 
@@ -2925,7 +2977,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "thermal energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000032>
     
     SubClassOf: 
@@ -3200,7 +3256,11 @@ This includes the portion of the oil shale or tar sands consumed in the transfor
         rdfs:label "lignite"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000008>
     
     SubClassOf: 
@@ -3221,7 +3281,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "lignite power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000040>
     
     SubClassOf: 
@@ -3424,7 +3488,11 @@ It does not include gases created by anaerobic digestion of biomass (e.g. munici
         rdfs:label "natural gas"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000552>
     
     SubClassOf: 
@@ -3525,7 +3593,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
         rdfs:label "nuclear binding energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000025>
     
     SubClassOf: 
@@ -3653,7 +3725,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "particulate matter"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000060>
     
     SubClassOf: 
@@ -3672,7 +3748,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
         rdfs:label "peat"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00005774>
     
     SubClassOf: 
@@ -3725,7 +3805,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         rdfs:label "pollution"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500036>
     
     SubClassOf: 
@@ -4047,7 +4131,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         rdfs:label "solar power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000041>
     
     SubClassOf: 
@@ -4232,7 +4320,11 @@ Class: OEO_00000401
         rdfs:label "sub bituminous coal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000009>
     
     SubClassOf: 
@@ -4657,7 +4749,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "PM10"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000405>
     
     SubClassOf: 
@@ -4674,7 +4770,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         rdfs:label "PM2.5"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000415>
     
     SubClassOf: 
@@ -4935,7 +5035,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "vehicle"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000604>
     
     SubClassOf: 
@@ -5148,7 +5252,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
         rdfs:label "motor"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000610>
     
     SubClassOf: 
@@ -5490,7 +5598,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
 
 Make river a subclass of water body:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
         rdfs:label "river"@en,
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000022>
     
@@ -5639,7 +5751,11 @@ Class: OEO_00010101
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
         rdfs:label "tidal flow"@en,
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001342>
     
@@ -9053,7 +9169,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447",
         rdfs:label "radiation"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001023>
     
     SubClassOf: 
@@ -9076,7 +9196,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         rdfs:label "solar radiation"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001862>
     
     SubClassOf: 
@@ -9117,7 +9241,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
         rdfs:label "radiative energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000030>
     
     SubClassOf: 
@@ -9152,7 +9280,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         rdfs:label "potential energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000016>
     
     SubClassOf: 
@@ -10018,7 +10150,11 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
         rdfs:label "climate system"@en,
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001364>
     
@@ -11249,7 +11385,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "transport"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000125>
     
     SubClassOf: 
@@ -12229,7 +12369,11 @@ Class: OEO_00140162
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
         rdfs:label "power plant with electro motive generator"@en,
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002214>
     
@@ -12405,7 +12549,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
         rdfs:label "kinetic energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000017>
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -931,11 +931,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "chemical energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000023",
-        rdfs:label "chemical energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000023>
     
     SubClassOf: 
         OEO_00000150
@@ -1580,11 +1580,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 changed bearer to material entity
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1376
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638",
+        rdfs:label "waste role"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000665",
-        rdfs:label "waste role"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000665>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -1597,11 +1597,11 @@ Class: OEO_00000043
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
+        rdfs:label "wind"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000793",
-        rdfs:label "wind"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000793>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -1679,11 +1679,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 remove axiom 'is used by' some 'energy storage unit'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
+        rdfs:label "air"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002005",
-        rdfs:label "air"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002005>
     
     SubClassOf: 
         OEO_00010236,
@@ -1700,11 +1700,11 @@ Class: OEO_00000055
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
+        rdfs:label "air pollution"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02500037",
-        rdfs:label "air pollution"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500037>
     
     SubClassOf: 
         OEO_00000330,
@@ -1730,12 +1730,12 @@ Class: OEO_00000058
         <http://purl.obolibrary.org/obo/IAO_0000115> "Anthracite is a hard coal with a high caloric value due to its high carbon content (about 90 % fixed carbon).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Anthrazit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
+        rdfs:label "anthracite"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000011",
-        rdfs:comment "Its gross calorific value is greater than 23 865 kJ/kg (5 700 kcal/kg) on an ash-free but moist basis."@en,
-        rdfs:label "anthracite"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000011>
     
     SubClassOf: 
         OEO_00000204
@@ -1896,11 +1896,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
+        rdfs:label "biogas"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000556",
-        rdfs:label "biogas"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000556>
     
     SubClassOf: 
         OEO_00010236,
@@ -1961,11 +1961,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
+        rdfs:label "charcoal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000560",
-        rdfs:label "charcoal"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000560>
     
     SubClassOf: 
         OEO_00000331,
@@ -1982,12 +1982,12 @@ Class: OEO_00000088
         <http://purl.obolibrary.org/obo/IAO_0000115> "Coal is a portion of matter consisting of combustible black or brownish-black sedimentary rock, formed as rock strata called coal seams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohle"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Coal&oldid=907331967",
+        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen. Coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
+        rdfs:label "coal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000091",
-        rdfs:comment "Coal is mostly carbon with variable amounts of other elements; chiefly hydrogen, sulphur, oxygen, and nitrogen. Coal is formed if dead plant matter decays into peat and over millions of years the heat and pressure of deep burial converts the peat into coal.",
-        rdfs:label "coal"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000091>
     
     SubClassOf: 
         OEO_00000331,
@@ -2008,11 +2008,11 @@ Class: OEO_00000089
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlekraftwerk"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "coal power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000038",
-        rdfs:label "coal power plant"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000038>
     
     SubClassOf: 
         OEO_00000031,
@@ -2268,11 +2268,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "electrical energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000020",
-        rdfs:label "electrical energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000020>
     
     SubClassOf: 
         OEO_00000150,
@@ -2743,11 +2743,11 @@ Class: OEO_00000191
         <http://purl.obolibrary.org/obo/IAO_0000118> "Geothermie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
+        rdfs:label "geothermal energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000034",
-        rdfs:label "geothermal energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000034>
     
     SubClassOf: 
         OEO_00000207,
@@ -2760,11 +2760,11 @@ Class: OEO_00000192
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "geothermal power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002215",
-        rdfs:label "geothermal power plant"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002215>
     
     SubClassOf: 
         OEO_00000031,
@@ -2922,11 +2922,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+        rdfs:label "thermal energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000032",
-        rdfs:label "thermal energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000032>
     
     SubClassOf: 
         OEO_00000150
@@ -3194,14 +3194,14 @@ Class: OEO_00000251
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Lignite is coal that is non-agglomerating with a gross calorific value less than 17 435 kJ/kg (4 165 kcal/kg) and greater than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000008",
         rdfs:comment "Oil shale and tar sands produced and combusted directly should be reported in this category. Oil shale and tar sands used as inputs for other transformation processes should also be reported in this category.	
 
 This includes the portion of the oil shale or tar sands consumed in the transformation process.",
-        rdfs:label "lignite"@en
+        rdfs:label "lignite"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000008>
     
     SubClassOf: 
         OEO_00000088,
@@ -3218,11 +3218,11 @@ Class: OEO_00000252
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "lignite power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000040",
-        rdfs:label "lignite power plant"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000040>
     
     SubClassOf: 
         OEO_00000089,
@@ -3418,14 +3418,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 improve definition and make subclass of gas mixture and add disjoints:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000552",
         rdfs:comment "It includes both ‘non-associated’ gas originating from fields producing hydrocarbons only in gaseous form, and ‘associated’ gas produced in association with crude oil as well as methane recovered from coal mines (colliery gas) or from coal seams (coal seam gas).
 
 It does not include gases created by anaerobic digestion of biomass (e.g. municipal or sewage gas) nor gasworks gas.",
-        rdfs:label "natural gas"@en
+        rdfs:label "natural gas"@en,
+        
+            Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000552>
     
     SubClassOf: 
         OEO_00010236,
@@ -3522,11 +3522,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 conversion to nuclear binding energy
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
+        rdfs:label "nuclear binding energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000025",
-        rdfs:label "nuclear binding energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000025>
     
     SubClassOf: 
         OEO_00000150,
@@ -3556,11 +3556,11 @@ Class: OEO_00000303
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "nuclear power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002271",
-        rdfs:label "nuclear power plant"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002271>
     
     SubClassOf: 
         OEO_00000031,
@@ -3650,11 +3650,11 @@ Class: OEO_00000318
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "particulate matter"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000060",
-        rdfs:label "particulate matter"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000060>
     
     SubClassOf: 
         OEO_00000331,
@@ -3669,11 +3669,11 @@ Class: OEO_00000320
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
+        rdfs:label "peat"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00005774",
-        rdfs:label "peat"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00005774>
     
     SubClassOf: 
         OEO_00000331,
@@ -3722,11 +3722,11 @@ Class: OEO_00000330
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
+        rdfs:label "pollution"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02500036",
-        rdfs:label "pollution"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500036>
     
     SubClassOf: 
         OEO_00000147
@@ -4044,11 +4044,11 @@ Class: OEO_00000386
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
+        rdfs:label "solar power plant"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000041",
-        rdfs:label "solar power plant"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000041>
     
     SubClassOf: 
         OEO_00000031,
@@ -4229,11 +4229,11 @@ Class: OEO_00000401
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sub bituminous coal is coal that is non-agglomerating with a gross calorific value between 17 435 kJ/kg (4 165 kcal/kg) and 23 865 kJ/kg (5 700 kcal/kg) containing more than 31 % volatile matter on a dry mineral matter free basis."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "sub bituminous coal"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000009",
-        rdfs:label "sub bituminous coal"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000009>
     
     SubClassOf: 
         OEO_00000088
@@ -4654,11 +4654,11 @@ Class: OEO_00010009
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM10"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000405",
-        rdfs:label "PM10"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000405>
     
     SubClassOf: 
         OEO_00000318
@@ -4671,11 +4671,11 @@ Class: OEO_00010010
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
+        rdfs:label "PM2.5"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000415",
-        rdfs:label "PM2.5"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000415>
     
     SubClassOf: 
         OEO_00000318
@@ -4932,11 +4932,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "vehicle"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000604",
-        rdfs:label "vehicle"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000604>
     
     SubClassOf: 
         OEO_00000061,
@@ -5145,11 +5145,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
+        rdfs:label "motor"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01000610",
-        rdfs:label "motor"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000610>
     
     SubClassOf: 
         OEO_00000011,
@@ -5491,8 +5491,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
 Make river a subclass of water body:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00000022",
-        rdfs:label "river"@en
+        rdfs:label "river"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000022>
     
     SubClassOf: 
         OEO_00010104,
@@ -5640,8 +5640,8 @@ Class: OEO_00010101
         <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001342",
-        rdfs:label "tidal flow"@en
+        rdfs:label "tidal flow"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001342>
     
     SubClassOf: 
         OEO_00110002
@@ -9050,11 +9050,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1031
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447",
+        rdfs:label "radiation"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001023",
-        rdfs:label "radiation"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001023>
     
     SubClassOf: 
         OEO_00020103,
@@ -9073,11 +9073,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
 Add alternative label and editor note:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
+        rdfs:label "solar radiation"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001862",
-        rdfs:label "solar radiation"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001862>
     
     SubClassOf: 
         OEO_00020037
@@ -9114,11 +9114,11 @@ Class: OEO_00020040
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
+        rdfs:label "radiative energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000030",
-        rdfs:label "radiative energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000030>
     
     SubClassOf: 
         OEO_00000150
@@ -9148,12 +9148,12 @@ Class: OEO_00020045
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
+        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
+        rdfs:label "potential energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000016",
-        rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
-        rdfs:label "potential energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000016>
     
     SubClassOf: 
         OEO_00000150
@@ -10019,9 +10019,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_01001364
-A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things).",
-        rdfs:label "climate system"@en
+        rdfs:label "climate system"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001364>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0002577>
@@ -11247,11 +11246,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:label "transport"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_02000125",
-        rdfs:label "transport"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000125>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -12231,8 +12230,8 @@ Class: OEO_00140162
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810",
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_00002214",
-        rdfs:label "power plant with electro motive generator"@en
+        rdfs:label "power plant with electro motive generator"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002214>
     
     EquivalentTo: 
         OEO_00000031
@@ -12403,11 +12402,11 @@ Class: OEO_00230020
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
+        rdfs:label "kinetic energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000017",
-        rdfs:label "kinetic energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000017>
     
     SubClassOf: 
         OEO_00000150

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1391,7 +1391,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
         skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000015>
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1387,12 +1387,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1485
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "Energy is power integrated over time.",
+        rdfs:label "energy"@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/ENVO_2000015",
-        rdfs:comment "Energy is power integrated over time.",
-        rdfs:label "energy"@en
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000015>
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,


### PR DESCRIPTION
## Summary of the discussion

This PR converts ENVO matchings using the annotation `iao:may be identical` to the annotation `skos:closeMatch`. It also makes sure that matched IRIs are not treated as literals.

Mappings to other ontologies (e.g. CHEBI) will be changed in subsequent pull requests.

## Type of change (CHANGELOG.md)

### Update
- `air`
- `air pollution`
- `anthracite`
- `biogas`
- `charcoal`
- `chemical energy`
- `climate system`
- `coal`
- `coal power plant`
- `electrical energy`
- `energy`
- `geothermal energy`
- `geothermal power plant`
- `kinetic energy`
- `lignite`
- `lignite power plant`
- `motor`
- `natural gas`
- `nuclear power plant`
- `particulate matter`
- `peat`
- `PM2.5`
- `PM10`
- `pollution`
- `potential energy`
- `power plant with electromotive generator`
- `radiation`
- `radiative energy`
- `river`
- `solar power plant`
- `solar radiation`
- `sub bituminous coal`
- `thermal energy`
- `tidal flow`
- `transport`
- `vehicle`
- `waste role`
- `wind`

## Workflow checklist

### Automation
Part of #636 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
