### PR TITLE
Simplify domain and range of `is traded at` and `trades` #1239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - kilowatt, megawatt (#1900)
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
+- service product (#1912)
 - term tracker annotation (#1913)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - train, regionalisation (#1899)
 - add annotation: climate neutrality criterion, negative emission, study report due to legislation, decarbonisation pathway, re-share, flexibility, energy conversion efficiency, resilience, life cycle assessment, co2 emissions, ghg emissions, acceptance, sufficiency, energy demand, electrical energy share, regionalsation, gross electricity generation, electricity/gas/heating grid, sector coupling, model coupling, scenario projection comparison, model intercomparison study, policies and measures  (#1897)
 - economic instrument, education instrument, information instrument, regulatory instrument, voluntary agreement instrument (#1906)
+- is traded at, trades (#1912)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - kilowatt, megawatt (#1900)
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
-- service product (#1912)
+- product (#1912)
 - term tracker annotation (#1913)
 
 ### Changed

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -213,7 +213,6 @@ ObjectProperty: OEO_00020056
 ObjectProperty: OEO_00020070
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a commodity and a market exchange where the commodity is offered for trade/sale at the market exchange."@en,
         OEO_00020426 "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 change range:
@@ -227,6 +226,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
 Simplify domain and range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a commodity and a market exchange where the commodity is offered for trade/sale at the market exchange."@en,
         rdfs:label "is traded at"@en
     
     SubPropertyOf: 
@@ -256,7 +256,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
 Simplify domain and range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
         rdfs:label "trades"@en
     
@@ -1012,6 +1011,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1906",
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
         <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00140151
+    
+    
+Class: OEO_00010501
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A product is a continuant that is either a good or a service product."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Produkt"@de,
+        rdfs:label "product"@en
+    
+    EquivalentTo: 
+        OEO_00010116 or OEO_00360019
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000002>
     
     
 Class: OEO_00020015

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -266,8 +266,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
         OEO_00020069
     
     Range: 
-        
-            Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
         OEO_00010501
     
     InverseOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -213,7 +213,7 @@ ObjectProperty: OEO_00020056
 ObjectProperty: OEO_00020070
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and commodities, or other products which are traded there."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and commodities which are traded there."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 change range:
@@ -222,7 +222,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/842
 
 add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
+
+Simplify domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
         rdfs:label "is traded at"@en
     
     SubPropertyOf: 
@@ -248,7 +252,11 @@ ObjectProperty: OEO_00020071
 
 add domain and range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
+
+Simplify domain and range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
         rdfs:label "trades"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1016,6 +1016,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1906",
 Class: OEO_00010501
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1514
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A product is a continuant that is either a good or a service product."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Produkt"@de,
         rdfs:label "product"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -213,7 +213,7 @@ ObjectProperty: OEO_00020056
 ObjectProperty: OEO_00020070
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and commodities which are traded there."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a commodity and a market exchange where the commodity is offered for trade/sale at the market exchange."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 change range:
@@ -247,7 +247,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
 ObjectProperty: OEO_00020071
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between commodities and a market exchange."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Trades is a relation that holds between a market exchange and a commodity where the commodity is offered for trade/sale at the market exchange."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 add domain and range:

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -223,10 +223,10 @@ add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
 
-Simplify domain and range:
+Simplify domain and range by using product:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a commodity and a market exchange where the commodity is offered for trade/sale at the market exchange."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a product and a market exchange where the product is offered for trade/sale at the market exchange."@en,
         rdfs:label "is traded at"@en
     
     SubPropertyOf: 
@@ -235,7 +235,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
     Domain: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
-        OEO_00020067
+        OEO_00010501
     
     Range: 
         OEO_00020069
@@ -253,10 +253,10 @@ add domain and range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/973
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127
 
-Simplify domain and range:
+Simplify domain and range by using product:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1239
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a product and a market exchange.",
         rdfs:label "trades"@en
     
     SubPropertyOf: 
@@ -268,7 +268,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1912",
     Range: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
-        OEO_00020067
+        OEO_00010501
     
     InverseOf: 
         OEO_00020070

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -213,7 +213,7 @@ ObjectProperty: OEO_00020056
 ObjectProperty: OEO_00020070
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and the financial instruments, commodities, or other products, services, or goods which are traded there.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Is traded at is a relation that holds between a market exchange and commodities, or other products which are traded there."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 change range:
@@ -231,10 +231,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
     Domain: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of domain to financial instrument and other products planned"
-        OEO_00010116 or OEO_00020067 or OEO_00140124
+        OEO_00020067
     
     Range: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
+        OEO_00020069
     
     InverseOf: 
         OEO_00020071
@@ -243,7 +243,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
 ObjectProperty: OEO_00020071
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between financial instruments, commodities, or other products, services, or goods and a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between commodities and a market exchange."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/748
 
 add domain and range:
@@ -255,12 +255,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1127",
         owl:topObjectProperty
     
     Domain: 
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040002
+        OEO_00020069
     
     Range: 
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Extension of range to financial instrument and other products planned"
-        OEO_00010116 or OEO_00020067 or OEO_00140124
+        OEO_00020067
     
     InverseOf: 
         OEO_00020070


### PR DESCRIPTION
## Summary of the discussion

Introducing a class `product` enables to simplify the object properties `is traded at` and `trades`.

## Type of change (CHANGELOG.md)

### Add
- `product`: _A product is a continuant that is either a good or a service product._
  - `product EquivalentTo: good or 'service product'`

### Update
- `is traded at`: _Is traded at is a relation that holds between a product and a market exchange where the product is offered for trade/sale at the market exchange._
  - domain: `product`
  - range: `market exchange`
- `trades`: _A relation that holds between a product and a market exchange._
  - domain: `market exchange`
  - range: `product`

## Workflow checklist

### Automation
Closes #1239
Also implements parts of (`product`) from #1514

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
