### PR TITLE
[bug fix] vehicle operational mode #2037

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Added
 ### Changed
+- vehicle operational mode (bug fix) (#2046)
 ### Removed
 
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14881,7 +14881,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
         rdfs:label "vehicle operational mode"@en
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000020>,
+        <http://purl.obolibrary.org/obo/BFO_0000017>,
         <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00010023
     
     


### PR DESCRIPTION
## Summary of the discussion

`vehicle operational mode` was lost in the hierarchy.  Now, it is a subclass of realizable entity again, as proposed by the def.

## Type of change (CHANGELOG.md)

### Update
- `vehicle operational mode`


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
