### PR TITLE
add concepts for (modelling) uncertainties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - term tracker annotation (#1913)
 - licence provider, licensee, has licence provider, permits (#1925)
 - has aggregation type, has time stamp alignment (#1944)
-- concepts for (modelling) uncertainties (#1829)
+- uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambigous uncertainty, epistomological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - term tracker annotation (#1913)
 - licence provider, licensee, has licence provider, permits (#1925)
 - has aggregation type, has time stamp alignment (#1944)
+- concepts for (modelling) uncertainties (#1829)
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - term tracker annotation (#1913)
 - licence provider, licensee, has licence provider, permits (#1925)
 - has aggregation type, has time stamp alignment (#1944)
+- study descriptor (#1950)
 - file oeo-tasks (#1940)
 - action specification for techno-economic potential, calculate economic potential, calculate levelised cost of energy, determine capital expenditures, determine discount and interest rate, determine operational expenditures, determine wind turbine lifetime (#1940)
 - action specification for the feasible potential, apply constraints for assessment of potential, calculate feasible potential (#1940)
@@ -33,6 +34,10 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - feasible potential determination process, techno-economic potential determination process, wind characteristics determination process, wind farm area determination process, wind potential determination process (#1940)
 - feasible potential determination method, techno-economic potential determination method, wind characteristics determination method, wind farm area determination method, wind potential determination method (#1940)
 - uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambigous uncertainty, epistomological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
+
+
+
+
 
 ### Changed
 - gams -> General Algebraic Modeling System (#1889)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - determined feasible potential, determined techno-economic potential, determined wind characteristics, determined wind farm area, determined wind potential (#1940)
 - feasible potential determination process, techno-economic potential determination process, wind characteristics determination process, wind farm area determination process, wind potential determination process (#1940)
 - feasible potential determination method, techno-economic potential determination method, wind characteristics determination method, wind farm area determination method, wind potential determination method (#1940)
-- uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambigous uncertainty, epistomological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
+- uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambiguous uncertainty, epistomological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - determined feasible potential, determined techno-economic potential, determined wind characteristics, determined wind farm area, determined wind potential (#1940)
 - feasible potential determination process, techno-economic potential determination process, wind characteristics determination process, wind farm area determination process, wind potential determination process (#1940)
 - feasible potential determination method, techno-economic potential determination method, wind characteristics determination method, wind farm area determination method, wind potential determination method (#1940)
-- uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambiguous uncertainty, epistomological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
+- uncertainty of a model, nature of uncertainty, level of uncertainty, location of uncertainty role, ambiguous uncertainty, epistemological uncertainty, ontological uncertainty, shallow uncertainty, medium uncertainty, deep uncertainty, recognised ignorance, has uncertainty nature, has uncertainty location, has uncertainty level (#1829)
 
 
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3727,9 +3727,9 @@ Class: OEO_00400012
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
-        rdfs:comment "Uncertainty is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
-        rdfs:label "uncertainty"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty of a model is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
+        rdfs:comment "Uncertainty of a model is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
+        rdfs:label "uncertainty of a model"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3744,18 +3744,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00020352
     
     
-Class: OEO_00400029
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A computer model is a model that implements a conceptual model.",
-        rdfs:label "computer model"@en
-    
-    SubClassOf: 
-        OEO_00020352
-    
-    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4406,7 +4406,7 @@ Individual: OEO_00400014
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambigous uncertainty is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambigous uncertainty is a nature of model uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ambiguity of uncertainty"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "ambigous uncertainty"@en
@@ -4420,7 +4420,7 @@ Individual: OEO_00400015
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistomological uncertainty is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistomological uncertainty is a nature of model uncertainty that stems from a lack of knowledge about a certain phenomenon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "epistemology of uncertainty"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "epistomological uncertainty"@en
@@ -4434,7 +4434,7 @@ Individual: OEO_00400016
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ontological uncertainty is a nature of uncertainty that stems from inherent variability of a phenomenon.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ontological uncertainty is a nature of model uncertainty that stems from inherent variability of a phenomenon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ontology of uncertainty"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "ontological uncertainty"@en
@@ -4448,7 +4448,7 @@ Individual: OEO_00400018
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of model uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "shallow uncertainty"@en
     
@@ -4461,7 +4461,7 @@ Individual: OEO_00400019
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of model uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "medium uncertainty"@en
     
@@ -4474,7 +4474,7 @@ Individual: OEO_00400020
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of model uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "deep uncertainty"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3803,9 +3803,9 @@ Class: OEO_00400022
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty role is a role of an entity in which a model uncertainty is located in.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Location of model uncertainty role is a role of an entity in which a model uncertainty is located in.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "location of uncertainty role"@en
+        rdfs:label "location of model uncertainty role"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -584,6 +584,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a location of uncertainty(y) that indicates x is located in y.",
         rdfs:label "has uncertainty location"@de
     
+    Domain: 
+        OEO_00400012
+    
     
 ObjectProperty: owl:topObjectProperty
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -563,6 +563,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
     
+    
+ObjectProperty: OEO_00400038
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and a level of uncertainty that indicates the severity of uncertainty within the model.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
+        rdfs:label "has uncertainty level"@de
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
+    
 ObjectProperty: owl:topObjectProperty
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -555,7 +555,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
 ObjectProperty: OEO_00400037
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model(x) and a nature of uncertainty(y) that indicates uncertainty within x is of kind y."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a nature of uncertainty(z) that indicates x  is of kind z."@en,
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:label "has uncertainty nature"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4340,8 +4340,9 @@ Individual: OEO_00400015
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistemology is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
-        rdfs:label "epistemology"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistomological uncertainty is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "epistemology of uncertainty"@en,
+        rdfs:label "epistomological uncertainty"@en
     
     Types: 
         OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -575,6 +575,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
     
+    
+ObjectProperty: OEO_00400039
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model(x) and a location of uncertainty(y) that indicates uncertainty within x is located in y.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
+        rdfs:label "has uncertainty location"@de
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -579,9 +579,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400039
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model(x) and a location of uncertainty(y) that indicates uncertainty within x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a nature of uncertainty(y) that indicates x is of kind y.",
         rdfs:label "has uncertainty location"@de
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3803,7 +3803,7 @@ Class: OEO_00400022
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty role is a role of an entity in which a model uncertainty is located in.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "location of uncertainty role"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3726,7 +3726,7 @@ Class: OEO_00400022
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
-        rdfs:label "location of uncertainty"@en
+        rdfs:label "location of uncertainty role"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4406,10 +4406,10 @@ Individual: OEO_00400014
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambigous uncertainty is a nature of model uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambiguous uncertainty is a nature of model uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ambiguity of uncertainty"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "ambigous uncertainty"@en
+        rdfs:label "ambiguous uncertainty"@en
     
     Types: 
         OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4327,8 +4327,9 @@ Individual: OEO_00400014
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambiguity is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
-        rdfs:label "ambiguity"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambigous uncertainty is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "ambiguity of uncertainty"@en,
+        rdfs:label "ambigous uncertainty"@en
     
     Types: 
         OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -581,7 +581,7 @@ ObjectProperty: OEO_00400039
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a nature of uncertainty(y) that indicates x is of kind y.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a location of uncertainty(y) that indicates x is located in y.",
         rdfs:label "has uncertainty location"@de
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -33,6 +33,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0006011>
 
     
@@ -97,6 +100,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
+
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000086>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
@@ -545,6 +551,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a time stamp or time series and a time stamp alignment that indicates the position of the time stamps that refer to the time step(s).",
         rdfs:label "has time stamp alignment"@en
     
+    
+ObjectProperty: OEO_00400037
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model(x) and a nature of uncertainty(y) that indicates uncertainty within x is of kind y."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
+        rdfs:label "has uncertainty nature"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086>
     
 ObjectProperty: owl:topObjectProperty
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3780,18 +3780,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00000276
     
     
-Class: OEO_00400033
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consists of the data that exists after propagating through the model complex.",
-        rdfs:label "processed output data"@en
-    
-    SubClassOf: 
-        OEO_00000276
-    
-    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -593,7 +593,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400039
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a location of uncertainty(y) that indicates x is located in y.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a location of uncertainty (y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -578,7 +578,7 @@ ObjectProperty: OEO_00400038
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:label "has uncertainty level"@en
+        rdfs:label "has uncertainty level"@de
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -597,7 +597,7 @@ ObjectProperty: OEO_00400039
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "has uncertainty location"@en
+        rdfs:label "has uncertainty location"@de
     
     Domain: 
         OEO_00400012
@@ -3744,17 +3744,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
     
     
 
-    Annotations: 
-        OEO_00020426 "add:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
-        rdfs:label "study descriptor"@en
-    
-    SubClassOf: 
-        OEO_00000119
-    
-    
 Class: OEO_00400012
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3690,7 +3690,7 @@ Class: OEO_00400012
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
         rdfs:comment "Uncertainty is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
-        rdfs:label "uncertainty"@de
+        rdfs:label "uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -3702,7 +3702,7 @@ Class: OEO_00400013
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
-        rdfs:label "nature of uncertainty"@de
+        rdfs:label "nature of uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -3714,7 +3714,7 @@ Class: OEO_00400017
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Level of uncertainty is a quality of a model that represents the degree of an uncertainty.",
-        rdfs:label "level of uncertainty"@de
+        rdfs:label "level of uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -3726,7 +3726,7 @@ Class: OEO_00400022
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
-        rdfs:label "location of uncertainty"@de
+        rdfs:label "location of uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -3738,7 +3738,7 @@ Class: OEO_00400028
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conceptual model is a model that specifies variables and relationships within a system boundary.",
-        rdfs:label "conceptual model"@de
+        rdfs:label "conceptual model"@en
     
     SubClassOf: 
         OEO_00020352
@@ -3750,7 +3750,7 @@ Class: OEO_00400029
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A computer model is a model that implements a conceptual model.",
-        rdfs:label "computer model"@de
+        rdfs:label "computer model"@en
     
     SubClassOf: 
         OEO_00020352
@@ -3762,7 +3762,7 @@ Class: OEO_00400030
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A system boundary is a model component that separates aspects of the real world that are included in the model from those that are not.",
-        rdfs:label "system boundary"@de
+        rdfs:label "system boundary"@en
     
     SubClassOf: 
         OEO_00000276
@@ -3774,7 +3774,7 @@ Class: OEO_00400031
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Input data is a model component  that consists of parameters inside the model aswell as inputs to the model.",
-        rdfs:label "input data"@de
+        rdfs:label "input data"@en
     
     SubClassOf: 
         OEO_00000276
@@ -3785,8 +3785,8 @@ Class: OEO_00400032
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:label "model implementation"@de
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model.",
+        rdfs:label "model implementation"@en
     
     SubClassOf: 
         OEO_00000276
@@ -3797,8 +3797,8 @@ Class: OEO_00400033
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:label "processed output data"@de
         <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consists of the data that exists after propagating through the model complex.",
+        rdfs:label "processed output data"@en
     
     SubClassOf: 
         OEO_00000276
@@ -4400,7 +4400,7 @@ Individual: OEO_00400014
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambiguity is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
-        rdfs:label "ambiguity"@de
+        rdfs:label "ambiguity"@en
     
     Types: 
         OEO_00400013
@@ -4412,7 +4412,7 @@ Individual: OEO_00400015
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Epistemology is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
-        rdfs:label "epistemology"@de
+        rdfs:label "epistemology"@en
     
     Types: 
         OEO_00400013
@@ -4424,7 +4424,7 @@ Individual: OEO_00400016
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ontology is a nature of uncertainty that stems from inherent variability of a phenomenon.",
-        rdfs:label "ontology"@de
+        rdfs:label "ontology"@en
     
     Types: 
         OEO_00400013
@@ -4436,7 +4436,7 @@ Individual: OEO_00400018
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
-        rdfs:label "shallow uncertainty"@de
+        rdfs:label "shallow uncertainty"@en
     
     Types: 
         OEO_00400017
@@ -4448,7 +4448,7 @@ Individual: OEO_00400019
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
-        rdfs:label "medium uncertainty"@de
+        rdfs:label "medium uncertainty"@en
     
     Types: 
         OEO_00400017
@@ -4460,7 +4460,7 @@ Individual: OEO_00400020
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
-        rdfs:label "deep uncertainty"@de
+        rdfs:label "deep uncertainty"@en
     
     Types: 
         OEO_00400017
@@ -4472,7 +4472,7 @@ Individual: OEO_00400021
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
-        rdfs:label "recognised ignorance"@de
+        rdfs:label "recognised ignorance"@en
     
     Types: 
         OEO_00400017

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -546,36 +546,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         rdfs:label "has time stamp alignment"@en
     
     
-ObjectProperty: OEO_00400024
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a model and a quality.",
-        rdfs:label "has quality"@de
-    
-    Domain: 
-        OEO_00020352
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
-ObjectProperty: OEO_00400034
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:comment "A relation that holds between a model and an uncertainty location.",
-        rdfs:label "has uncertainty location"@de
-    
-    Domain: 
-        OEO_00020352
-    
-    Range: 
-        OEO_00400022
-    
-    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -2732,12 +2702,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648",
     
 Class: OEO_00020352
 
-    SubClassOf: 
-        OEO_00400024 some OEO_00400012,
-        OEO_00400024 some OEO_00400013,
-        OEO_00400024 some OEO_00400017,
-        OEO_00400034 some OEO_00400022
-    
     
 Class: OEO_00020353
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3747,7 +3747,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:label "uncertainty of a model"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
+        <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00400037 some OEO_00400013,
+        OEO_00400038 some OEO_00400017
     
     
 Class: OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -574,7 +574,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400038
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a level of model uncertainty (y) that indicates the severity y of x.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a level of model uncertainty (y) that indicates the degree or severity y of x.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
@@ -593,9 +593,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400039
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a location of model uncertainty (y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a location of model uncertainty (y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "has uncertainty location"@en
     
@@ -3790,7 +3790,7 @@ Class: OEO_00400017
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Level of model uncertainty is a quality of a model that represents the degree of an uncertainty.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Level of model uncertainty is a quality of a model that represents the degree or severity of an uncertainty.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "level of model uncertainty"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4353,8 +4353,9 @@ Individual: OEO_00400016
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ontology is a nature of uncertainty that stems from inherent variability of a phenomenon.",
-        rdfs:label "ontology"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ontological uncertainty is a nature of uncertainty that stems from inherent variability of a phenomenon.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "ontology of uncertainty"@en,
+        rdfs:label "ontological uncertainty"@en
     
     Types: 
         OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -556,6 +556,7 @@ ObjectProperty: OEO_00400037
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a nature of uncertainty(z) that indicates x  is of kind z."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:label "has uncertainty nature"@en
@@ -574,6 +575,7 @@ ObjectProperty: OEO_00400038
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a level of uncertainty(y) that indicates the severity of x.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:label "has uncertainty level"@de
@@ -591,9 +593,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400039
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a location of uncertainty(y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a location of uncertainty(y) that indicates x is located in y.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "has uncertainty location"@de
     
     Domain: 
@@ -3746,6 +3749,7 @@ Class: OEO_00400012
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty of a model is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:comment "Uncertainty of a model is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
         rdfs:label "uncertainty of a model"@en
     
@@ -3761,6 +3765,7 @@ Class: OEO_00400013
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "nature of uncertainty"@en
     
     SubClassOf: 
@@ -3773,6 +3778,7 @@ Class: OEO_00400017
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Level of uncertainty is a quality of a model that represents the degree of an uncertainty.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "level of uncertainty"@en
     
     SubClassOf: 
@@ -3785,6 +3791,7 @@ Class: OEO_00400022
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "location of uncertainty role"@en
     
     SubClassOf: 
@@ -4388,6 +4395,7 @@ Individual: OEO_00400014
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambigous uncertainty is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ambiguity of uncertainty"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "ambigous uncertainty"@en
     
     Types: 
@@ -4401,6 +4409,7 @@ Individual: OEO_00400015
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Epistomological uncertainty is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "epistemology of uncertainty"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "epistomological uncertainty"@en
     
     Types: 
@@ -4414,6 +4423,7 @@ Individual: OEO_00400016
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ontological uncertainty is a nature of uncertainty that stems from inherent variability of a phenomenon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ontology of uncertainty"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "ontological uncertainty"@en
     
     Types: 
@@ -4426,6 +4436,7 @@ Individual: OEO_00400018
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "shallow uncertainty"@en
     
     Types: 
@@ -4438,6 +4449,7 @@ Individual: OEO_00400019
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "medium uncertainty"@en
     
     Types: 
@@ -4450,6 +4462,7 @@ Individual: OEO_00400020
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "deep uncertainty"@en
     
     Types: 
@@ -4462,6 +4475,7 @@ Individual: OEO_00400021
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "recognised ignorance"@en
     
     Types: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -549,6 +549,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
 ObjectProperty: OEO_00400024
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a quality and an independent contiuant.",
         rdfs:label "quality of"@de
     
@@ -556,6 +558,8 @@ ObjectProperty: OEO_00400024
 ObjectProperty: OEO_00400034
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:comment "A relation that holds between a model and an uncertainty location.",
         rdfs:label "has uncertainty location"@de
     
@@ -3700,6 +3704,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
 Class: OEO_00400012
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
         rdfs:comment "Uncertainty is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
         rdfs:label "uncertainty"@de
@@ -3711,6 +3717,8 @@ Class: OEO_00400012
 Class: OEO_00400013
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
         rdfs:label "nature of uncertainty"@de
     
@@ -3721,6 +3729,8 @@ Class: OEO_00400013
 Class: OEO_00400017
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Level of uncertainty is a quality of a model that represents the degree of an uncertainty.",
         rdfs:label "level of uncertainty"@de
     
@@ -3731,6 +3741,8 @@ Class: OEO_00400017
 Class: OEO_00400022
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
         rdfs:label "location of uncertainty"@de
     
@@ -3741,6 +3753,8 @@ Class: OEO_00400022
 Class: OEO_00400028
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conceptual model is a model that specifies variables and relationships within a system boundary.",
         rdfs:label "conceptual model"@de
     
@@ -3751,6 +3765,8 @@ Class: OEO_00400028
 Class: OEO_00400029
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A computer model is a model that implements a conceptual model.",
         rdfs:label "computer model"@de
     
@@ -3761,6 +3777,8 @@ Class: OEO_00400029
 Class: OEO_00400030
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A system boundary is a model component that separates aspects of the real world that are included in the model from those that are not.",
         rdfs:label "system boundary"@de
     
@@ -3771,6 +3789,8 @@ Class: OEO_00400030
 Class: OEO_00400031
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Input data is a model component  that consists of parameters inside the model aswell as inputs to the model.",
         rdfs:label "input data"@de
     
@@ -3781,6 +3801,8 @@ Class: OEO_00400031
 Class: OEO_00400032
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model",
         rdfs:label "model implementation"@de
     
@@ -3791,6 +3813,8 @@ Class: OEO_00400032
 Class: OEO_00400033
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consits of the data that exists after propagating through the model complex",
         rdfs:label "processed output data"@de
     
@@ -4391,6 +4415,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
 Individual: OEO_00400014
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambiguity is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
         rdfs:label "ambiguity"@de
     
@@ -4401,6 +4427,8 @@ Individual: OEO_00400014
 Individual: OEO_00400015
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Epistemology is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
         rdfs:label "epistemology"@de
     
@@ -4411,6 +4439,8 @@ Individual: OEO_00400015
 Individual: OEO_00400016
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ontology is a nature of uncertainty that stems from inherent variability of a phenomenon.",
         rdfs:label "ontology"@de
     
@@ -4421,6 +4451,8 @@ Individual: OEO_00400016
 Individual: OEO_00400018
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
         rdfs:label "shallow uncertainty"@de
     
@@ -4431,6 +4463,8 @@ Individual: OEO_00400018
 Individual: OEO_00400019
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
         rdfs:label "medium uncertainty"@de
     
@@ -4441,6 +4475,8 @@ Individual: OEO_00400019
 Individual: OEO_00400020
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
         rdfs:label "deep uncertainty"@de
     
@@ -4451,6 +4487,8 @@ Individual: OEO_00400020
 Individual: OEO_00400021
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
         rdfs:label "recognised ignorance"@de
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3768,18 +3768,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00000276
     
     
-Class: OEO_00400032
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model.",
-        rdfs:label "model implementation"@en
-    
-    SubClassOf: 
-        OEO_00000276
-    
-    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3785,8 +3785,8 @@ Class: OEO_00400032
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model",
         rdfs:label "model implementation"@de
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model.",
     
     SubClassOf: 
         OEO_00000276
@@ -3797,8 +3797,8 @@ Class: OEO_00400033
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consits of the data that exists after propagating through the model complex",
         rdfs:label "processed output data"@de
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consists of the data that exists after propagating through the model complex.",
     
     SubClassOf: 
         OEO_00000276

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3790,9 +3790,9 @@ Class: OEO_00400017
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Level of uncertainty is a quality of a model that represents the degree of an uncertainty.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Level of model uncertainty is a quality of a model that represents the degree of an uncertainty.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "level of uncertainty"@en
+        rdfs:label "level of model uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4420,10 +4420,10 @@ Individual: OEO_00400015
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistomological uncertainty is a nature of model uncertainty that stems from a lack of knowledge about a certain phenomenon.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistemological uncertainty is a nature of model uncertainty that stems from a lack of knowledge about a certain phenomenon.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "epistemology of uncertainty"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "epistomological uncertainty"@en
+        rdfs:label "epistemological uncertainty"@en
     
     Types: 
         OEO_00400013

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -567,7 +567,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400038
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a model and a level of uncertainty that indicates the severity of uncertainty within the model.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a level of uncertainty(y) that indicates the severity of x.",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:label "has uncertainty level"@de

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -551,8 +551,14 @@ ObjectProperty: OEO_00400024
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a quality and an independent contiuant.",
-        rdfs:label "quality of"@de
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a model and a quality.",
+        rdfs:label "has quality"@de
+    
+    Domain: 
+        OEO_00020352
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 ObjectProperty: OEO_00400034
@@ -562,6 +568,12 @@ ObjectProperty: OEO_00400034
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         rdfs:comment "A relation that holds between a model and an uncertainty location.",
         rdfs:label "has uncertainty location"@de
+    
+    Domain: 
+        OEO_00020352
+    
+    Range: 
+        OEO_00400022
     
     
 ObjectProperty: owl:topObjectProperty
@@ -2720,6 +2732,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648",
     
 Class: OEO_00020352
 
+    SubClassOf: 
+        OEO_00400024 some OEO_00400012,
+        OEO_00400024 some OEO_00400013,
+        OEO_00400024 some OEO_00400017,
+        OEO_00400034 some OEO_00400022
+    
     
 Class: OEO_00020353
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -546,6 +546,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
         rdfs:label "has time stamp alignment"@en
     
     
+ObjectProperty: OEO_00400024
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a quality and an independent contiuant.",
+        rdfs:label "quality of"@de
+    
+    
+ObjectProperty: OEO_00400034
+
+    Annotations: 
+        rdfs:comment "A relation that holds between a model and an uncertainty location.",
+        rdfs:label "has uncertainty location"@de
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -571,6 +585,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000003>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000004>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000006>
@@ -3680,6 +3697,107 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         OEO_00360020
     
     
+Class: OEO_00400012
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Uncertainty is a qualtity of a model that represents any departure from the unachievable ideal of complete determinism.",
+        rdfs:comment "Uncertainty is a situation of inadequate information, which can be of three sorts: inexactness, unreliability, and border with ignorance.",
+        rdfs:label "uncertainty"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00400013
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
+        rdfs:label "nature of uncertainty"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00400017
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Level of uncertainty is a quality of a model that represents the degree of an uncertainty.",
+        rdfs:label "level of uncertainty"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
+    
+    
+Class: OEO_00400022
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Location of uncertainty is a role of an oeo class that has the disposition to be the part of a system in which an uncertainty occurs.",
+        rdfs:label "location of uncertainty"@de
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00400028
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A conceptual model is a model that specifies variables and relationships within a system boundary.",
+        rdfs:label "conceptual model"@de
+    
+    SubClassOf: 
+        OEO_00020352
+    
+    
+Class: OEO_00400029
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A computer model is a model that implements a conceptual model.",
+        rdfs:label "computer model"@de
+    
+    SubClassOf: 
+        OEO_00020352
+    
+    
+Class: OEO_00400030
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A system boundary is a model component that separates aspects of the real world that are included in the model from those that are not.",
+        rdfs:label "system boundary"@de
+    
+    SubClassOf: 
+        OEO_00000276
+    
+    
+Class: OEO_00400031
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Input data is a model component  that consists of parameters inside the model aswell as inputs to the model.",
+        rdfs:label "input data"@de
+    
+    SubClassOf: 
+        OEO_00000276
+    
+    
+Class: OEO_00400032
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Model implementation is a model component that consists of the computer code used to represent the model",
+        rdfs:label "model implementation"@de
+    
+    SubClassOf: 
+        OEO_00000276
+    
+    
+Class: OEO_00400033
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Processed output data is a model component that consits of the data that exists after propagating through the model complex",
+        rdfs:label "processed output data"@de
+    
+    SubClassOf: 
+        OEO_00000276
+    
+    
 Individual: OEO_00000049
 
     Annotations: 
@@ -4268,5 +4386,75 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/824",
     
     Types: 
         OEO_00140167
+    
+    
+Individual: OEO_00400014
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambiguity is a nature of uncertainty that stems from multiple frames of reference about a phenomenon existing similtaneously.",
+        rdfs:label "ambiguity"@de
+    
+    Types: 
+        OEO_00400013
+    
+    
+Individual: OEO_00400015
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Epistemology is a nature of uncertainty that stems from a lack of knowledge about a certain phenomenon.",
+        rdfs:label "epistemology"@de
+    
+    Types: 
+        OEO_00400013
+    
+    
+Individual: OEO_00400016
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ontology is a nature of uncertainty that stems from inherent variability of a phenomenon.",
+        rdfs:label "ontology"@de
+    
+    Types: 
+        OEO_00400013
+    
+    
+Individual: OEO_00400018
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Shallow uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and provide probabilites(subjective or objective) for them.",
+        rdfs:label "shallow uncertainty"@de
+    
+    Types: 
+        OEO_00400017
+    
+    
+Individual: OEO_00400019
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Medium uncertainty is a level of uncertainty at which one can enumerate multiple alternatives and rank them in order of perceived likelihood, without being able to discern how intensely the likelihood varies between two alternatives.",
+        rdfs:label "medium uncertainty"@de
+    
+    Types: 
+        OEO_00400017
+    
+    
+Individual: OEO_00400020
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Deep uncertainty is a level of uncertainty at which one can enumerate multiple alternatives, without being able to rank them in order of likelihood.",
+        rdfs:label "deep uncertainty"@de
+    
+    Types: 
+        OEO_00400017
+    
+    
+Individual: OEO_00400021
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
+        rdfs:label "recognised ignorance"@de
+    
+    Types: 
+        OEO_00400017
     
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3768,18 +3768,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00000276
     
     
-Class: OEO_00400031
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Input data is a model component  that consists of parameters inside the model aswell as inputs to the model.",
-        rdfs:label "input data"@en
-    
-    SubClassOf: 
-        OEO_00000276
-    
-    
 Class: OEO_00400032
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -578,7 +578,7 @@ ObjectProperty: OEO_00400038
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:label "has uncertainty level"@de
+        rdfs:label "has uncertainty level"@en
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -597,7 +597,7 @@ ObjectProperty: OEO_00400039
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "has uncertainty location"@de
+        rdfs:label "has uncertainty location"@en
     
     Domain: 
         OEO_00400012
@@ -3744,6 +3744,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
     
     
 
+    Annotations: 
+        OEO_00020426 "add:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
+        rdfs:label "study descriptor"@en
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    
 Class: OEO_00400012
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -563,6 +563,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
     
+    Domain: 
+        OEO_00400012
+    
+    Range: 
+        OEO_00400013
+    
     
 ObjectProperty: OEO_00400038
 
@@ -574,6 +580,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
+    
+    Domain: 
+        OEO_00400012
+    
+    Range: 
+        OEO_00400017
     
     
 ObjectProperty: OEO_00400039

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -574,7 +574,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400038
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model(x) and a level of uncertainty(y) that indicates the severity of x.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a level of uncertainty (y) that indicates the severity y of x.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2756,6 +2756,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648",
     
 Class: OEO_00020352
 
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00400012
+    
     
 Class: OEO_00020353
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -555,7 +555,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1944",
 ObjectProperty: OEO_00400037
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a nature of uncertainty (z) that indicates x is of kind z."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a nature of model uncertainty (z) that indicates x is of kind z."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
@@ -574,7 +574,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400038
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a level of uncertainty (y) that indicates the severity y of x.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a level of model uncertainty (y) that indicates the severity y of x.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
@@ -593,9 +593,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
 ObjectProperty: OEO_00400039
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a location of uncertainty (y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an uncertainty of a model (x) and a location of model uncertainty (y) that indicates x is located in y.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "has uncertainty location"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3732,18 +3732,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
-Class: OEO_00400028
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A conceptual model is a model that specifies variables and relationships within a system boundary.",
-        rdfs:label "conceptual model"@en
-    
-    SubClassOf: 
-        OEO_00020352
-    
-    
 Individual: OEO_00000049
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -578,7 +578,7 @@ ObjectProperty: OEO_00400038
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         <http://purl.obolibrary.org/obo/IAO_0000233> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        rdfs:label "has uncertainty level"@de
+        rdfs:label "has uncertainty level"@en
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -597,7 +597,7 @@ ObjectProperty: OEO_00400039
         <http://purl.obolibrary.org/obo/IAO_0000115> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "has uncertainty location"@de
+        rdfs:label "has uncertainty location"@en
     
     Domain: 
         OEO_00400012
@@ -3743,7 +3743,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791",
         OEO_00360020
     
     
+Class: OEO_00390064
 
+    Annotations: 
+        OEO_00020426 "add:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
+        rdfs:label "study descriptor"@en
+    
+    SubClassOf: 
+        OEO_00000119
+    
+    
 Class: OEO_00400012
 
     Annotations: 
@@ -3797,19 +3809,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
-
-Class: OEO_00390064
-
-    Annotations: 
-        OEO_00020426 "add:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
-        rdfs:label "study descriptor"@en
-    
-    SubClassOf: 
-        OEO_00000119
-
     
     
 Individual: OEO_00000049

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3777,9 +3777,9 @@ Class: OEO_00400013
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nature of model uncertainty is a quality of a model that represents the core reason for uncertainty within it.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
-        rdfs:label "nature of uncertainty"@en
+        rdfs:label "nature of model uncertainty"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4487,7 +4487,7 @@ Individual: OEO_00400021
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Recognised ignorance is a level of model uncertainty at which one isn't able to enumerate multiple alternatives, while admitting the possibility of being surprised.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.researchgate.net/publication/264816512_Classifying_and_communicating_uncertainties_in_model-based_policy_analysis",
         rdfs:label "recognised ignorance"@en
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3756,18 +3756,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00020352
     
     
-Class: OEO_00400030
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1829
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A system boundary is a model component that separates aspects of the real world that are included in the model from those that are not.",
-        rdfs:label "system boundary"@en
-    
-    SubClassOf: 
-        OEO_00000276
-    
-    
 Individual: OEO_00000049
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

See issue #1829

## Type of change (CHANGELOG.md)

### Add

relations:
- `has uncertainty nature`
- `has uncertainty location `
- `has uncertainty level`

entities:
- `uncertainty of a model`
- `nature of uncertainty`
- `level of uncertainty`
- `location of uncertainty role`

individuals:
- `ambigous uncertainty`
- `epistomological uncertainty`
- `ontological uncertainty`
- `shallow uncertainty`
- `medium uncertainty`
- `deep uncertainty`
- `recognised ignorance`

axioms to:
- `uncertainty of a model`
- `model`


## Workflow checklist

### Automation
Closes 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
