### PR TITLE
add and remove oekg annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Changed
 - vehicle operational mode (bug fix) (#2046)
-- annotations: demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion (#2063)
+- demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion (#2063)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Changed
 - vehicle operational mode (bug fix) (#2046)
+- annotations: demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion (#2063)
+
 ### Removed
 
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15690,7 +15690,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 
 remove oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxxx",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system."@en,
         rdfs:comment "There are several climate neutrality criteria defined, e.g. by UNFCCC, IPCC or other institutions, with more or less differing sprecifications. A climate neutrality criterion usually includes net-zero emissions but might, e.g. include non-emission effects like surface albedo."@en,
         rdfs:label "climate neutrality criterion"@en

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11588,7 +11588,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11500,6 +11500,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
 Class: OEO_00050016
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 
@@ -11509,7 +11510,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340
 
 Add axiom 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Endenergieverbrauch"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "final energy consumption"@en,
@@ -11564,6 +11569,7 @@ https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inla
 Class: OEO_00050018
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
 
@@ -11578,7 +11584,11 @@ Move to oeo-shared:
 https://github.com/OpenEnergyPlatform/ontology/pull/1463
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
@@ -12023,6 +12033,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140040
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
 
@@ -12037,7 +12048,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bedarf"@de,
         rdfs:label "demand"@en
@@ -12078,6 +12093,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00140050
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
 
@@ -12087,7 +12103,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
 
 rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
@@ -13204,8 +13224,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00240013
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Nettostromerzeugung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production"@en,
@@ -15702,8 +15727,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00360011
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Process climate neutrality is a process attribute that conforms to some climate neutrality criteria."@en,
         rdfs:label "process climate neutrality"@en
     
@@ -15730,8 +15760,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722",
 Class: OEO_00360014
 
     Annotations: 
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
+
+add oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Material climate neutrality is a disposition of a material entity that conforms to some climate neutrality criterion."@en,
         rdfs:label "material climate neutrality"@en
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -15681,12 +15681,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
 Class: OEO_00360010
 
     Annotations: 
-        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
+
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+
+remove oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/xxxx",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system."@en,
         rdfs:comment "There are several climate neutrality criteria defined, e.g. by UNFCCC, IPCC or other institutions, with more or less differing sprecifications. A climate neutrality criterion usually includes net-zero emissions but might, e.g. include non-emission effects like surface albedo."@en,
         rdfs:label "climate neutrality criterion"@en


### PR DESCRIPTION
## Summary of the discussion

See #2063. Okeg annotations were added for the classes 

- `demand`, 
- `efficiency value`, 
- `final energy consumption value`, 
- `process climate neutrality`, 
- `material climate neutrality`, 
- `primary energy consumption value`, 
- `net electricity generation `

and removed for 

- `climate neutrality criterion`

## Type of change (CHANGELOG.md)

### Update
demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion 

## Workflow checklist

### Automation
Closes #2063

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
