### PR TITLE
Make 3 object aggregates subclasses of (supply) system #1833 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - replace has bearer with characteristic of (#1928)
 - rework contributing and readme file (#1937)
 - time stamp (#1944)
-- move supply grid, transport network and critical infrastructure to subclass of supply system (#1947)
+- supply grid, transport network, critical infrastructure (#1947)
 
 
 ### Obsoletion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - replace has bearer with characteristic of (#1928)
 - rework contributing and readme file (#1937)
 - time stamp (#1944)
+- move supply grid, transport network and critical infrastructure to subclass of supply system (#1947)
 
 
 ### Obsoletion

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2960,7 +2960,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+moved to subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is a supply system of systematically connected artificial objects that can work as a supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungsnetz"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "grid"@en,
@@ -14505,7 +14509,11 @@ Class: OEO_00320016
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
+
+moved to subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is a supply system of transport network components that enables the transport of people and/or goods."@en,
         rdfs:label "transport network"@en
     
@@ -15804,7 +15812,11 @@ Class: OEO_00360041
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809
+
+moved to subclass of supply system:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
         rdfs:label "critical infrastructure"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -131,6 +131,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000052>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000053>
+
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000056>
 
     
@@ -2526,8 +2529,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00000159
@@ -2907,10 +2910,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
             (OEO_00000331
-             and (OEO_00000531 value OEO_00000182)),
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00000199
+             and (OEO_00000531 value OEO_00000182))
     
     
 Class: OEO_00000199
@@ -2958,14 +2961,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/137
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is an object aggregate of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is a supply system of systematically connected artificial objects that can work as a supply system.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungsnetz"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "grid"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "network"@en,
         rdfs:label "supply grid"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
+        OEO_00030025
     
     
 Class: OEO_00000204
@@ -3118,7 +3121,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         OEO_00230020,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3126,7 +3128,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002
+        OEO_00020182 some OEO_00110002,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
     
     
 Class: OEO_00000219
@@ -4688,13 +4691,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     SubClassOf: 
         OEO_00230020,
         OEO_00000530 some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
         
             Annotations: OEO_00020426 "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
         OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043
+        OEO_00020183 some OEO_00020043,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054
     
     
 Class: OEO_00000447
@@ -7970,8 +7973,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        OEO_00010231 some OEO_00010332
+        OEO_00010231 some OEO_00010332,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00010334
@@ -8232,8 +8235,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010386
@@ -8499,8 +8502,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
     
     
 Class: OEO_00010413
@@ -10113,9 +10116,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
+        OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000044 or OEO_00000448),
-        OEO_00140002 some OEO_00140001
+            (OEO_00000044 or OEO_00000448)
     
     
 Class: OEO_00020147
@@ -11250,19 +11253,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030035
 
     
-Class: OEO_00340069
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
-        OEO_00020426 "Update size and add amount
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        rdfs:label "amount"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000019>
-    
-    
 Class: OEO_00050000
 
     Annotations: 
@@ -11773,8 +11763,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044,
-        OEO_00140002 some OEO_00140001
+        OEO_00140002 some OEO_00140001,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044
     
     
 Class: OEO_00140001
@@ -12636,8 +12626,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140127
@@ -12674,8 +12664,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
-        OEO_00140002 some OEO_00140127
+        OEO_00140002 some OEO_00140127,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
     
     
 Class: OEO_00140133
@@ -14516,11 +14506,11 @@ Class: OEO_00320016
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is an object aggregate of transport network components that enables the transport of people and/or goods."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is a supply system of transport network components that enables the transport of people and/or goods."@en,
         rdfs:label "transport network"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>,
+        OEO_00030025,
         OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320021
     
@@ -15563,19 +15553,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340068
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         OEO_00020426 "restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851
 Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-     
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
         rdfs:label "size"@en
     
     SubClassOf: 
         OEO_00340062
+    
+    
+Class: OEO_00340069
+
+    Annotations: 
+        OEO_00020426 "Update size and add amount
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
+        rdfs:label "amount"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000019>
     
     
 Class: OEO_00360001
@@ -15654,8 +15656,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>,
-        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008
+        <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00360008,
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/RO_0002577>
     
     
 Class: OEO_00360008
@@ -15803,12 +15805,12 @@ Class: OEO_00360041
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is an object aggregate of artificial objects and systems which have the critical infrastructure role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
         rdfs:label "critical infrastructure"@en
     
     EquivalentTo: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
+        OEO_00030025
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00000061
              and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040)))
@@ -15817,7 +15819,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809",
              and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040)))
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000027>
+        OEO_00030025
     
     
 Class: OEO_00390000

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14511,7 +14511,7 @@ Class: OEO_00320016
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
 
-moved to subclass of supply system:
+make subclass of supply system:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is a supply system of transport network components that enables the transport of people and/or goods."@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2962,7 +2962,7 @@ rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
-moved to subclass of supply system:
+make subclass of supply system:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is a supply system of systematically connected artificial objects that can work as a supply system.",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15814,7 +15814,7 @@ Class: OEO_00360041
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809
 
-moved to subclass of supply system, edit axiom:
+make subclass of supply system, edit axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15814,7 +15814,7 @@ Class: OEO_00360041
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809
 
-moved to subclass of supply system:
+moved to subclass of supply system, edit axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,
@@ -15823,12 +15823,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
     
     EquivalentTo: 
         OEO_00030025
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some 
+         and ((<http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00000061
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040)))
-         and (<http://purl.obolibrary.org/obo/BFO_0000051> some 
-            (<http://purl.obolibrary.org/obo/RO_0002577>
-             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040)))
+             and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040))) or (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00360040))
     
     SubClassOf: 
         OEO_00030025


### PR DESCRIPTION
## Summary of the discussion
See #1833.
As agreed in the discussion` supply grid`, `transport network` and `critical infrastructure` should be `supply systems` instead of` object aggregates`. I changed the definitions accordingly.
Please let me know if the equivalence for  `critical infrastructure` should change (as also asked in #1833)

## Type of change (CHANGELOG.md)

### Update
- move supply grid, transport network and critical infrastructure to subclass of supply system

## Workflow checklist

### Automation
Closes #1833

### PR-Assignee
- [x ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
