### PR TITLE
Remove duplicated word from the definition of `gaseous`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [2.x.y] - 202x-xx-xx
 ### Added
 ### Changed
+* gaseous (#1980)
 
 ## [2.5.0] - 2024-09-24
 ### Added

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15880,7 +15880,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390,
 restructure modules:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+Fix definition:
+https://github.com/OpenEnergyPlatform/ontology/pull/1980",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has no definite shape and no definite volume and is not electrically conductive.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmig"@de,
         rdfs:label "gaseous"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11606,8 +11606,8 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1865
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energiemenge"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy amount value",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
         rdfs:label "energy value"@en
     
     SubClassOf: 
@@ -15881,7 +15881,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390,
 restructure modules:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has has no definite shape and no definite volume and is not electrically conductive.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has no definite shape and no definite volume and is not electrically conductive.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmig"@de,
         rdfs:label "gaseous"@en
     


### PR DESCRIPTION
## Summary of the discussion

Just a small fix, thus no issue

## Type of change (CHANGELOG.md)

### Update
- Remove duplicated word from the definition of `gaseous` in e3437aa07e3a770134e2d7f644cf430c2479e2d5

## Workflow checklist


### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
