### PR TITLE
Automatically attach the required files to releases

### DIFF
--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -6,21 +6,19 @@ name: Post Release Scripts
 #       - 'feature-1020-export-of-existing-terms-and-definitions'
 # First we test the setup, to see if the files are building correctly once that is checked we introduce the wiki upload each release.
 on:
- push:
-   tags:
-     - "v*"
-   branches:
-     - 'feature-1020-export-of-existing-terms-and-definitions'
+  release: 
+    types: [published]
+
 jobs:
   exportTermsDefinitions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
           architecture: x64
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -45,7 +43,7 @@ jobs:
         run: |
           python src/scripts/etd/etd.py
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: existing-terms-and-definitions
           path: src/scripts/etd/glossary
@@ -62,3 +60,73 @@ jobs:
       #     git config --local user.name "GitHub Action"
       #     git add .
       #     git diff-index --quiet HEAD || git commit -m "Add changes" && git push
+
+  buildOntologyFullAndClosure:
+    # steps taken from the build job in automated-testing.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: make
+        run: |
+          make
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7.17'
+          architecture: x64
+      - name: install python dependencies
+        run: pip install -r src/scripts/requirements.txt
+      - name: setup robot 1.9.0
+        run: |
+          wget https://github.com/ontodev/robot/releases/download/v1.9.0/robot.jar -O build/robot19.jar
+      - name: Build ETD xlsx
+        run: |
+          java -jar build/robot19.jar merge --input build/oeo/$(cat VERSION)/oeo-full.omn \
+            --include-annotations true \
+          export --header "ID|LABEL|definition" \
+                 --prefix "OEO: http://openenergy-platform.org/ontology/oeo/OEO_" \
+                 --sort "LABEL" \
+                 --export $(pwd)/build/oeo/$(cat VERSION)/etd.xlsx
+      - name: Build ETD csv
+        run: |
+          python $(pwd)/src/scripts/etd/etd.py $(pwd)/build/oeo/$(cat VERSION)
+      - name: Upload Ontology
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-files
+          path: |
+            build/**/*
+            !build/**/*.jar
+
+  attachArtifactsToRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-files
+          path: build/oeo
+      - name: Zip build files again for usage as release artifact
+        run: |
+          cd build
+          zip -r ../build-files.zip oeo
+          cd ..
+      - uses: actions/download-artifact@v4
+        with:
+          name: existing-terms-and-definitions
+          path: src/scripts/etd/glossary
+      - name: Zip terms and definitions for usage as release artifact
+        run: |
+          cd src/scripts/etd/glossary
+          zip -r ../../../../existing-terms-and-definitions.zip ./
+          cd ../../../..
+      - name: Attach artifacts to release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.release.tag_name }}
+          allowUpdates: true
+          artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip"


### PR DESCRIPTION
## Summary of the discussion

As described in https://github.com/OpenEnergyPlatform/ontology/pull/1955, the [Release workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/How-to-release-a-new-ontology-version) currently requires that an `oeo-closure.owl` file present in the `build-files.zip` artifact to be attached to a release. However that pull request would remove said file from the artifacts for a reduced completion time of workflow runs.

This Pr tries to automate the release workflow. Instead of a maintainer going to the workflow artifacts of two separate runs to download the `build-files.zip` and `existing-terms-and-definitions.zip` and create a release with them, the maintainer would now only have to write and publish the release and this workflow would then automatically attach said files.

However, I am not really able to test this easily. But even if the automation fails, this pr ensures that a version of `build-files.zip` is uploaded that contains the `oeo-closure.zip` file, so the maintainer can add it automatically.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
