### PR TITLE
Fix failing test workflow

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.17'
+          python-version: '3.13.1'
           architecture: x64
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary of the discussion

We already had a similar issue a few months ago, where the test workflow was failing as it couldn't find Python version `3.7` (https://github.com/OpenEnergyPlatform/ontology/pull/1948)
From what I can read in the `setup-python` repository (https://github.com/actions/setup-python/issues/962), this is due to `3.7` and now `3.7.17` reaching their end-of-life and `ubuntu-latest`, the os version we are using to run our actions, dropping their support for those older versions.

So bumping the Python version to the latest stable version - `3.13.1` - seems like a reasonable step. Otherwise when just jumping to `3.8` or `3.9`, we would probably have to create such a pull request again in the next months.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #1996

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
