### PR TITLE
Adapt implementation of `arable land` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - WHG, BWaldG (#2006)
 - biosphere reserve role, protected landscape area role, water protection area role, floodplain role, forest role (#2006)
 - biosphere reserve, protected landscape area, water protection area, floodplain, forest (#2006)
-- arable land, arable land with poor soil quality, arable land with high soil quality, soil quality role, high soil quality role, poor soil quality role (#2006)
+- arable land, arable land with poor soil quality, arable land with high soil quality, arable land role, arable land with poor soil quality role, arable land with high soil quality role (#2041)
 
 
 ### Changed

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4387,7 +4387,8 @@ Class: OEO_00410031
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role of a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops."@en,
+        rdfs:comment "An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions. See also the soil quality definition from GEMET https://www.eionet.europa.eu/gemet/en/concept/7884",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://en.wikipedia.org/wiki/Soil_quality",
         <http://purl.obolibrary.org/obo/IAO_0000119> "Soil quality definition from https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land role"@en
@@ -4401,7 +4402,8 @@ Class: OEO_00410032
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with high soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a high soil quality."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with high soil quality role is a role of an arable land (region of relevance) reflecting that the soil, that is part of the bearer, has a high soil quality."@en,
+        rdfs:comment "An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions. See also the soil quality definition from GEMET https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land with high soil quality role"@en
     
     SubClassOf: 
@@ -4413,7 +4415,8 @@ Class: OEO_00410033
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with poor soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a poor soil quality."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with poor soil quality role is a role of an arable land (region of relevance) reflecting that the soil, that is part of the bearer, has a poor soil quality."@en,
+        rdfs:comment "An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions. See also the soil quality definition from GEMET https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land with poor soil quality role"@en
     
     SubClassOf: 
@@ -4425,10 +4428,10 @@ Class: OEO_00410036
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. "@en,
+       rdfs:comment "An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions. See also the soil quality definition from GEMET https://www.eionet.europa.eu/gemet/en/concept/7884",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://ontobee.org/ontology/ENVO?iri=http://purl.obolibrary.org/obo/ENVO_01001177",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Soil quality definition from https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land"@en
     
     EquivalentTo: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4387,9 +4387,9 @@ Class: OEO_00410031
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A soil quality role is a role inherent in a region of relevance reflecting how well a soil, that is part of the bearer, performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://en.wikipedia.org/wiki/Soil_quality",
-        rdfs:label "soil quality role"@en
+        rdfs:label "arable land role"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -4400,8 +4400,8 @@ Class: OEO_00410032
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A high soil quality role is a soil quality role inherent in a region of relevance reflecting that the soil, that is part of the bearer, has a high soil quality."@en,
-        rdfs:label "high soil quality role"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with high soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a high soil quality."@en,
+        rdfs:label "arable land with high soil quality role"@en
     
     SubClassOf: 
         OEO_00410031
@@ -4412,8 +4412,8 @@ Class: OEO_00410033
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A poor soil quality role is a soil quality role inherent in a region of relevance reflecting that the soil, that is part of the bearer, has a poor soil quality."@en,
-        rdfs:label "poor soil quality role"@en
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with poor soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a poor soil quality."@en,
+        rdfs:label "arable land with poor soil quality role"@en
     
     SubClassOf: 
         OEO_00410031
@@ -4424,7 +4424,7 @@ Class: OEO_00410036
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://ontobee.org/ontology/ENVO?iri=http://purl.obolibrary.org/obo/ENVO_01001177",
         rdfs:label "arable land"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4386,7 +4386,7 @@ Class: OEO_00410031
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://en.wikipedia.org/wiki/Soil_quality",
         rdfs:label "arable land role"@en
@@ -4399,7 +4399,7 @@ Class: OEO_00410032
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with high soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a high soil quality."@en,
         rdfs:label "arable land with high soil quality role"@en
     
@@ -4411,7 +4411,7 @@ Class: OEO_00410033
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with poor soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a poor soil quality."@en,
         rdfs:label "arable land with poor soil quality role"@en
     
@@ -4423,7 +4423,7 @@ Class: OEO_00410036
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://ontobee.org/ontology/ENVO?iri=http://purl.obolibrary.org/obo/ENVO_01001177",
@@ -4441,7 +4441,7 @@ Class: OEO_00410037
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with high soil quality is an arable land having some soil as part that can be categorized as having high soil quality."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland mit hoher Bodenqualität"@de,
         rdfs:label "arable land with high soil quality"@en
@@ -4458,7 +4458,7 @@ Class: OEO_00410038
 
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land with poor soil quality is an arable land having some soil as part that can be categorized as having poor soil quality."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland mit geringer Bodenqualität"@de,
         rdfs:label "arable land with poor soil quality"@en

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4387,8 +4387,9 @@ Class: OEO_00410031
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://en.wikipedia.org/wiki/Soil_quality",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Soil quality definition from https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land role"@en
     
     SubClassOf: 
@@ -4424,9 +4425,10 @@ Class: OEO_00410036
     Annotations: 
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1962
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized respecting all current positive and negative properties with regard to soil utilization and soil functions."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ackerland"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Definition partly adapted from https://ontobee.org/ontology/ENVO?iri=http://purl.obolibrary.org/obo/ENVO_01001177",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Soil quality definition from https://www.eionet.europa.eu/gemet/en/concept/7884",
         rdfs:label "arable land"@en
     
     EquivalentTo: 


### PR DESCRIPTION
## Summary of the discussion

As discussed in #1962, a different implementation of the `arable land` classes is required.

## Type of change (CHANGELOG.md)

### Add / Update
- `arable land` equivalent to `region of relevance that 'has role' some 'arable land role'`
  - `An arable land is a region of relevance that has the arable land role, i.e. for areas which are regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. An arable land has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures.`
- `arable land with high soil quality` equivalent to `arable land that 'has role' some 'arable land with high soil quality role'`
  - `An arable land with high soil quality is an arable land having some soil as part that can be categorized as having high soil quality.` 
- `arable land with poor soil quality` equivalent to `arable land that 'has role' some 'arable land with poor soil quality role'`
  - `An arable land with poor soil quality is an arable land having some soil as part that can be categorized as having poor soil quality.`
 
- `arable land role` as subclass of `role`
  - `An arable land role is a role inherent in a region of relevance which is regularly manipulated by human activities, such as plowing or tilling, in order to grow crops. Such a region has some soil as part, whose quality can be categorized to reflect, how well it performs the functions of maintaining biodiversity and productivity, partitioning water and solute flow, filtering and buffering, nutrient cycling, and providing support for plants and other structures.`
- `arable land with high soil quality role` as subclass of `arable land role`  
  - `An arable land with high soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a high soil quality.` 
- `arable land with poor soil quality role` as subclass of `arable land role`  
  - `An arable land with poor soil quality role is an arable land role inherent in an arable land reflecting that the soil, that is part of the bearer, has a poor soil quality.` 

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
