### PR TITLE
Bumped python version in release workflow

### DIFF
--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -6,9 +6,6 @@ name: Post Release Scripts
 #       - 'feature-1020-export-of-existing-terms-and-definitions'
 # First we test the setup, to see if the files are building correctly once that is checked we introduce the wiki upload each release.
 on:
-  push:
-    branches:
-        - 'feature-fix-release-workflow-fix'
   release: 
     types: [published]
 

--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -6,6 +6,9 @@ name: Post Release Scripts
 #       - 'feature-1020-export-of-existing-terms-and-definitions'
 # First we test the setup, to see if the files are building correctly once that is checked we introduce the wiki upload each release.
 on:
+  push:
+    branches:
+        - 'feature-fix-release-workflow-fix'
   release: 
     types: [published]
 
@@ -16,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.13.1'
           architecture: x64
       - uses: actions/setup-java@v4
         with:
@@ -75,7 +78,7 @@ jobs:
           make
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7.17'
+          python-version: '3.13.1'
           architecture: x64
       - name: install python dependencies
         run: pip install -r src/scripts/requirements.txt


### PR DESCRIPTION
## Summary of the discussion
Bumped python version used by post release workflow to `3.13.1`.

## Type of change (CHANGELOG.md)
\---

## Workflow checklist

### Automation
Closes #---

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
