### PR TITLE
Add object properties "has aggregation type" and "has time stamp alignment" #1901

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - product (#1912)
 - term tracker annotation (#1913)
 - licence provider, licensee, has licence provider, permits (#1925)
-- object properties "has aggregation type" and "has time stamp alignment" (#1944)
+- has aggregation type, has time stamp alignment (#1944)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - product (#1912)
 - term tracker annotation (#1913)
 - licence provider, licensee, has licence provider, permits (#1925)
+- object properties "has aggregation type" and "has time stamp alignment" (#1944)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)
@@ -34,6 +35,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is traded at, trades (#1912)
 - replace term tracker item with term tracker annotation (#1922, #1923)
 - replace has bearer with characteristic of (#1928)
+- definition of time stamp (#1944)
 
 ### Obsoletion
 - economic value, has economic value, economic value (#1931)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - is traded at, trades (#1912)
 - replace term tracker item with term tracker annotation (#1922, #1923)
 - replace has bearer with characteristic of (#1928)
-- definition of time stamp (#1944)
+- time stamp (#1944)
 
 ### Obsoletion
 - economic value, has economic value, economic value (#1931)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3167,7 +3167,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853
 update definition
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a temporal region, or a data item that is related to a temporal region, e.g. a time stamped measurement datum. If the time stamp refers to a time step/one-dimensional temporal region, the indication of a time stamp alignment is required",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe either a temporal region or a data item that is related to a temporal region, e.g. a time stamped measurement datum. If the time stamp refers to a time step/one-dimensional temporal region, the indication of a time stamp alignment is required",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zeitstempel"@de,
         rdfs:label "time stamp"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -89,7 +89,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
-
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000052>
 
     
@@ -524,6 +524,26 @@ ObjectProperty: OEO_00140164
 
     Domain: 
         OEO_00000274
+    
+    
+ObjectProperty: OEO_00390023
+
+    Annotations: 
+        OEO_00020426 "Added
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data item and an aggregation type that indicates the method of data aggregation applied to the data set.",
+        rdfs:label "has aggregation type"@en
+    
+    
+ObjectProperty: OEO_00390024
+
+    Annotations: 
+        OEO_00020426 "Added
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a time stamp or time series and a time stamp alignment that indicates the position of the time stamps that refer to the time step(s).",
+        rdfs:label "has time stamp alignment"@en
     
     
 ObjectProperty: owl:topObjectProperty
@@ -3142,8 +3162,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 reclassify as data descriptor
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1536
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a zero-dimensional temporal region, or a data item that is related to a zero-dimensional temporal region, e.g. a time stamped measurement datum.",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853
+
+update definition
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a temporal region, or a data item that is related to a temporal region, e.g. a time stamped measurement datum. If the time stamp refers to a time step/one-dimensional temporal region, the indication of a time stamp alignment is required",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zeitstempel"@de,
         rdfs:label "time stamp"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -531,7 +531,7 @@ ObjectProperty: OEO_00390023
     Annotations: 
         OEO_00020426 "Added
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data item and an aggregation type that indicates the method of data aggregation applied to the data set.",
         rdfs:label "has aggregation type"@en
     
@@ -541,7 +541,7 @@ ObjectProperty: OEO_00390024
     Annotations: 
         OEO_00020426 "Added
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a time stamp or time series and a time stamp alignment that indicates the position of the time stamps that refer to the time step(s).",
         rdfs:label "has time stamp alignment"@en
     
@@ -3166,7 +3166,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1853
 
 update definition
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/0",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A time stamp is a data descriptor that is used to describe a temporal region, or a data item that is related to a temporal region, e.g. a time stamped measurement datum. If the time stamp refers to a time step/one-dimensional temporal region, the indication of a time stamp alignment is required",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zeitstempel"@de,
         rdfs:label "time stamp"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -532,7 +532,7 @@ ObjectProperty: OEO_00390023
         OEO_00020426 "Added
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1901
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data item and an aggregation type that indicates the method of data aggregation applied to the data set.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a data item or data set and an aggregation type that indicates the method of data aggregation applied to the data set.",
         rdfs:label "has aggregation type"@en
     
     


### PR DESCRIPTION
## Summary of the discussion
See #1901
I added the two object properties and changed the definition of time stamp. However I found it a bit hard to find out what the consensus of the discussion really was so double-checking the definitions would be helpful.

## Type of change (CHANGELOG.md)

### Add
- object properties "has aggregation type" and "has time stamp alignment" 

### Update
- definition of time stamp 



## Workflow checklist

### Automation
Closes #1901

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker item`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
