### PR TITLE
Fix issues no longer being moved to the `In discussion` project column

### DIFF
--- a/.github/workflows/LabelInDiscussion.yml
+++ b/.github/workflows/LabelInDiscussion.yml
@@ -1,13 +1,10 @@
-name: Label & Move issues to "In discussion" project column
+name: Label issues as "In discussion"
 on:
   issue_comment:
     types: [created]
-  issues: 
-    types: [labeled]
 
 jobs:
   labelIssueAsInDiscussion:
-    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -31,18 +28,3 @@ jobs:
         NUMBER: ${{ github.event.issue.number }}
         LABELS: in discussion
       if: steps.count.outputs.continue == 'true' 
-  moveIssueToInDiscussionColumn:
-    if: github.event_name == 'issues' && github.event.issue.state == 'open'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: PaperMC/update-projects-action@v0.2.0
-        with:
-          github-token: "${{ secrets.OEO_WORKFLOWS }}"
-          project-url: https://github.com/orgs/OpenEnergyPlatform/projects/45/views/1
-          column-field: Status
-          clear-on-no-match: false
-          label-to-column-map: |
-            {
-              "To do": "To do",
-              "in discussion": "In discussion"
-            }

--- a/.github/workflows/MoveInDiscussionProject.yml
+++ b/.github/workflows/MoveInDiscussionProject.yml
@@ -1,0 +1,21 @@
+name: Move issues to "In discussion" project column
+on:
+  issues: 
+    types: [labeled]
+
+jobs:
+  moveIssueToInDiscussionColumn:
+    if: github.event_name == 'issues' && github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: PaperMC/update-projects-action@v0.2.0
+        with:
+          github-token: "${{ secrets.OEO_WORKFLOWS }}"
+          project-url: https://github.com/orgs/OpenEnergyPlatform/projects/45/views/1
+          column-field: Status
+          clear-on-no-match: false
+          label-to-column-map: |
+            {
+              "To do": "To do",
+              "in discussion": "In discussion"
+            }


### PR DESCRIPTION
## Summary of the discussion

PR https://github.com/OpenEnergyPlatform/ontology/pull/1961 and https://github.com/OpenEnergyPlatform/ontology/pull/1969 should have already fixed this but I thought it was possible to include two different events in the same workflow file.
This didn't work, that's why this PR "splits" the current `InDiscussionProject.yml` file apart into two workflow files each handling its events:
- `LabelInDiscussion.yml` - Labels issues with the `in discussion` label and removes the `to do` label
- `MoveInDiscussionProject.yml` - Moves issues, once labelled with the `in discussion` label, into the `In discussion` project column

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
