### PR TITLE
Add `licensee`, `licence provider`, `permits` and `has licence provider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
 - term tracker annotation (#1913)
+- licence provider, licensee, has licence provider, permits (#1925)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -301,6 +301,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441",
 ObjectProperty: OEO_00010497
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a licence and the agent providing the licence to do something."@en,
         rdfs:label "has licence provider"@en
     
@@ -314,6 +316,8 @@ ObjectProperty: OEO_00010497
 ObjectProperty: OEO_00010498
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a licence and a process in which the licence describes under which conditions a licensee can perform a process."@en,
         rdfs:label "permits"@en
     
@@ -1814,6 +1818,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1799",
 Class: OEO_00010499
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licensee is an agent that is permitted by a licence provider to participate in some process."@en,
         rdfs:label "licensee"@en
     
@@ -1824,6 +1830,8 @@ Class: OEO_00010499
 Class: OEO_00010500
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licence provider is an agent that provide a licence that allows a licensee to do something specific."@en,
         rdfs:label "licence provider"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -90,6 +90,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 
     
@@ -293,6 +296,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441",
     
     Range: 
         <http://purl.obolibrary.org/obo/BFO_0000006>
+    
+    
+ObjectProperty: OEO_00010497
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a licence and the agent providing the licence to do something."@en,
+        rdfs:label "has licence provider"@en
+    
+    Domain: 
+        OEO_00020015
+    
+    Range: 
+        OEO_00010500
+    
+    
+ObjectProperty: OEO_00010498
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a licence and a process in which the licence describes under which conditions a licensee can perform a process."@en,
+        rdfs:label "permits"@en
+    
+    Domain: 
+        OEO_00020015
+    
+    Range: 
+        OEO_00010499
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some <http://purl.obolibrary.org/obo/BFO_0000015>)
     
     
 ObjectProperty: OEO_00020056
@@ -631,6 +661,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1075",
     SubClassOf: 
         OEO_00010247
     
+    
+Class: OEO_00000051
+
     
 Class: OEO_00000059
 
@@ -1776,6 +1809,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1799",
     SubClassOf: 
         OEO_00000275,
         OEO_00140094 some OEO_00010411
+    
+    
+Class: OEO_00010499
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licensee is an agent that is permitted by a licence provider to participate in some process."@en,
+        rdfs:label "licensee"@en
+    
+    SubClassOf: 
+        OEO_00000051
+    
+    
+Class: OEO_00010500
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence provider is an agent that provide a licence that allows a licensee to do something specific."@en,
+        rdfs:label "licence provider"@en
+    
+    SubClassOf: 
+        OEO_00000051
     
     
 Class: OEO_00020011

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1821,6 +1821,7 @@ Class: OEO_00010499
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licensee is an agent that is permitted by a licence provider to participate in some process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Lizenznehmer"@de,
         rdfs:label "licensee"@en
     
     SubClassOf: 
@@ -1833,6 +1834,7 @@ Class: OEO_00010500
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A licence provider is an agent that provide a licence that allows a licensee to do something specific."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Lizenzgeber"@de,
         rdfs:label "licence provider"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -1833,7 +1833,7 @@ Class: OEO_00010500
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1925",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence provider is an agent that provide a licence that allows a licensee to do something specific."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A licence provider is an agent that provides a licence that allows a licensee to do something specific."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lizenzgeber"@de,
         rdfs:label "licence provider"@en
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -68,7 +68,7 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
-AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/OEO_00020426>
+AnnotationProperty: OEO_00020426
 
     
 AnnotationProperty: dc:contributor

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -68,9 +68,6 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
-AnnotationProperty: OEO_00020426
-
-    
 AnnotationProperty: dc:contributor
 
     
@@ -84,8 +81,5 @@ AnnotationProperty: dct:title
 
     
 Datatype: rdf:PlainLiteral
-
-    
-Datatype: xsd:string
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -68,6 +68,9 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
+
+    
 AnnotationProperty: dc:contributor
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -68,6 +68,9 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
+AnnotationProperty: <http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/OEO_00020426>
+
+    
 AnnotationProperty: dc:contributor
 
     
@@ -81,5 +84,8 @@ AnnotationProperty: dct:title
 
     
 Datatype: rdf:PlainLiteral
+
+    
+Datatype: xsd:string
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -68,9 +68,6 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/>,
     dct:title "Open Energy Ontology"
 
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
-
-    
 AnnotationProperty: dc:contributor
 
     


### PR DESCRIPTION
## Summary of the discussion

Improve depiction `licence` by adding related classes and object properties.

```
                    has license provider              permits                 participates in
licence provider <------------------------ license ------------> (licensee --------------------> process)
```

## Type of change (CHANGELOG.md)

### Add
- classes:
  - `licence provider`: _A licence provider is an agent that provide a licence that allows a licensee to do something specific._
  - `licensee`: _A licensee is an agent that is permitted by a licence provider to participate in some process._
- object properties:
  - `permits`: _A relation between a licence and a process in which the licence describes under which conditions a licensee can perform a process._
  - `has licence provider`: _A relation between a licence and the agent providing the licence to do something._

### Update
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Remove
- Removed a broken link [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

## Workflow checklist

### Automation
Closes #1873

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
