### PR TITLE
Restructure cost and its subclasses

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.17'
+          python-version: '3.13.1'
           architecture: x64
       - uses: actions/setup-java@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - conceptual model (#1976)
 
+### Changed
+- restructure cost and its subclasses (#1999)
+
 ## [2.6.0] - 2024-12-06
 ### Added
 - has aggregation type, has time stamp alignment (#1944)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - conceptual model (#1976)
 
 ### Changed
-- restructure cost and its subclasses (#1999)
+- cost, delivery cost, fixed cost, investment cost, levelised cost of electricity, social cost of emission, system cost, variable cost  (#1999)
 
 ## [2.6.0] - 2024-12-06
 ### Added

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -676,15 +676,9 @@ Class: OEO_00020121
     
 Class: OEO_00020155
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
     
 Class: OEO_00020181
 
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
-    
     
 Class: OEO_00020185
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -546,8 +546,7 @@ Class: OEO_00010268
     SubClassOf: 
         OEO_00020056 some 
             (OEO_00000147
-             and (<http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020427)),
-        OEO_00020179 some OEO_00140081
+             and (<http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020427))
     
     
 Class: OEO_00010280

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -678,14 +678,12 @@ Class: OEO_00020121
 Class: OEO_00020155
 
     SubClassOf: 
-        OEO_00020179 some OEO_00140081,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
     
     
 Class: OEO_00020181
 
     SubClassOf: 
-        OEO_00020179 some OEO_00140081,
         <http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00140081
     
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -935,9 +935,6 @@ Class: OEO_00260007
     
 Class: OEO_00320021
 
-    SubClassOf: 
-        OEO_00020180 some OEO_00040009
-    
     
 Individual: OEO_00010042
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -826,9 +826,6 @@ Class: OEO_00140039
     
 Class: OEO_00140081
 
-    SubClassOf: 
-        OEO_00020180 some OEO_00020181
-    
     
 Class: OEO_00140124
 

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -426,7 +426,11 @@ Class: <http://www.openenergy-platform.org/ontology/oeo/OEO_00330002>
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1365
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1482",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1482
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity cost is a variable cost that depends on electricity price and amount.",
         rdfs:label "electricity cost"@en
     
@@ -1403,7 +1407,11 @@ Class: OEO_00020116
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/910
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "System cost are total costs of a system.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Systemkosten"@de,
         rdfs:label "system cost"@en
@@ -1486,7 +1494,11 @@ Class: OEO_00020127
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/906
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/913
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Levelised cost of electricity are the net cost of converting energy to electricity / electric energy over the lifetime of an energy transformation unit. They are calculated considering all relevant costs including investment, operation, maintenance and fuel cost, etc.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LCOE",
         rdfs:comment "Since over the lifetime of an energy transformation unit different costs exhibit different relevance or vary over time, the LCOE differ over the course of the lifetime.",
@@ -1521,7 +1533,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953
 
 Reformulate definition to singular:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A variable cost is a cost that depends on an amount of goods or services.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "unit-level cost"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "variable Kosten"@de,
@@ -1535,7 +1551,11 @@ Class: OEO_00020146
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are paid by the producer.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "variable Produktionskosten"@de,
@@ -1579,7 +1599,10 @@ add axiom to emission value, add new parent class and relabel
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of carbon emission is the cost the society bears for a greenhouse gas emission value.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "social cost of CO2",
         rdfs:label "social cost of carbon emission"@en
@@ -1606,7 +1629,11 @@ Class: OEO_00020167
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Investment costs are costs of a long-term commitment of financial resources in tangible or intangible assets.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Investitionskosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "capital investment cost"@en,
@@ -1629,7 +1656,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
 
 Reformulate definition to singular:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000112> "rent, regular technical maintenance cost, staff cost, certification cost",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fixed cost is a cost for operation and maintenance that does not vary with the amount of goods or services produced.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Fixkosten"@de,
@@ -1651,7 +1682,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
 
 Reformulate definition to singular:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Equipment cost is an investment cost for acquisition of the components and machinery including environmental facilities.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ausrüstungskosten"@de,
         rdfs:label "equipment cost"@en
@@ -1664,7 +1699,11 @@ Class: OEO_00020170
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000112> "costs that occur for becoming operational",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Installation and development cost are investment costs incurred for setting up the installation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Installationskosten"@de,
@@ -1680,7 +1719,11 @@ Class: OEO_00020171
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid connection costs are investment costs for establishing the grid connection from the energy generating device to point of connection to national grid.",
         rdfs:label "grid connection cost"@en
     
@@ -1696,7 +1739,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
 
 Reformulate definition to singular:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A property cost is an investment cost arising from the acquisition of a property.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "land cost",
         rdfs:label "property cost"@en
@@ -1709,7 +1756,11 @@ Class: OEO_00020173
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/891
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Decommissioning costs are investment costs arising from the decommissioning of a technological device at the end of its lifetime.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stilllegungskosten"@de,
         rdfs:label "decommissioning cost"@en
@@ -1726,7 +1777,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1022
 
 Reformulate definition to singular:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A delivery cost is a cost for a product or service that refers to the total unit cost of a product or commodity delivered to a certain market, city or customer. It is normally composed of all associated transport costs and the unit cost of production for that product.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lieferkosten"@de,
         rdfs:label "delivery cost"@en
@@ -1742,7 +1797,10 @@ Class: OEO_00020181
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1034
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Social cost of emission is the cost the society bears for an emission value.",
         rdfs:label "social cost of emission"@en
     
@@ -1806,6 +1864,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/370",
     SubClassOf: 
         OEO_00030016
     
+    
+Class: OEO_00030019
+
     
 Class: OEO_00030022
 
@@ -1985,14 +2046,17 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 make subclass of quantity value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is a quantity value that describes the amount of money needed to buy, make, or do a thing.",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1931
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cost is a process attribute that describes the amount of money needed to buy, make, or do a thing.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://dictionary.cambridge.org/dictionary/english/cost",
         rdfs:label "cost"@en
     
     SubClassOf: 
-        OEO_00000350,
+        OEO_00030019,
         OEO_00040010 some OEO_00040004
     
     
@@ -2447,7 +2511,11 @@ Class: OEO_00160005
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1257
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1260
+
+make subclass of process attribute
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cost is a variable cost that depends on the type and amount of fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffkosten"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftstoffkosten"@de,

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -1556,8 +1556,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/953
 make subclass of process attribute
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1914
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable cost are costs incurred for raw materials (of which more are needed if production is increased).",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable costs are costs that depend on the amount of goods or services produced and which are paid by the producer.",
+        <http://purl.obolibrary.org/obo/IAO_0000112> "An example for variable production cost are costs incurred for raw materials (of which more are needed if production is increased).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Variable production costs are costs that depend on the amount of goods or services produced and which are paid by the producer.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "variable Produktionskosten"@de,
         rdfs:label "variable production cost"@en
     
@@ -2057,7 +2057,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1999",
     
     SubClassOf: 
         OEO_00030019,
-        OEO_00040010 some OEO_00040004
+        OEO_00140002 some OEO_00040003
     
     
 Class: OEO_00040011


### PR DESCRIPTION
## Summary of the discussion

See #1914

## Type of change (CHANGELOG.md)

### Update
- make `cost` (and all its subclasses) subclass of `process attribute`

## Workflow checklist

### Automation
Closes #1914

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
