### PR TITLE
`oeo-closure.owl` no longer built on every push

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -11,7 +11,7 @@ jobs:
           java-version: '11'
       - name: make
         run: |
-          make
+          make base merge
       - name: validate-profile
         run: |
           echo "java -jar build/robot.jar validate-profile --input build/oeo/$(cat VERSION)/oeo-full.owl --profile Full -vvv --output merged-validation.txt"


### PR DESCRIPTION
## Summary of the discussion

The [`OEO CI`](https://github.com/OpenEnergyPlatform/ontology/blob/dev/.github/workflows/automated-testing.yml) workflow is run on every push and regularly requires around 11 minutes to build and test the ontology. To do this it builds the `oeo-full.omn`, `oeo-full.owl` and `oeo-closure.owl` files. However, only the first two are required for the subsequent test step. 

This Pr changes the workflow to no longer build the `oeo-closure.owl` file as it does not need to be built after every push. As can be seen at the required completion time on the workflow of this pr, the time was reduced to 3m 39s.

This breaks backwards compatibility as this workflow also attaches the built files as artifacts of the workflow run for anyone to download. So any script, tool or tutorial (e.g. the wiki entry [How-to-release-a-new-ontology-version](https://github.com/OpenEnergyPlatform/ontology/wiki/How-to-release-a-new-ontology-version)) will no longer be feasible since the artifacts no longer contain the previously expected files.
The problem with the release workflow as described in the tutorial is fixed with https://github.com/OpenEnergyPlatform/ontology/pull/1956.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #1934 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
