### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - German alternative labels (#1883, #1895)
 - English language tags to existing alternative labels (#1883, #1895)
 - GAMS programming language (#1889)
-- kilowatt, megawatt (#1900)
 - oeo:unit, oeo:physical unit (#1892)
+- kilowatt, megawatt (#1900)
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
 - product (#1912)
@@ -18,8 +18,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)
-- train, regionalisation (#1899)
 - uo:unit (#1892)
+- train, regionalisation (#1899)
 - add annotation: climate neutrality criterion, negative emission, study report due to legislation, decarbonisation pathway, re-share, flexibility, energy conversion efficiency, resilience, life cycle assessment, co2 emissions, ghg emissions, acceptance, sufficiency, energy demand, electrical energy share, regionalsation, gross electricity generation, electricity/gas/heating grid, sector coupling, model coupling, scenario projection comparison, model intercomparison study, policies and measures  (#1897)
 - economic instrument, education instrument, information instrument, regulatory instrument, voluntary agreement instrument (#1906)
 - is traded at, trades (#1912)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - German alternative labels (#1883, #1895)
 - English language tags to existing alternative labels (#1883, #1895)
 - GAMS programming language (#1889)
-- oeo:unit, oeo:physical unit (#1892)
-
-### Changed
-- gams -> General Algebraic Modeling System (#1889)
-- uo:unit (#1892)
 - kilowatt, megawatt (#1900)
+- oeo:unit, oeo:physical unit (#1892)
 - oekg annotation (#1897)
 - economic instrument function, education instrument function, information instrument function, regulatory instrument function, voluntary agreement instrument function (#1906)
 - product (#1912)
@@ -23,6 +19,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)
 - train, regionalisation (#1899)
+- uo:unit (#1892)
 - add annotation: climate neutrality criterion, negative emission, study report due to legislation, decarbonisation pathway, re-share, flexibility, energy conversion efficiency, resilience, life cycle assessment, co2 emissions, ghg emissions, acceptance, sufficiency, energy demand, electrical energy share, regionalsation, gross electricity generation, electricity/gas/heating grid, sector coupling, model coupling, scenario projection comparison, model intercomparison study, policies and measures  (#1897)
 - economic instrument, education instrument, information instrument, regulatory instrument, voluntary agreement instrument (#1906)
 - is traded at, trades (#1912)


### PR DESCRIPTION
## Summary of the discussion

@LillyG901 found that CHANGELOG.md has two _changed sections_
https://github.com/OpenEnergyPlatform/ontology/pull/1928#issuecomment-2363246015

This PR fixes this

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
