### PR TITLE
Update IssueProject.yml

### DIFF
--- a/.github/workflows/IssueProject.yml
+++ b/.github/workflows/IssueProject.yml
@@ -9,12 +9,12 @@ jobs:
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/OpenEnergyPlatform/ontology/projects/3
+        GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
         GITHUB_PROJECT_COLUMN_NAME: To do
     - name: add-new-prs-to-repository-based-project-column
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'pull_request' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/OpenEnergyPlatform/ontology/projects/3
+        GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
         GITHUB_PROJECT_COLUMN_NAME: Review in progress


### PR DESCRIPTION
## Summary of the discussion
Opening a new issue caused an error in the issue-project-workflow: https://github.com/OpenEnergyPlatform/ontology/actions/runs/10629987303
I checked the link and saw that the "project 3" in the former link is redirected to "project 45" now. Therefore I adjusted the links in the yaml file.


### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
