### PR TITLE
Changed typo in "definition" and "example of usage"

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2032,7 +2032,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749",
         <http://purl.obolibrary.org/obo/IAO_0000112> "In a study, the spatial focus of the investigation lies on one European country, e.g. Germany. This is the study region.
 The study region is not modelled as a whole, but several subregions are modelled, e.g. German Federal States. These are study subregions.
 In the study, a spatial region outside the study region plays a role. E.g. for modelling the electricity transfer between Germany and its neighbouring countries. In this example, the neighbouring countries represent the interacting / external region.
-The union of the study region and the interacting/ external region ist the considered region."@en,
+The union of the study region and the interacting/ external region is the considered region."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study region is a region of relevance that has the study region role and consists entirely of one or more subregions."@en,
         rdfs:label "study region"@en
     
@@ -2234,7 +2234,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881
 reclassify
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1684
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an  objective specification that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an objective specification that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zielbeschreibung"@de,
         rdfs:label "target description"@en
     


### PR DESCRIPTION
## Summary of the discussion
It's not a lot, but I noticed these two while reading over these classes for #1962 and didn't want to wait for a more meaningful PR later in fear of forgetting them.

## Type of change (CHANGELOG.md)

### Update
- Fixed a typo (double-space) in the definition of `target description`.
- Fixed a typo (_ist_ instead of _is_) in the example of usage of `study region`.

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
