### PR TITLE
make economic value obsolete #1917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - replace term tracker item with term tracker annotation (#1922, #1923)
 - monetary value (formerly: monetary price) and subclasses (#1902)
 
+### Obsoletion
+- economic value, has economic value, economic value (#1931)
+
 ### Removed
 
 ## [2.4.0] - 2024-07-01

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1954,7 +1954,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
-        rdfs:comment "This term was made obsolete together with economic value because its definition is rather vague and thus not useful.",
+        rdfs:comment "This term was made obsolete because its definition is rather vague and thus not useful.",
         rdfs:label "obsolete economic value"@en,
         owl:deprecated true
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1954,7 +1954,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
-        rdfs:comment "This term was made obsolete because its definition is rather vague and thus not useful.",
+        rdfs:comment "This term was made obsolete together with economic value because its definition is rather vague and thus not useful.",
         rdfs:label "obsolete economic value"@en,
         owl:deprecated true
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1940,9 +1940,13 @@ move to oeo-shared
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+obsoletion
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
+        rdfs:comment "This term was made obsolete because its definition is rather vague and thus not useful.",
         rdfs:label "obsolete economic value"@en,
         owl:deprecated true
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1955,7 +1955,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
         rdfs:comment "This term was made obsolete because its definition is rather vague and thus not useful.",
-        rdfs:label "obsolete economic value"@en
+        rdfs:label "obsolete economic value"@en,
+        owl:deprecated true
     
     SubClassOf: 
         OEO_00000350

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -932,12 +932,16 @@ ObjectProperty: OEO_00020179
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
 Make subproperty of 'quantity value of' and add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates an economic value to a related entity in reality.",
-        rdfs:label "economic value of"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422
+Obsoletion
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: A relation that relates an economic value to a related entity in reality.",
+        rdfs:comment "This relation was made obsolete together with economic value because its definition is rather vague and thus not useful.",
+        rdfs:label "obsolete economic value of"@en,
+        owl:deprecated true
     
     SubPropertyOf: 
         OEO_00020056
@@ -1947,8 +1951,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
         rdfs:comment "This term was made obsolete because its definition is rather vague and thus not useful.",
-        rdfs:label "obsolete economic value"@en,
-        owl:deprecated true
+        rdfs:label "obsolete economic value"@en
     
     SubClassOf: 
         OEO_00000350

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -117,6 +117,9 @@ AnnotationProperty: dc:description
 AnnotationProperty: dc:identifier
 
     
+AnnotationProperty: owl:deprecated
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -139,6 +142,9 @@ AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral
+
+    
+Datatype: xsd:boolean
 
     
 Datatype: xsd:integer
@@ -1935,9 +1941,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/956
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic value is a quantity value that is economically relevant.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: An economic value is a quantity value that is economically relevant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "wirtschaftlicher Wert"@de,
-        rdfs:label "economic value"@en
+        rdfs:label "obsolete economic value"@en,
+        owl:deprecated true
     
     SubClassOf: 
         OEO_00000350

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -955,12 +955,16 @@ ObjectProperty: OEO_00020180
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/958
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
-
 Make subproperty of 'has quatity value' and add range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1411
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an entity and an economic value.",
-        rdfs:label "has economic value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1422
+Obsoletion
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "OBSOLETE: A relation between an entity and an economic value.",
+        rdfs:comment "This relation was made obsolete together with economic value because its definition is rather vague and thus not useful.",
+        rdfs:label "obsolete has economic value"@en,
+        owl:deprecated true
     
     SubPropertyOf: 
         OEO_00140002

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1455,7 +1455,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is a quantity value that describes a financial compensation provided in exchange for services performed.",
         rdfs:label "remuneration"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1471,7 +1471,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is a quantity value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gebühr"@de,
         rdfs:label "fee"@en
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1225,28 +1225,34 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/781",
 Class: OEO_00020076
 
     Annotations: 
-        OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Aufschlag"@de,
         rdfs:label "markup"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
 Class: OEO_00020077
 
     Annotations: 
-        OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/256
-https://github.com/OpenEnergyPlatform/ontology/pull/800",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Abschlag"@de,
         rdfs:label "markdown"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -1428,13 +1434,16 @@ Class: OEO_00020124
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/904
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mitgliedsbeitrag"@de,
         rdfs:label "due"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -1442,12 +1451,15 @@ Class: OEO_00020125
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/902
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A remuneration is an economic value that describes a financial compensation provided in exchange for services performed.",
         rdfs:label "remuneration"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -1455,13 +1467,16 @@ Class: OEO_00020126
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/905
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fee is an economic value that represents an amount of money paid for a  particular piece of work or for a particular right or service.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gebühr"@de,
         rdfs:label "fee"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -1484,12 +1499,15 @@ Class: OEO_00020128
     Annotations: 
         OEO_00020426 "add term
 https://github.com/OpenEnergyPlatform/ontology/issues/908
-https://github.com/OpenEnergyPlatform/ontology/pull/929",
+https://github.com/OpenEnergyPlatform/ontology/pull/929
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
         rdfs:label "market revenue"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -1829,10 +1847,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00040003
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary value is a quantity value that states the amount of money specified in monetary units.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Geldwert"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "amount of money",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/331
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/640
 move to oeo-shared
@@ -1844,12 +1858,19 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 relabel as monetary value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1902
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1915",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1915
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A monetary value is a quantity value that states the amount of money specified in monetary units.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Geldwert"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "amount of money",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "fibo-fnd-acc-cur:MonetaryPrice",
         rdfs:label "monetary value"@en,
         rdfs:seeAlso "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/MonetaryPrice"
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00020179 some OEO_00010117,
         OEO_00040010 some OEO_00040004
     
@@ -1933,15 +1954,18 @@ https://github.com/OpenEnergyPlatform/ontology/pull/642",
 Class: OEO_00040008
 
     Annotations: 
-        OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/376
-https://github.com/OpenEnergyPlatform/ontology/pull/642",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/376
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/642
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Grenzkosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
         rdfs:label "marginal cost"@en
     
     SubClassOf: 
-        OEO_00140012
+        OEO_00000350
     
     
 Class: OEO_00040009
@@ -1956,14 +1980,17 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/975
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/977
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
         rdfs:label "cost"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -2032,7 +2059,10 @@ alternative term:
 https://github.com/OpenEnergyPlatform/ontology/issues/675
 https://github.com/OpenEnergyPlatform/ontology/pull/676
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1487
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "BIP"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttoinlandsprodukt"@de,
@@ -2041,7 +2071,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623",
         rdfs:label "gross domestic product"@en
     
     SubClassOf: 
-        OEO_00140012,
+        OEO_00000350,
         OEO_00040010 some OEO_00040004
     
     
@@ -2052,14 +2082,17 @@ Class: OEO_00140023
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/563
 alternative term:
 https://github.com/OpenEnergyPlatform/ontology/issues/675
-https://github.com/OpenEnergyPlatform/ontology/pull/676",
+https://github.com/OpenEnergyPlatform/ontology/pull/676
+make subclass of quantity value
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttowertschöpfung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GVA"@en,
         rdfs:label "gross value added"@en
     
     SubClassOf: 
-        OEO_00140012
+        OEO_00000350
     
     
 Class: OEO_00140109

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1247,7 +1247,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is an economic value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markdown is a quantity value that indicates a virtual amount deducted from an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Abschlag"@de,
         rdfs:label "markdown"@en
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1438,7 +1438,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is an economic value that represents a payment that an agent makes to belong to an organisation.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A due is a quantity value that represents a payment that an agent makes to belong to an organisation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mitgliedsbeitrag"@de,
         rdfs:label "due"@en
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1984,7 +1984,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is an economic value that describes the amount of money needed to buy, make, or do a thing.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is a quantity value that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
         rdfs:label "cost"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2086,7 +2086,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/676
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is an economic value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross value added is a quantity value that is the value of goods and services produced in a sector of an economy, measuring that sector's contribution to gross domestic product (GDP). It is calculated as the monetary value of products and services produced, less the value of intermediate consumption.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttowertschöpfung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GVA"@en,
         rdfs:label "gross value added"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -2063,7 +2063,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1623
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is an economic value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gross domestic product is a quantity value that represents the broadest measure of aggregate economic activity, measuring the total unduplicated market value of all final goods and services produced within a statistical area in a period.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "BIP"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttoinlandsprodukt"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GDP"@en,

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1230,7 +1230,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/800
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is an economic value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A markup is a quantity value that indicates a virtual amount added to an assumed or historical price to predict a price in a different context.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Aufschlag"@de,
         rdfs:label "markup"@en
     

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1959,7 +1959,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/642
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the economic value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marginal cost is the quantity value that corresponds to the change in the total cost that arises when the quantity produced is incremented by one unit; that is, it is the cost of producing one more unit of a good.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Grenzkosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "O'Sullivan, Arthur; Sheffrin, Steven M. (2003). Economics: Principles in Action.",
         rdfs:label "marginal cost"@en

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1503,7 +1503,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/929
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is an economic value that represents the income from a trade at a market exchange.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Market revenue is a quantity value that represents the income from a trade at a market exchange.",
         rdfs:label "market revenue"@en
     
     SubClassOf: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -80,6 +80,12 @@ AnnotationProperty: dct:license
 AnnotationProperty: dct:title
 
     
+AnnotationProperty: rdfs:comment
+
+    
 Datatype: rdf:PlainLiteral
+
+    
+Datatype: xsd:string
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -80,12 +80,6 @@ AnnotationProperty: dct:license
 AnnotationProperty: dct:title
 
     
-AnnotationProperty: rdfs:comment
-
-    
 Datatype: rdf:PlainLiteral
-
-    
-Datatype: xsd:string
 
     


### PR DESCRIPTION
## Summary of the discussion

If we agree that we do not need this class anymore, then should deprecate it and not simply delete it as this class was potentially already used externally. Inspired by https://wiki.geneontology.org/Obsoleting_an_Existing_Ontology_Term I suggest:
* [x] label: `obsolete economic value`
* [x] definition: _OBSOLETE: An economic value is a quantity value that is economically relevant._
* [x] comment: _This term was made obsolete because its definition is rather vague and thus not useful._
* [x] Add annotation `owl:deprecated: true`
* [x] Remove all axioms

For the object properties the same, respectively with the comment: _As the class economic value was deprecated this object property became obsolete, too._

## Type of change (CHANGELOG.md)

### Add
- Added a new class [#](https://github.com/OpenEnergyPlatform/ontology/issues/)

### Update
- markup, markdown, due, remuneration, fee, market revenue, monetary value, marginal cost, cost, gross domestic product, gross value added (#1931)

### Obsoletion
- economic value


## Workflow checklist

### Automation
Closes #1917

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
