### PR TITLE
Adjust definition of `areal solar energy density`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Changed
 * gaseous (#1980)
+* areal solar energy density (#1983)
 
 ## [2.5.0] - 2024-09-24
 ### Added

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5505,7 +5505,11 @@ Class: OEO_00010077
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615
+
+correct definition to state 'energy' instead of 'power'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1981
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1983",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar energy per area. A synonym for areal solar energy density is irradiation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
         rdfs:label "areal solar energy density"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -5506,7 +5506,7 @@ Class: OEO_00010077
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar power per area. A synonym for areal solar power density is irradiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar energy per area. A synonym for areal solar energy density is irradiation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
         rdfs:label "areal solar energy density"@en
     


### PR DESCRIPTION
## Summary of the discussion

`areal solar energy density`'s definition should be _An areal solar energy density is an areal energy density that gives the arriving solar energy per area. A synonym for areal solar energy density is irradiation._
 
## Type of change (CHANGELOG.md)

### Update
- Updated a definition [#](https://github.com/OpenEnergyPlatform/ontology/issues/1981)

## Workflow checklist

### Automation
Closes #1981

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
