### PR TITLE
Changed IRIs in oeo-sector to use the new OEP URL

### DIFF
--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -1,4 +1,4 @@
-Prefix: : <http://openenergy-platform.org/ontology/oeo/>
+Prefix: : <https://openenergyplatform.org/ontology/oeo/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -9,8 +9,8 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 
-Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-sector/>
-<http://openenergy-platform.org/ontology/oeo/dev/oeo-sector.omn>
+Ontology: <https://openenergyplatform.org/ontology/oeo/oeo-sector/>
+<https://openenergyplatform.org/ontology/oeo/dev/oeo-sector.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared.omn>
 
 Annotations: 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -12,7 +12,7 @@ Ontology: <http://openenergy-platform.org/ontology/oeo/oeo-shared-axioms>
 <http://openenergy-platform.org/ontology/oeo/dev/oeo-shared-axioms.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-model.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-physical.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-sector.omn>
+Import: <https://openenergyplatform.org/ontology/oeo/dev/oeo-sector.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo-social.omn>
 
 Annotations: 


### PR DESCRIPTION
## Summary of the discussion
As discussed in the oeo-dev meeting #95, although the OEP switched it's URL already to https://openenergyplatform.org/ the IRIs in the ontology still use the old URL of http://openenergy-platform.org/. 
To show whether just replacing the URLs is feasible, this PR serves as a test for that.

## Type of change (CHANGELOG.md)

### Update
- Updated the IRI in the `oeo-sector` module to use https://openenergyplatform.org/ instead of http://openenergy-platform.org/.

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
