### PR TITLE
Change label of energy amount value #1865

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is traded at, trades (#1912)
 - replace term tracker item with term tracker annotation (#1922, #1923)
 - replace has bearer with characteristic of (#1928)
-- replace lable "energy amount value" with "energy value and added it as alt lable (#1941)
+- energy amount value / energy value (#1941)
 - rework contributing and readme file (#1937)
 - time stamp (#1944)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is traded at, trades (#1912)
 - replace term tracker item with term tracker annotation (#1922, #1923)
 - replace has bearer with characteristic of (#1928)
+- replace lable "energy amount value" with "energy value and added it as alt lable (#1941)
 
 ### Obsoletion
 - economic value, has economic value, economic value (#1931)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -131,6 +131,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000052>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -2526,8 +2529,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00000159
@@ -2907,10 +2910,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
             (OEO_00000331
-             and (OEO_00000531 value OEO_00000182)),
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
+             and (OEO_00000531 value OEO_00000182))
     
     
 Class: OEO_00000199
@@ -3118,7 +3121,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         OEO_00230020,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3126,7 +3128,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002
+        OEO_00020182 some OEO_00110002,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
     
     
 Class: OEO_00000219
@@ -4688,13 +4691,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
         
             Annotations: OEO_00020426 "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
         OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043
+        OEO_00020183 some OEO_00020043,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054
     
     
 Class: OEO_00000447
@@ -7970,8 +7973,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        OEO_00010231 some OEO_00010332
+        OEO_00010231 some OEO_00010332,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00010334
@@ -8232,8 +8235,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010386
@@ -8499,8 +8502,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010413
@@ -10113,9 +10116,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000044 or OEO_00000448),
-        OEO_00140002 some OEO_00140001
+            (OEO_00000044 or OEO_00000448)
     
     
 Class: OEO_00020147
@@ -11250,19 +11253,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030035
 
     
-Class: OEO_00340069
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
-        OEO_00020426 "Update size and add amount
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        rdfs:label "amount"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
 Class: OEO_00050000
 
     Annotations: 
@@ -11773,8 +11763,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044,
-        OEO_00140002 some OEO_00140001
+        OEO_00140002 some OEO_00140001,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044
     
     
 Class: OEO_00140001
@@ -12636,8 +12626,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140127
@@ -12674,8 +12664,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140133
@@ -15563,19 +15553,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340068
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         OEO_00020426 "restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851
 Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-     
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         rdfs:label "size"@en
     
     SubClassOf: 
         OEO_00340062
+    
+    
+Class: OEO_00340069
+
+    Annotations: 
+        OEO_00020426 "Update size and add amount
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
+        rdfs:label "amount"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00360001
@@ -15654,8 +15656,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00360008

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -131,6 +131,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000052>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -2526,8 +2529,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00000159
@@ -2907,10 +2910,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
             (OEO_00000331
-             and (OEO_00000531 value OEO_00000182)),
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
+             and (OEO_00000531 value OEO_00000182))
     
     
 Class: OEO_00000199
@@ -3118,7 +3121,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         OEO_00230020,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3126,7 +3128,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002
+        OEO_00020182 some OEO_00110002,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
     
     
 Class: OEO_00000219
@@ -4688,13 +4691,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
         
             Annotations: OEO_00020426 "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
         OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043
+        OEO_00020183 some OEO_00020043,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054
     
     
 Class: OEO_00000447
@@ -7970,8 +7973,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        OEO_00010231 some OEO_00010332
+        OEO_00010231 some OEO_00010332,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00010334
@@ -8232,8 +8235,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010386
@@ -8499,8 +8502,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010413
@@ -10113,9 +10116,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000044 or OEO_00000448),
-        OEO_00140002 some OEO_00140001
+            (OEO_00000044 or OEO_00000448)
     
     
 Class: OEO_00020147
@@ -11250,19 +11253,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030035
 
     
-Class: OEO_00340069
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
-        OEO_00020426 "Update size and add amount
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        rdfs:label "amount"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
 Class: OEO_00050000
 
     Annotations: 
@@ -11605,11 +11595,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy amount value is a quantity value that has an energy unit as unit."@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+change lable and add alt lable
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1865
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energiemenge"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        rdfs:label "energy amount value"@en
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy amount value",
+        rdfs:label "energy value"@en
     
     SubClassOf: 
         OEO_00000350,
@@ -11773,8 +11768,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044,
-        OEO_00140002 some OEO_00140001
+        OEO_00140002 some OEO_00140001,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044
     
     
 Class: OEO_00140001
@@ -12636,8 +12631,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140127
@@ -12674,8 +12669,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140133
@@ -15563,19 +15558,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340068
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         OEO_00020426 "restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851
 Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-     
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         rdfs:label "size"@en
     
     SubClassOf: 
         OEO_00340062
+    
+    
+Class: OEO_00340069
+
+    Annotations: 
+        OEO_00020426 "Update size and add amount
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
+        rdfs:label "amount"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00360001
@@ -15654,8 +15661,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00360008

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11597,7 +11597,7 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
-change lable and add alt lable
+change label and add alternative label
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1865
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -131,9 +131,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000052>
 
     
-ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
-
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -2529,8 +2526,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
     
     
 Class: OEO_00000159
@@ -2910,10 +2907,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
             (OEO_00000331
-             and (OEO_00000531 value OEO_00000182))
+             and (OEO_00000531 value OEO_00000182)),
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
     
     
 Class: OEO_00000199
@@ -3121,6 +3118,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         OEO_00230020,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3128,8 +3126,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
+        OEO_00020182 some OEO_00110002
     
     
 Class: OEO_00000219
@@ -4691,13 +4688,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
         
             Annotations: OEO_00020426 "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
         OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054
+        OEO_00020183 some OEO_00020043
     
     
 Class: OEO_00000447
@@ -7973,8 +7970,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010231 some OEO_00010332,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        OEO_00010231 some OEO_00010332
     
     
 Class: OEO_00010334
@@ -8235,8 +8232,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
     
     
 Class: OEO_00010386
@@ -8502,8 +8499,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103
     
     
 Class: OEO_00010413
@@ -10116,9 +10113,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000044 or OEO_00000448)
+            (OEO_00000044 or OEO_00000448),
+        OEO_00140002 some OEO_00140001
     
     
 Class: OEO_00020147
@@ -11253,6 +11250,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030035
 
     
+Class: OEO_00340069
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
+        OEO_00020426 "Update size and add amount
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
+        rdfs:label "amount"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
 Class: OEO_00050000
 
     Annotations: 
@@ -11763,8 +11773,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044,
+        OEO_00140002 some OEO_00140001
     
     
 Class: OEO_00140001
@@ -12626,8 +12636,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
+        OEO_00140002 some OEO_00140127
     
     
 Class: OEO_00140127
@@ -12664,8 +12674,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
+        OEO_00140002 some OEO_00140127
     
     
 Class: OEO_00140133
@@ -15553,31 +15563,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340068
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         OEO_00020426 "restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851
 Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
+     
         rdfs:label "size"@en
     
     SubClassOf: 
         OEO_00340062
-    
-    
-Class: OEO_00340069
-
-    Annotations: 
-        OEO_00020426 "Update size and add amount
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
-        rdfs:label "amount"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00360001
@@ -15656,8 +15654,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
     
     
 Class: OEO_00360008


### PR DESCRIPTION
## Summary of the discussion

See #1865. I implemented the suggestion that was agreed on: Changing energy amount value to energy value and keeping the old name as alternative lable. I also changed the name in the definition to the main lable.

## Type of change (CHANGELOG.md)

### Update
- replace lable "energy amount value" with "energy value and added it as alt lable 


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
