### PR TITLE
Add wind power density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - biosphere reserve role, protected landscape area role, water protection area role, floodplain role, forest role (#2006)
 - biosphere reserve, protected landscape area, water protection area, floodplain, forest (#2006)
 - arable land, arable land with poor soil quality, arable land with high soil quality, arable land role, arable land with poor soil quality role, arable land with high soil quality role (#2041)
+- wind power density (#2067)
 
 ### Changed
 - vehicle operational mode (bug fix) (#2046)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -698,7 +698,7 @@ ObjectProperty: OEO_00240025
 ObjectProperty: owl:topObjectProperty
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00400054>
+Class: OEO_00400054
 
     Annotations: 
         OEO_00110012 "WPD = 0.5 * air density * ([wind speed]^3).",

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -36,6 +36,9 @@ AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000119>
 
     
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000600>
 
     
@@ -701,6 +704,8 @@ Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00400054>
         OEO_00110012 "WPD = 0.5 * air density * ([wind speed]^3).",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind power density (WPD) is a quantity value of the power wind has in a specific area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Windleistungsdichte"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/1997
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/2067",
         rdfs:label "wind power density"@en
     
     SubClassOf: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -695,6 +695,19 @@ ObjectProperty: OEO_00240025
 ObjectProperty: owl:topObjectProperty
 
     
+Class: <http://openenergy-platform.org/ontology/oeo/oeo-physical/OEO_00400054>
+
+    Annotations: 
+        OEO_00110012 "WPD = 0.5 * air density * ([wind speed]^3).",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind power density (WPD) is a quantity value of the power wind has in a specific area.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Windleistungsdichte"@de,
+        rdfs:label "wind power density"@en
+    
+    SubClassOf: 
+        OEO_00000350,
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000155>
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000002>
 
     
@@ -806,6 +819,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000114>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000122>
+
+    
+Class: <http://purl.obolibrary.org/obo/UO_0000155>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000223>


### PR DESCRIPTION
## Summary of the discussion

See #1997 
This PR is supposed to add the term `wind power density`, as it is needed for the task module.

The agreed upon definition is:
`wind power density (WPD)` _is a quantity vale of the power wind has in a specific area. It is calculated as 0.5 * air density * (wind speed to the power of 3)_

It was leter decided to add the formula using the annotation property `mathematical expression` instead of adding it directly into the definition.

It was also requested to add the German name `Windleistungsdichte` as an `alternative label`.

## Type of change (CHANGELOG.md)

### Add
- wind power density

## Workflow checklist

### Automation
Closes #1997

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
