### PR TITLE
Fix definition of `solid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - model (#2007)
 - models (#2007)
 - cost, delivery cost, fixed cost, investment cost, levelised cost of electricity, social cost of emission, system cost, variable cost  (#1999)
+- solid (#2019)
 
 
 ## [2.6.0] - 2024-12-06

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15928,7 +15928,7 @@ Individual: OEO_00000326
 Individual: OEO_00000390
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fest"@de,
         rdfs:label "solid"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15928,6 +15928,8 @@ Individual: OEO_00000326
 Individual: OEO_00000390
 
     Annotations: 
+        OEO_00020426 "fix wording in definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2019",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fest"@de,
         rdfs:label "solid"@en


### PR DESCRIPTION
Word missing, see definitions of other states

## Type of change (CHANGELOG.md)

### Update
- `solid`


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
