### PR TITLE
Update used Action & Secret in IssueProject.yml

### DIFF
--- a/.github/workflows/IssueProject.yml
+++ b/.github/workflows/IssueProject.yml
@@ -1,20 +1,24 @@
 name: Add new GitHub issues and pull requests to the "Issues" project
-on: [issues, pull_request]
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
 jobs:
   github-actions-automate-projects:
     runs-on: ubuntu-latest
     steps:
     - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-      if: github.event_name == 'issues' && github.event.action == 'opened'
-      env:
-        GITHUB_TOKEN: ${{ secrets.OEO_WORKFLOWS }}
-        GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
-        GITHUB_PROJECT_COLUMN_NAME: To do
+      uses: actions/add-to-project@v1.0.2
+      with:
+        project-url: https://github.com/orgs/OpenEnergyPlatform/projects/45
+        github-token: ${{ secrets.OEO_WORKFLOWS }}
+      if: github.event_name == 'issues'
     - name: add-new-prs-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-      if: github.event_name == 'pull_request' && github.event.action == 'opened'
-      env:
-        GITHUB_TOKEN: ${{ secrets.OEO_WORKFLOWS }}
-        GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
-        GITHUB_PROJECT_COLUMN_NAME: Review in progress
+      uses: actions/add-to-project@v1.0.2
+      with:
+        project-url: https://github.com/orgs/OpenEnergyPlatform/projects/45
+        github-token: ${{ secrets.OEO_WORKFLOWS }}
+      if: github.event_name == 'pull_request'

--- a/.github/workflows/IssueProject.yml
+++ b/.github/workflows/IssueProject.yml
@@ -8,13 +8,13 @@ jobs:
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.OEO_WORKFLOWS }}
         GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
         GITHUB_PROJECT_COLUMN_NAME: To do
     - name: add-new-prs-to-repository-based-project-column
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'pull_request' && github.event.action == 'opened'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.OEO_WORKFLOWS }}
         GITHUB_PROJECT_URL: https://github.com/orgs/OpenEnergyPlatform/projects/45
         GITHUB_PROJECT_COLUMN_NAME: Review in progress


### PR DESCRIPTION
## Summary of the discussion

Updated the action & secret used in IssueProject.yml. 
In contrast to the previous one, the now-used action [`actions/add-to-project`](https://github.com/actions/add-to-project) is not only still maintained but also supports ProjectsV2.
The secret redirects to a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) that grants access to the whole organization for managing organization-based projects (like the [Issues Project](https://github.com/orgs/OpenEnergyPlatform/projects/45))

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
\---

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
