### PR TITLE
Add `grid component role`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - changed base IRI to https://openenergyplatform.org/
 - vehicle operational mode (bug fix) (#2046)
 - demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion (#2063)
+- grid component (#2054)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - biosphere reserve role, protected landscape area role, water protection area role, floodplain role, forest role (#2006)
 - biosphere reserve, protected landscape area, water protection area, floodplain, forest (#2006)
 - arable land, arable land with poor soil quality, arable land with high soil quality, arable land role, arable land with poor soil quality role, arable land with high soil quality role (#2041)
-
-
+- grid component role (#2054)
 ### Changed
 - vehicle operational mode (bug fix) (#2046)
 ### Removed

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,10 +11,10 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/stato-extracted.owl" uri="../imports/stato-extracted.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>                                      
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl" uri="../imports/meno-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1740265509439" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1740265509439" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1746311537431" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1746311537431" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -11,10 +11,10 @@
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/ro-extracted.owl" uri="../imports/ro-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/uo-extracted.owl" uri="../imports/uo-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/stato-extracted.owl" uri="../imports/stato-extracted.owl"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>                                      
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl" uri="../imports/meno-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1746311537431" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1746311537431" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1740265509439" name="http://openenergy-platform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1740265509439" name="http://openenergy-platform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9425,6 +9425,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
         rdfs:label "grid component"@en
     
+    EquivalentTo: 
+        OEO_00020102
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00410067)
+    
     SubClassOf: 
         OEO_00020102,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
@@ -15863,6 +15867,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_1000114>
+    
+    
+Class: OEO_00410067
+
+    Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2054",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component role is a role of an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        rdfs:label "grid component role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9420,8 +9420,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+dependence to 'grid component role'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2054",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose. A grid component is defined by having a grid component role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
         rdfs:label "grid component"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2417,12 +2417,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "electricity grid component"@en
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006
     
     
 Class: OEO_00000146
@@ -2973,8 +2972,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         rdfs:label "supply grid"@en
     
     SubClassOf: 
-        OEO_00030025,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
+        OEO_00030025
     
     
 Class: OEO_00000204
@@ -3407,8 +3405,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "grid component link"@en
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006
     
     DisjointWith: 
         OEO_00000296
@@ -3621,8 +3618,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "grid node"@en
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006
     
     DisjointWith: 
         OEO_00000255
@@ -4440,13 +4436,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage unit"@en
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
     
     
 Class: OEO_00000401
@@ -4485,9 +4480,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "transformer"@en
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
     
     
 Class: OEO_00000425
@@ -9416,6 +9410,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
     
     
+Class: OEO_00020006
+
+    Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
+        rdfs:label "grid component"@en
+    
+    SubClassOf: 
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+    
+    
 Class: OEO_00020007
 
     Annotations: 
@@ -9427,12 +9441,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "gas grid component"@en
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006
     
     
 Class: OEO_00020008
@@ -9446,12 +9459,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "heating grid component"@en
     
     EquivalentTo: 
-        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
+        OEO_00020006
+         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
     
     SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        OEO_00020006
     
     
 Class: OEO_00020009
@@ -9464,10 +9476,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "switchyard"@en
     
     SubClassOf: 
-        OEO_00020102,
+        OEO_00020006,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
     
     
 Class: OEO_00020011
@@ -15852,25 +15863,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_1000114>
-    
-    
-Class: OEO_00020006
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component role is a role of an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponentenrolle"@de,
-        rdfs:label "grid component role"@en
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Individual: OEO_00000182

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2417,11 +2417,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         rdfs:label "electricity grid component"@en
     
     EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
+        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
     
     SubClassOf: 
-        OEO_00020006
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00000146
@@ -2972,7 +2973,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
         rdfs:label "supply grid"@en
     
     SubClassOf: 
-        OEO_00030025
+        OEO_00030025,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
     
     
 Class: OEO_00000204
@@ -3405,7 +3407,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         rdfs:label "grid component link"@en
     
     SubClassOf: 
-        OEO_00020006
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     DisjointWith: 
         OEO_00000296
@@ -3618,7 +3621,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "grid node"@en
     
     SubClassOf: 
-        OEO_00020006
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     DisjointWith: 
         OEO_00000255
@@ -4436,12 +4440,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         rdfs:label "energy storage unit"@en
     
     EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
+        (<http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000012)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
     
     SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00000401
@@ -4480,8 +4485,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "transformer"@en
     
     SubClassOf: 
-        OEO_00020006,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00000425
@@ -9410,26 +9416,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020008
     
     
-Class: OEO_00020006
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
-subclass of energy transformation unit
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
-        rdfs:label "grid component"@en
-    
-    SubClassOf: 
-        OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000200
-    
-    
 Class: OEO_00020007
 
     Annotations: 
@@ -9441,11 +9427,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "gas grid component"@en
     
     EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
+        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020004)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
     
     SubClassOf: 
-        OEO_00020006
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00020008
@@ -9459,11 +9446,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "heating grid component"@en
     
     EquivalentTo: 
-        OEO_00020006
-         and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
+        (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020005)
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006)
     
     SubClassOf: 
-        OEO_00020006
+        OEO_00020102,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00020009
@@ -9476,9 +9464,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         rdfs:label "switchyard"@en
     
     SubClassOf: 
-        OEO_00020006,
+        OEO_00020102,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000143,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000420,
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020006
     
     
 Class: OEO_00020011
@@ -15863,6 +15852,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_1000114>
+    
+    
+Class: OEO_00020006
+
+    Annotations: 
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
+subclass of energy transformation unit
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component role is a role of an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponentenrolle"@de,
+        rdfs:label "grid component role"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
     
     
 Individual: OEO_00000182


### PR DESCRIPTION
## Summary of the discussion

As discussed in #1960, the current `grid component` class should be extended by an equivalence axiom of a new `grid component role` class.

## Type of change (CHANGELOG.md)

### Add
- Added `grid component role` as a subclass of `role`
  - definition: `A grid component role is a role of an energy transformation unit that is a discrete part of a supply grid serving a specific purpose.` 

### Update
- Added the equivalence axiom `'energy transformation unit' that 'has role' some 'grid component role'` to the `grid component` class

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
