### PR TITLE
Fix issues no longer being marked as `in discussion`

### DIFF
--- a/.github/workflows/InDiscussionProject.yml
+++ b/.github/workflows/InDiscussionProject.yml
@@ -17,13 +17,6 @@ jobs:
       uses: akleinau/githubJSActions/DiscussedToColumn@master
       with:
         repo: https://api.github.com/repos/OpenEnergyPlatform/ontology
-    - name: addToColumn
-      uses: peter-evans/create-or-update-project-card@v1
-      with:
-        project-name: Issues
-        column-name: In discussion
-        issue-number: ${{ steps.count.outputs.issue_number }} 
-      if: steps.count.outputs.continue == 'true' 
     - run: gh issue edit "$NUMBER" --remove-label "$LABELS"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of the discussion

PR #1961 should have already fixed this but I forgot to delete some automation that previously moved the issue card between the columns in the project that no longer worked with the recent project changes.
This PR fixes this by correctly removing the code that no longer works.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
