### PR TITLE
[Bugfix] import of oeo-import-edits in oeo-shared

### DIFF
--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn" uri="oeo-model.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn" uri="oeo-physical.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo-sector.omn" uri="oeo-sector.omn"/>
@@ -9,7 +10,7 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1726817551697" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1726817551697" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1728550706758" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1728550706758" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>


### PR DESCRIPTION
## Summary of the discussion
Somehow, the import of oeo-import-edits to oeo-share are corrupted. Instead of oeo-import-edits, oeo v2.5 was imported, see screenshots. That causes duplicate annotations, when the module files are opened seperately in Protege (without oeo.omn).
@madbkr found the bug and I could reproduce it.
![grafik](https://github.com/user-attachments/assets/9cd22933-ceb6-4f55-998c-d1ef7e7ea019)
![grafik](https://github.com/user-attachments/assets/d31118cc-928b-43bc-b764-7dee7e88a958)

I renewed the import on oeo-import-edits to oeo-shared via the protege import wizard. The problem seems to be fixed now.
![grafik](https://github.com/user-attachments/assets/c7ac7634-57f7-4f3f-ad4c-62f74b0577cc)

## Type of change (CHANGELOG.md)

### Update
- import of oeo-import-edits to oeo-shared


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
