### PR TITLE
Split individual `gams` into two individuals #859

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - German alternative labels (#1883)
 - English language tags to existing alternative labels (#1883)
+- GAMS programming language (#1889)
 
 ### Changed
+- gams -> General Algebraic Modeling System (#1889)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3596,11 +3596,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1869",
 Individual: OEO_00000180
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The General Algebraic Modeling System (GAMS) is a proprietary software framework developed by GAMS Development Corp. that uses the GAMS programming language."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@de,
-        rdfs:label "gams"@en
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@en,
+        rdfs:label "General Algebraic Modeling System"@en
     
     Types: 
         OEO_00000382
+    
+    Facts:  
+     OEO_00000503  OEO_00010488
     
     
 Individual: OEO_00000187
@@ -3840,6 +3845,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1869",
     
     Facts:  
      OEO_00000501  OEO_00000267
+    
+    
+Individual: OEO_00010488
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The GAMS programming language is a programming language developed by GAMS Development Corp. for use in the General Algebraic Modeling System.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@en,
+        rdfs:label "GAMS programming language"@en
+    
+    Types: 
+        <http://purl.obolibrary.org/obo/IAO_0000025>
+    
+    Facts:  
+     OEO_00000501  OEO_00000180
     
     
 Individual: OEO_00020027

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3599,6 +3599,8 @@ Individual: OEO_00000180
         <http://purl.obolibrary.org/obo/IAO_0000115> "The General Algebraic Modeling System (GAMS) is a proprietary software framework developed by GAMS Development Corp. that uses the GAMS programming language."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/859
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1889",
         rdfs:label "General Algebraic Modeling System"@en
     
     Types: 
@@ -3853,6 +3855,8 @@ Individual: OEO_00010488
         <http://purl.obolibrary.org/obo/IAO_0000115> "The GAMS programming language is a programming language developed by GAMS Development Corp. for use in the General Algebraic Modeling System.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GAMS"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/859
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1889",
         rdfs:label "GAMS programming language"@en
     
     Types: 


### PR DESCRIPTION
## Summary of the discussion

To properly define GAMS, split existing individual `gams` into two individuals.

## Type of change (CHANGELOG.md)

### Update
- `gams` (OEO_00000180) -> `General Algebraic Modeling System` (alternative label: `GAMS`): _The General Algebraic Modeling System (GAMS) is a proprietary software framework developed by GAMS Development Corp. that uses the GAMS programming language._

### Add
- `GAMS programming language` (alternative label: `GAMS`): _The GAMS programming language is a programming language developed by GAMS Development Corp. for use in the General Algebraic Modeling System._

## Workflow checklist

### Automation
Part of #859, but solves the issue not completely, so no automation.

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
