### PR TITLE
Fixed problems with Release Workflow Automation

### DIFF
--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -104,11 +104,13 @@ jobs:
 
   attachArtifactsToRelease:
     runs-on: ubuntu-latest
+    # these jobs have to finish so that the existing-terms-and-definitions and build-files exist
+    needs: [exportTermsDefinitions, buildOntologyFullAndClosure]
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: build-files
-          path: build/oeo
+          path: build
       - name: Zip build files again for usage as release artifact
         run: |
           cd build
@@ -128,5 +130,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.release.tag_name }}
+          # allowing the action to update the release as it is already created
           allowUpdates: true
+          # omitting the release name, body, draft state and prerelease state so they won't be updated by attaching the artifacts
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
           artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip"

--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -137,4 +137,8 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
+          # The default behavior of this action is to determine the release by the version number.
+          # We don't want this behavior, as releases created as draft or pre-release won't be updated in that regard and therefore result in
+          # unconsistent behavior when creating normal releases vs. draft or pre-releases.
+          makeLatest: false
           artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip"

--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -137,8 +137,8 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-          # The default behavior of this action is to determine the release by the version number.
-          # We don't want this behavior, as releases created as draft or pre-release won't be updated in that regard and therefore result in
-          # unconsistent behavior when creating normal releases vs. draft or pre-releases.
+          # The default behaviour of this action is to determine the release by the version number.
+          # We don't want this behaviour, as releases created as draft or pre-release won't be updated in that regard and therefore result in
+          # unconsistent behaviour when creating normal releases vs. draft or pre-releases.
           makeLatest: false
           artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip"


### PR DESCRIPTION
## Summary of the discussion

During the release of [v2.6.0](https://github.com/OpenEnergyPlatform/ontology/discussions/1949) and the therefor testing of the in #1956 introduced release workflow automation, multiple errors were noticed:

- The jobs responsible for generating the artifacts for the release, ran concurrently with the job responsible for uploading those artifacts. This results in no artifacts being uploaded, as they haven't been built at that time.
  - This PR fixes this by ensuring the job responsible for uploading the artifacts can only run after the ones generating them are finished.
- The `build-files.zip` artifact contained the `oeo` folder twice instead of having the required structure of `build-files/oeo/[version]/`.
  -  This should no longer be the case.
- If the person creating the release provided release notes or set the release as draft or pre-release, this workflow would wrongly undo those changes when attaching the artifacts, making the release non-draft and non-pre-release, as well removing the release notes.
  - This is no longer case, the release name, body as well as draft and pre-release state are no longer updated when attaching the artifacts.
  - If the workflow runs on a "normal" release (not draft, not pre-release), it will also no longer be automatically marked as "latest" based on the version number. Instead this has to be set manually as well.

Due to being unable to properly test these changes, they have to be properly verified again at the next release.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
