### PR TITLE
add `term tracker annotation` property #1850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - kilowatt, megawatt (#1900)
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
+- term tracker annotation (#1913)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -58,9 +58,6 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
-AnnotationProperty: <http://www.ontologyrepository.com/CommonCoreOntologies/definition>
-
-    
 AnnotationProperty: OEO_00010037
 
     Annotations: 
@@ -86,10 +83,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 AnnotationProperty: OEO_00020426
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A term tracker annotation is an editor note used to track the history of an entity. For each change, it records the related GitHub issue and pull request.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This annotation property was added to replace the previously used \"term tracker item\". 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://www.ontologyrepository.com/CommonCoreOntologies/definition> "A term tracker annotation is an editor note used to track the history of an entity. For each change, it records the related GitHub issue and pull request.",
         rdfs:label "term tracker annotation"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -58,6 +58,9 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
+AnnotationProperty: <http://www.ontologyrepository.com/CommonCoreOntologies/definition>
+
+    
 AnnotationProperty: OEO_00010037
 
     Annotations: 
@@ -86,7 +89,7 @@ AnnotationProperty: OEO_00020426
         <http://purl.obolibrary.org/obo/IAO_0000116> "This annotation property was added to replace the previously used \"term tracker item\". 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        rdfs:comment "A term tracker annotation is an editor note used to track the history of an entity. For each change, it records the related GitHub issue and pull request.",
+        <http://www.ontologyrepository.com/CommonCoreOntologies/definition> "A term tracker annotation is an editor note used to track the history of an entity. For each change, it records the related GitHub issue and pull request.",
         rdfs:label "term tracker annotation"
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -80,6 +80,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
         rdfs:label "oekg annotation"
     
     
+AnnotationProperty: OEO_00020426
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000116> "This annotation property was added to replace the previously used \"term tracker item\". 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        rdfs:comment "A term tracker annotation is an editor note used to track the history of an entity. For each change, it records the related GitHub issue and pull request.",
+        rdfs:label "term tracker annotation"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000116>
+    
+    
 AnnotationProperty: OEO_00040001
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

To replace the formerly used `term tracker item`, which was used in an unproper way, a new annotation property `term tracker annotation` is introduced as subproperty of `editor note`. See #1850 
The replacement of the annotations in the oeo files will be done in separate PRs.

## Type of change (CHANGELOG.md)

### Add
- `term tracker annotation`



### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
