### PR TITLE
Correction of implementing mistake concerning emission value #1759 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - API -> application programming interface; GUI -> graphical user interface (#1810)
 - forecasting model calculation (#1799)
 - uo-extracted.owl (#1820)
+- emission factor value (#1880)
+
+### Removed
+- emission value (#1880)
 
 ## [2.1.0] - 2023-12-05
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5265,17 +5265,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010079
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission quantity value is a quantity value that has a mass unit as unit. It is the quantity value of an emission value."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a quantity value that quantifies an emission rate and has a mass unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "emission quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:label "emission quantity value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+restructuring emission rate and emission value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "It can be calculated using the an emission factor.",
+        rdfs:label "emission value"@en
     
     SubClassOf: 
         OEO_00000350,
+        OEO_00020056 some OEO_00140081,
         OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
     
     
@@ -11872,7 +11879,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
         rdfs:label "carbon dioxide equivalent quantity value"@en
     
     SubClassOf: 
-        OEO_00340064
+        OEO_00010079
     
     
 Class: OEO_00140091
@@ -14832,24 +14839,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
         OEO_00140127
     
     
-Class: OEO_00340064
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a quantity value that quantifies an emission rate and has a mass unit.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionswert"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "emission quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000233> "restructuring emission rate and emission value
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "It can be calculated using the an emission factor.",
-        rdfs:label "emission value"@en
-    
-    SubClassOf: 
-        OEO_00000350,
-        OEO_00020056 some OEO_00140081,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000002>
-    
-    
 Class: OEO_00340065
 
     Annotations: 
@@ -14860,7 +14849,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
         rdfs:label "greenhouse gas emission value"@en
     
     SubClassOf: 
-        OEO_00340064,
+        OEO_00010079,
         OEO_00020056 some OEO_00140082
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5266,6 +5266,7 @@ Class: OEO_00010079
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a quantity value that quantifies an emission rate and has a mass unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionswert"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "emission quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5276,7 +5276,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
+
+Correction of implementing mistake concerning emission value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
         <http://purl.obolibrary.org/obo/IAO_0000600> "It can be calculated using the an emission factor.",
         rdfs:label "emission value"@en
     
@@ -14832,8 +14836,12 @@ Class: OEO_00340063
         <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor value is a fraction value that quantifies an emission factor as quotient of the emissions or removals of a gas per unit activity.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        rdfs:label "emission factor value"@de
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
+
+Correction of implementing mistake concerning emission value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
+        rdfs:label "emission factor value"@en
     
     SubClassOf: 
         OEO_00140127
@@ -14845,7 +14853,11 @@ Class: OEO_00340065
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies a greenhouse gas emission rate and has a mass unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
+
+Correction of implementing mistake concerning emission value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
         rdfs:label "greenhouse gas emission value"@en
     
     SubClassOf: 
@@ -14859,7 +14871,11 @@ Class: OEO_00340066
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission value is a greenhouse gas emission value that quantifies a CO2 emission rate and has a mass unit.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
+
+Correction of implementing mistake concerning emission value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
         rdfs:label "CO2 emission value"@en
     
     SubClassOf: 


### PR DESCRIPTION
## Summary of the discussion

This PR fixes the implementing mistakes concerning emission value. #1759 

### Remove
-  emission value (there accidentally existed two of them)

## Workflow checklist

### Automation
Closes #1759 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
