### PR TITLE
Alternative label for capacity factor and new tasks label #1994

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.X.X] - 20XX-XX-XX
+
+### Added
+-CF alternative label/ net capacity factor (#1995)
+
+### Changed
+- apply socio-economic constraints for assessment of potential (#1995)
+
+### Removed
+
+
 ## [2.6.0] - 2024-12-06
 ### Added
 - has aggregation type, has time stamp alignment (#1944)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [2.X.X] - 20XX-XX-XX
 
 ### Added
--CF alternative label/ net capacity factor (#1995)
 
 ### Changed
 - apply socio-economic constraints for assessment of potential (#1995)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - apply socio-economic constraints for assessment of potential (#1995)
+- net capacity factor (#1995)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13275,9 +13275,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1146
 
 make subclass of 'utilisation value':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435
+
+add alt label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/++++",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CF"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Nettojahresnutzungsgrad"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Nettokapazitätsfaktor"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor"@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13279,7 +13279,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435
 
 add alt label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/++++",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1995",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CF"@en,

--- a/src/ontology/edits/oeo-tasks.omn
+++ b/src/ontology/edits/oeo-tasks.omn
@@ -671,7 +671,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1940
 
 Change label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/++++",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1995",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Apply socio-economic constraints for assessment of potential is an action specification that describes the process of integrating non-technical factors, such as social acceptance, land use regulations, or market conditions, into the potential assessment.",
         rdfs:label "apply socio-economic constraints for assessment of potential"@en
     

--- a/src/ontology/edits/oeo-tasks.omn
+++ b/src/ontology/edits/oeo-tasks.omn
@@ -667,9 +667,13 @@ Class: OEO_00390059
     Annotations: 
         OEO_00020426 "Add:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1940",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Apply constraints for assessment of potential is an action specification that describes the process of integrating non-technical factors, such as social acceptance, land use regulations, or market conditions, into the potential assessment.",
-        rdfs:label "apply constraints for assessment of potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1940
+
+Change label:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/++++",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Apply socio-economic constraints for assessment of potential is an action specification that describes the process of integrating non-technical factors, such as social acceptance, land use regulations, or market conditions, into the potential assessment.",
+        rdfs:label "apply socio-economic constraints for assessment of potential"@en
     
     SubClassOf: 
         OEO_00390058


### PR DESCRIPTION
## Summary of the discussion

See #1994.
As discussed in the meeting I changed the label for `apply socio-economic constraints for assessment of potential` and added `CF `ad alternative label for` net capacity factor`.


## Type of change (CHANGELOG.md)

### Add
- CF alternative label/ net capacity factor

### Update
- apply socio-economic constraints for assessment of potential (#1995)


## Workflow checklist

### Automation
Closes #1994

### PR-Assignee
- [ x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
