### PR TITLE
create shortcut relations for oekg #2013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - has unit numerator, has unit denominator and subproperties (#1816)
 - compressor, compressor station and subclasses (#1818)
 - new units and prefixes from UO (#1820)
+- has associated axiom(sparql), shortcut relations for has information input/output, covers energy carrier, covers technology, covers sector (#2023)
 
 ### Changed
 - energy transfer function, energy transformation function and subclasses (#1785)

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -306,7 +306,7 @@ ObjectProperty: OEO_00020432
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000523 ?energycarrier.
 }",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'energy carrier'. The original relation 'covers energy carrier' relates 'study' (process) to 'energy carrier'. 
 The shortcut relation should be used to represents these statements:
 ('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers energy carrier' some 'energy carrier')",
@@ -326,11 +326,9 @@ ObjectProperty: OEO_00020436
 
     Annotations: 
         OEO_00020434 "select ?scenariofactsheet ?dataset where {
-
 ?scenariofactsheet IAO:0000136 _:1.
 _:2 OEO:00020226 _:1.
 _:2 OEO_00140094 ?dataset.
-
 }",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario factsheet and a dataset, where the dataset is an output of the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information output' relates 'scenario projection' (process) to 'data set'. 
@@ -354,11 +352,9 @@ ObjectProperty: OEO_00020437
 
     Annotations: 
         OEO_00020434 "select ?scenariofactsheet ?dataset where {
-
 ?scenariofactsheet IAO:0000136 _:1.
 _:2 OEO:00020226 _:1.
 _:2 OEO_00140093 ?dataset.
-
 }",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information input' relates 'scenario projection' (process) to 'data set'. 
 The shortcut relation should be used to represents these statements:
@@ -373,6 +369,29 @@ The shortcut relation should be used to represents these statements:
     
     Range: 
         <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+ObjectProperty: OEO_00020438
+
+    Annotations: 
+        OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
+?scenariobundle IAO:0000136 _:1.
+_:1 OEO:00390101 ?technology.
+}",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a technology that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'technology'. The original relation 'covers technology' relates 'study' (process) to 'technology'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers technology' some 'technology')",
+        rdfs:label "covers technology (shortcut)"@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00020227
+    
+    Range: 
+        OEO_00000407
     
     
 ObjectProperty: OEO_00040010

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -35,6 +35,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000601>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -45,6 +48,9 @@ AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 
     
 AnnotationProperty: OEO_00020426
+
+    
+AnnotationProperty: OEO_00020434
 
     
 AnnotationProperty: OEO_00110012
@@ -290,7 +296,14 @@ ObjectProperty: OEO_00020190
 ObjectProperty: OEO_00020432
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see annotation.",
+        OEO_00020434 "SELECT ?scenariobundle ?energycarrier WHERE {
+?scenariobundle IAO:0000136 _:1.
+_:1 OEO:00000523 ?energycarrier.
+}",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000601> "'scenatio bundle' 'is about' some scenario
+and
+scenario 'has energy carrier' some 'energy carrier'",
         rdfs:label "covers bundle energy carrier"@en
     
     SubPropertyOf: 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -397,9 +397,9 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020439
 
     Annotations: 
-        OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
+        OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
 ?scenariobundle IAO:0000136 _:1.
-_:1 OEO:00390101 ?technology.
+_:1 OEO:00000505 ?sector.
 }",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a sector that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'sector'. The original relation 'covers sector' relates 'study' (process) to 'sector'. 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -329,7 +329,7 @@ ObjectProperty: OEO_00020436
 
 ?scenariofactsheet IAO:0000136 _:1.
 _:2 OEO:00020226 _:1.
-_:2 RO:0002234 ?dataset.
+_:2 OEO_00140094 ?dataset.
 
 }",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario factsheet and a dataset, where the dataset is an output of the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
@@ -353,6 +353,13 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020437
 
     Annotations: 
+        OEO_00020434 "select ?scenariofactsheet ?dataset where {
+
+?scenariofactsheet IAO:0000136 _:1.
+_:2 OEO:00020226 _:1.
+_:2 OEO_00140093 ?dataset.
+
+}",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information input' relates 'scenario projection' (process) to 'data set'. 
 The shortcut relation should be used to represents these statements:
 ('scenario factsheet' 'is about' some scenario) and

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -287,6 +287,22 @@ ObjectProperty: OEO_00020189
 ObjectProperty: OEO_00020190
 
     
+ObjectProperty: OEO_00020432
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see annotation.",
+        rdfs:label "covers bundle energy carrier"@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00020227
+    
+    Range: 
+        OEO_00020039
+    
+    
 ObjectProperty: OEO_00040010
 
     
@@ -697,6 +713,9 @@ Class: OEO_00020202
     SubClassOf: 
         (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
     
+    
+Class: OEO_00020227
+
     
 Class: OEO_00020248
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -50,6 +50,9 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 AnnotationProperty: <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>
 
     
+AnnotationProperty: <https://www.commoncoreontologies.org/ont00001754>
+
+    
 AnnotationProperty: OEO_00020426
 
     
@@ -330,15 +333,33 @@ _:2 RO:0002234 ?dataset.
 
 }",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario factsheet and a dataset, where the dataset is an output of the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has output' relates 'scenario projection' (process) to 'data set'. 
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information output' relates 'scenario projection' (process) to 'data set'. 
 The shortcut relation should be used to represents these statements:
 ('scenario factsheet' 'is about' some scenario) and
 ('scenario projection' 'is based on' some scenario) and
-('scenario projection' 'has output' some dataset)",
-        rdfs:label "has output (shortcut)"@en
+('scenario projection' 'has information output' some dataset)",
+        rdfs:label "has information output (shortcut)"@en
     
     SubPropertyOf: 
         owl:topObjectProperty
+    
+    Domain: 
+        OEO_00000365
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
+    
+    
+ObjectProperty: OEO_00020437
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information input' relates 'scenario projection' (process) to 'data set'. 
+The shortcut relation should be used to represents these statements:
+('scenario factsheet' 'is about' some scenario) and
+('scenario projection' 'is based on' some scenario) and
+('scenario projection' 'has information input' some dataset)",
+        rdfs:label "has information input (shortcut)"@en,
+        <https://www.commoncoreontologies.org/ont00001754> "A relation between a scenario factsheet and a dataset, where the dataset is an input to the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom."
     
     Domain: 
         OEO_00000365

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -35,6 +35,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000600>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000601>
 
     
@@ -301,10 +304,10 @@ ObjectProperty: OEO_00020432
 _:1 OEO:00000523 ?energycarrier.
 }",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see associated sparql axiom.",
-        <http://purl.obolibrary.org/obo/IAO_0000601> "'scenatio bundle' 'is about' some scenario
-and
-scenario 'has energy carrier' some 'energy carrier'",
-        rdfs:label "covers bundle energy carrier"@en
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'energy carrier'. The original relation 'covers energy carrier' relates 'study' (process) to 'energy carrier'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers energy carrier' some 'energy carrier')",
+        rdfs:label "covers energy carrier (shortcut)"@en
     
     SubPropertyOf: 
         owl:topObjectProperty

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -302,6 +302,8 @@ ObjectProperty: OEO_00020190
 ObjectProperty: OEO_00020432
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?energycarrier WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000523 ?energycarrier.
@@ -325,6 +327,8 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020436
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "select ?scenariofactsheet ?dataset where {
 ?scenariofactsheet IAO:0000136 _:1.
 _:2 OEO:00020226 _:1.
@@ -351,6 +355,8 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020437
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "select ?scenariofactsheet ?dataset where {
 ?scenariofactsheet IAO:0000136 _:1.
 _:2 OEO:00020226 _:1.
@@ -374,6 +380,8 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020438
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00390101 ?technology.
@@ -397,6 +405,8 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020439
 
     Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000505 ?sector.

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -424,7 +424,7 @@ The shortcut relation should be used to represents these statements:
         OEO_00020227
     
     Range: 
-        OEO_00000407
+        OEO_00000367
     
     
 ObjectProperty: OEO_00040010

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -394,6 +394,29 @@ The shortcut relation should be used to represents these statements:
         OEO_00000407
     
     
+ObjectProperty: OEO_00020439
+
+    Annotations: 
+        OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
+?scenariobundle IAO:0000136 _:1.
+_:1 OEO:00390101 ?technology.
+}",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a sector that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'sector'. The original relation 'covers sector' relates 'study' (process) to 'sector'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
+        rdfs:label "covers sector (shortcut)"@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00020227
+    
+    Range: 
+        OEO_00000407
+    
+    
 ObjectProperty: OEO_00040010
 
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -303,7 +303,7 @@ ObjectProperty: OEO_00020432
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000523 ?energycarrier.
 }",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier. It is a shortcut relation, see elucidation and associated sparql axiom.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'energy carrier'. The original relation 'covers energy carrier' relates 'study' (process) to 'energy carrier'. 
 The shortcut relation should be used to represents these statements:
 ('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers energy carrier' some 'energy carrier')",
@@ -317,6 +317,34 @@ The shortcut relation should be used to represents these statements:
     
     Range: 
         OEO_00020039
+    
+    
+ObjectProperty: OEO_00020436
+
+    Annotations: 
+        OEO_00020434 "select ?scenariofactsheet ?dataset where {
+
+?scenariofactsheet IAO:0000136 _:1.
+_:2 OEO:00020226 _:1.
+_:2 RO:0002234 ?dataset.
+
+}",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario factsheet and a dataset, where the dataset is an output of the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has output' relates 'scenario projection' (process) to 'data set'. 
+The shortcut relation should be used to represents these statements:
+('scenario factsheet' 'is about' some scenario) and
+('scenario projection' 'is based on' some scenario) and
+('scenario projection' 'has output' some dataset)",
+        rdfs:label "has output (shortcut)"@en
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    Domain: 
+        OEO_00000365
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/IAO_0000100>
     
     
 ObjectProperty: OEO_00040010
@@ -504,6 +532,9 @@ Class: OEO_00000350
 
     
 Class: OEO_00000364
+
+    
+Class: OEO_00000365
 
     
 Class: OEO_00000367

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -98,7 +98,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1923",
 AnnotationProperty: OEO_00020434
 
     Annotations: 
-        rdfs:label "has associated axiom (sparql)"@en
+        rdfs:label "has associated axiom(sparql)"@en
     
     
 AnnotationProperty: OEO_00040001

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -95,6 +95,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1923",
         <http://purl.obolibrary.org/obo/IAO_0000116>
     
     
+AnnotationProperty: OEO_00020434
+
+    Annotations: 
+        rdfs:label "has associated axiom (sparql)"@en
+    
+    
 AnnotationProperty: OEO_00040001
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

For the restructuring of oekg, a couple of shortcut relations are needed, see #2013. To annotate the respective sparql queries, a new annotation property is added as well.

## Type of change (CHANGELOG.md)
### Add
annotation property: `has associated axiom(sparql)` (OEO_00020434)

**scenario factsheet:**
`has information output (shortcut)` (OEO_00020436)
`has information input (shortcut)` (OEO_00020437)

**scenario bundle:**
`covers enrgy carrier (shortcut)` (OEO_00020432)
`covers technology (shortcut)` (OEO_00020438)
`covers sector (shortcut)` (OEO_00020439)



### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
